### PR TITLE
fix(safari): add font inheritance for safari browsers

### DIFF
--- a/libs/gui/components/src/styles/form.scss
+++ b/libs/gui/components/src/styles/form.scss
@@ -9,4 +9,11 @@
   font-size: var(--gui-font-sm);
   color: var(--gui-text-default);
   box-sizing: border-box;
+
+  /* Safari (WebKit) ignores font inheritance on native <button>; re-assert it
+     so widget buttons match the surrounding form text in every browser. */
+  button {
+    font-family: inherit;
+    font-size: inherit;
+  }
 }


### PR DESCRIPTION
## Description

Safari browser is rendering a font-size of 11px instead of 0.875rem.

Fixes #65

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing

## Checklist

- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
