### PR TITLE
fix: safari keyboard navigation

### DIFF
--- a/libs/gui/angular/src/lib/components/accordion/accordion.component.html
+++ b/libs/gui/angular/src/lib/components/accordion/accordion.component.html
@@ -5,6 +5,7 @@
     <div class="gui-accordion__section">
       <button
         type="button"
+        tabindex="0"
         [id]="'accordion_button_' + section.uid"
         [attr.aria-controls]="'accordion_section_' + section.uid"
         [attr.aria-expanded]="activeSections[section.uid] ? 'true' : 'false'"

--- a/libs/gui/angular/src/lib/components/repeater/repeater.component.html
+++ b/libs/gui/angular/src/lib/components/repeater/repeater.component.html
@@ -27,6 +27,7 @@
           }
           <button
             type="button"
+            tabindex="0"
             class="gui-button gui-button--sm gui-repeater__remove-btn"
             (click)="removeItem($index)"
           >
@@ -45,6 +46,7 @@
   }
   <button
     type="button"
+    tabindex="0"
     class="gui-button gui-repeater__add-btn"
     (click)="addItem()"
     [disabled]="

--- a/libs/gui/angular/src/lib/components/tabs/tabs.component.html
+++ b/libs/gui/angular/src/lib/components/tabs/tabs.component.html
@@ -15,7 +15,7 @@
           type="button"
           role="tab"
           [attr.data-cy]="'tab_' + widget.uid + '_' + i"
-          [tabindex]="tab.uid === activeTab() ? null : -1"
+          [tabindex]="tab.uid === activeTab() ? 0 : -1"
           [id]="'tab_' + widget.uid + '_' + i"
           [attr.aria-controls]="'tabpanel_' + widget.uid + '_' + i"
           [attr.aria-selected]="tab.uid === activeTab() ? 'true' : 'false'"

--- a/libs/gui/components/src/lib/components/abstract-calendar.ts
+++ b/libs/gui/components/src/lib/components/abstract-calendar.ts
@@ -101,6 +101,7 @@ export abstract class AbstractCalendar extends LitElement {
           <div class="gui-calendar__container">
             <button
               type="button"
+              tabindex="0"
               class="gui-button gui-calendar__month-button gui-calendar__month-button--prev"
               ?disabled=${!this.canGoPrev()}
               @click=${this.prevMonth}
@@ -120,6 +121,7 @@ export abstract class AbstractCalendar extends LitElement {
 
             <button
               type="button"
+              tabindex="0"
               class="gui-button gui-calendar__month-button gui-calendar__month-button--next"
               ?disabled=${!this.canGoNext()}
               @click=${this.nextMonth}
@@ -195,6 +197,7 @@ export abstract class AbstractCalendar extends LitElement {
             part.type === 'year'
               ? html`<button
                   type="button"
+                  tabindex="0"
                   class="gui-calendar__year-selector"
                   @click=${this.toggleYearSelector}
                   aria-expanded=${this._yearSelectorOpen}

--- a/libs/gui/components/src/lib/components/button.ts
+++ b/libs/gui/components/src/lib/components/button.ts
@@ -39,6 +39,7 @@ export class GuiButton extends LitElement {
       <div class="gui-widget">
         <button
           type="button"
+          tabindex="0"
           id=${this.uid}
           class=${classMap(buttonClasses)}
           data-cy=${`${this.uid}_button`}

--- a/libs/gui/components/src/lib/components/checkbox.ts
+++ b/libs/gui/components/src/lib/components/checkbox.ts
@@ -75,6 +75,7 @@ export class GuiCheckbox extends LitElement {
         <div class="gui-widget gui-widget--horizontal">
           <input
             type="checkbox"
+            tabindex="0"
             id=${this.uid}
             data-cy=${`${this.uid}_checkbox`}
             ?checked=${this.value}

--- a/libs/gui/components/src/lib/components/markdown.ts
+++ b/libs/gui/components/src/lib/components/markdown.ts
@@ -159,6 +159,7 @@ export class GuiMarkdown extends LitElement {
             <li>
               <button
                 type="button"
+                tabindex="0"
                 class=${classMap({
                   'gui-markdown__toolbar-button': true,
                   'gui-markdown__toolbar-button--active': this.splitViewActive,
@@ -242,6 +243,7 @@ export class GuiMarkdown extends LitElement {
         return html`<li>
           <button
             type="button"
+            tabindex="0"
             class=${this.toolbarBtnClass('heading')}
             @click=${this.applyFormat('# ', '', 'heading')}
             title=${this.headingTitle ?? 'Heading'}
@@ -257,6 +259,7 @@ export class GuiMarkdown extends LitElement {
         return html`<li>
           <button
             type="button"
+            tabindex="0"
             class=${this.toolbarBtnClass('bold')}
             @click=${this.applyFormat('**', '**', 'bold')}
             title=${this.boldTitle ?? 'Bold'}
@@ -272,6 +275,7 @@ export class GuiMarkdown extends LitElement {
         return html`<li>
           <button
             type="button"
+            tabindex="0"
             class=${this.toolbarBtnClass('italic')}
             @click=${this.applyFormat('_', '_', 'italic')}
             title=${this.italicTitle ?? 'Italic'}
@@ -287,6 +291,7 @@ export class GuiMarkdown extends LitElement {
         return html`<li>
           <button
             type="button"
+            tabindex="0"
             class=${this.toolbarBtnClass('strikethrough')}
             @click=${this.applyFormat('~~', '~~', 'strikethrough')}
             title=${this.strikethroughTitle ?? 'Strikethrough'}
@@ -302,6 +307,7 @@ export class GuiMarkdown extends LitElement {
         return html`<li>
           <button
             type="button"
+            tabindex="0"
             class=${this.toolbarBtnClass('quote')}
             @click=${this.applyFormat('> ', '', 'quote')}
             title=${this.quoteTitle ?? 'Quote'}
@@ -317,6 +323,7 @@ export class GuiMarkdown extends LitElement {
         return html`<li>
           <button
             type="button"
+            tabindex="0"
             class=${this.toolbarBtnClass('link')}
             @click=${this.applyFormat('[', '](url)', 'link')}
             title=${this.linkTitle ?? 'Link'}
@@ -332,6 +339,7 @@ export class GuiMarkdown extends LitElement {
         return html`<li>
           <button
             type="button"
+            tabindex="0"
             class=${this.toolbarBtnClass('orderedList')}
             @click=${this.applyFormat('1. ', '', 'orderedList')}
             title=${this.orderedListTitle ?? 'Ordered List'}
@@ -347,6 +355,7 @@ export class GuiMarkdown extends LitElement {
         return html`<li>
           <button
             type="button"
+            tabindex="0"
             class=${this.toolbarBtnClass('unorderedList')}
             @click=${this.applyFormat('- ', '', 'unorderedList')}
             title=${this.unorderedListTitle ?? 'Unordered List'}

--- a/libs/gui/components/src/lib/components/radiogroup.ts
+++ b/libs/gui/components/src/lib/components/radiogroup.ts
@@ -85,22 +85,27 @@ export class GuiRadiogroup extends LitElement {
           ${repeat(
             this.options || [],
             (opt: any) => opt?.value,
-            (opt: any, index) =>
-              html`<label for=${`${this.uid}_${index}`}>
+            (opt: any, index) => {
+              const isChecked = this.hasMatchingValue && opt.value === templateData.value;
+              const isFirstUnchecked = !this.hasMatchingValue && index === 0;
+              const focusable = isChecked || isFirstUnchecked;
+              return html`<label for=${`${this.uid}_${index}`}>
                 <input
                   type="radio"
+                  tabindex=${focusable ? '0' : '-1'}
                   id=${`${this.uid}_${index}`}
                   data-cy=${`${this.uid}_radiogroup_${index}`}
                   name=${this.uid}
                   value=${opt.value}
-                  ?checked=${this.hasMatchingValue && opt.value === templateData.value}
+                  ?checked=${isChecked}
                   ?required=${templateData.required}
                   ?disabled=${templateData.disabled || templateData.readonly}
                   @change=${this.valueChanged}
                   @blur=${this.onBlur}
                 />
                 ${opt.label}
-              </label>`,
+              </label>`;
+            },
           )}
         `;
 

--- a/libs/gui/components/src/lib/components/range-date-input.ts
+++ b/libs/gui/components/src/lib/components/range-date-input.ts
@@ -152,6 +152,7 @@ export class GuiRangeDateInput extends LitElement {
                 <div class="gui-range-date-input__pills-compact">
                   <button
                     type="button"
+                    tabindex="0"
                     class="gui-range-date-input__pill--count"
                     aria-label="${pills.length} date ranges"
                     @click=${this.togglePillsList}

--- a/libs/gui/components/src/lib/components/select.ts
+++ b/libs/gui/components/src/lib/components/select.ts
@@ -111,6 +111,7 @@ export class GuiSelect extends LitElement {
       <div class="gui-widget">
         <select
           id=${this.uid as string}
+          tabindex="0"
           data-cy=${`${this.uid}_select`}
           class=${classMap(selectIcon.widgetClasses)}
           ?required=${templateData.required}

--- a/libs/gui/components/src/lib/components/toggle.ts
+++ b/libs/gui/components/src/lib/components/toggle.ts
@@ -75,6 +75,7 @@ export class GuiToggle extends LitElement {
         <div class="gui-widget gui-widget--horizontal gui-toggle--switch">
           <input
             type="checkbox"
+            tabindex="0"
             id=${this.uid}
             data-cy=${`${this.uid}_toggle`}
             ?checked=${templateData.value}

--- a/libs/gui/components/src/styles/form.scss
+++ b/libs/gui/components/src/styles/form.scss
@@ -9,4 +9,11 @@
   font-size: var(--gui-font-sm);
   color: var(--gui-text-default);
   box-sizing: border-box;
+
+  /* Safari (WebKit) ignores font inheritance on native <button>; re-assert it
+     so widget buttons match the surrounding form text in every browser. */
+  button {
+    font-family: inherit;
+    font-size: inherit;
+  }
 }

--- a/libs/gui/lit/src/lib/components/accordion.element.ts
+++ b/libs/gui/lit/src/lib/components/accordion.element.ts
@@ -99,6 +99,7 @@ export class AccordionElement extends LitElement implements Core.WithWidget {
                 return html`<div class="gui-accordion__section">
                   <button
                     type="button"
+                    tabindex="0"
                     class=${classMap({
                       active: this.activeSections[section.uid],
                     })}

--- a/libs/gui/lit/src/lib/components/repeater.element.ts
+++ b/libs/gui/lit/src/lib/components/repeater.element.ts
@@ -103,6 +103,7 @@ export class RepeaterElement extends LitElement implements Core.WithWidget {
                       : nothing}
                     <button
                       type="button"
+                      tabindex="0"
                       class="gui-button gui-button--sm gui-repeater__remove-btn"
                       @click=${() => this.removeItem(index)}
                     >
@@ -126,6 +127,7 @@ export class RepeaterElement extends LitElement implements Core.WithWidget {
 
         <button
           type="button"
+          tabindex="0"
           class="gui-button gui-repeater__add-btn"
           @click=${() => this.addItem()}
           ?disabled=${!!(templateData.limit && templateData.limit === templateData.value?.length)}

--- a/libs/gui/lit/src/lib/components/tabs.element.ts
+++ b/libs/gui/lit/src/lib/components/tabs.element.ts
@@ -8,7 +8,6 @@ import { repeat } from 'lit-html/directives/repeat.js';
 import { customElement, property, query, queryAll, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { Subscription } from 'rxjs';
-import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 @customElement('gui-tabs-layout')
 export class TabsElement extends LitElement implements Core.WithWidget {
@@ -110,7 +109,7 @@ export class TabsElement extends LitElement implements Core.WithWidget {
                     <button
                       type="button"
                       role="tab"
-                      tabindex=${ifDefined(tab.uid === this.activeTab ? undefined : -1)}
+                      tabindex=${tab.uid === this.activeTab ? '0' : '-1'}
                       data-cy=${`tab_${this.widget.uid}_${index}`}
                       id=${`tab_${this.widget.uid}_${index}`}
                       aria-controls=${`tabpanel_${this.widget.uid}_${index}`}

--- a/libs/gui/react/src/lib/components/Accordion.tsx
+++ b/libs/gui/react/src/lib/components/Accordion.tsx
@@ -64,6 +64,7 @@ export function Accordion(widgetInstance: Core.WithWidget) {
       <div className="gui-accordion__section" key={`${'accordion_section_' + section.uid}`}>
         <button
           type="button"
+          tabIndex={0}
           id={`accordion_button_${section.uid}`}
           aria-controls={`accordion_section_${section.uid}`}
           aria-expanded={activeSections[section.uid] ? 'true' : 'false'}

--- a/libs/gui/react/src/lib/components/Repeater.tsx
+++ b/libs/gui/react/src/lib/components/Repeater.tsx
@@ -75,6 +75,7 @@ export function Repeater(widgetInstance: Core.WithWidget) {
               )}
               <button
                 type="button"
+                tabIndex={0}
                 className="gui-button gui-button--sm gui-repeater__remove-btn"
                 onClick={() => removeItem(value, index)}
               >
@@ -119,6 +120,7 @@ export function Repeater(widgetInstance: Core.WithWidget) {
         {renderWidgets()}
         <button
           type="button"
+          tabIndex={0}
           className="gui-button gui-repeater__add-btn"
           onClick={() => addItem(value || [])}
           disabled={templateData.limit ? templateData.limit === (value?.length ?? 0) : false}

--- a/libs/gui/react/src/lib/components/Tabs.tsx
+++ b/libs/gui/react/src/lib/components/Tabs.tsx
@@ -113,7 +113,7 @@ export function Tabs(widgetInstance: Core.WithWidget) {
             }}
             type="button"
             role="tab"
-            tabIndex={tab.uid === activeTab ? undefined : -1}
+            tabIndex={tab.uid === activeTab ? 0 : -1}
             data-cy={`tab_${widget.uid}_${index}`}
             id={`tab_${widget.uid}_${index}`}
             aria-controls={`tabpanel_${widget.uid}_${index}`}


### PR DESCRIPTION
## Description

Safari browser need `tabindex=0` or elements are ignored. Added in all buttons and components needed to have the same keyboard navigation than firefox and chrome.

Fixes #66 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing

## Checklist

- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
