### PR TITLE
Add setData and setMeta methods to form components

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -56,6 +56,7 @@ export default defineConfig({
             { slug: 'features/validators' },
             { slug: 'features/middlewares' },
             { slug: 'features/events' },
+            { slug: 'features/runtime-methods' },
             { slug: 'features/i18n' },
             { slug: 'features/dependencies' },
             { label: 'States', autogenerate: { directory: 'features/states' } },

--- a/docs/src/content/docs/features/runtime-methods.mdx
+++ b/docs/src/content/docs/features/runtime-methods.mdx
@@ -1,0 +1,281 @@
+---
+title: Runtime Methods
+description: Imperatively update form data or meta from outside the component.
+sidebar:
+  order: 6
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import IntegrationTabs from '../../../components/IntegrationTabs.astro';
+
+`setData` and `setMeta` let you push state changes into a mounted form without re-initialising it. Use them to pre-fill fields after an async fetch, sync the form with external state, or toggle meta-driven behaviour at runtime.
+
+Both methods **replace** their respective state objects entirely — there is no deep merge.
+
+## Getting a reference to the form
+
+Each framework has its own mechanism for obtaining a handle to the form component instance:
+
+<IntegrationTabs>
+  <Fragment slot="react">
+    ```tsx
+    import { useRef } from 'react';
+    import { GuiForm } from '@golemui/gui-react';
+    import type { FormComponentHandle } from '@golemui/react';
+
+    export function MyForm({ config }) {
+      const formRef = useRef<FormComponentHandle>(null);
+
+      return <GuiForm ref={formRef} config={config} />;
+    }
+    ```
+
+  </Fragment>
+  <Fragment slot="angular">
+    ```ts
+    import { Component, ViewChild } from '@angular/core';
+    import { FormComponent } from '@golemui/gui-angular';
+
+    @Component({
+      imports: [FormComponent],
+      selector: 'app-my-form',
+      template: `<gui-form #myForm [config]="config"></gui-form>`,
+    })
+    export class MyFormComponent {
+      @ViewChild('myForm') form!: FormComponent;
+
+      protected config = { /* ... */ };
+    }
+    ```
+
+  </Fragment>
+  <Fragment slot="lit">
+    ```ts
+    import { LitElement, html } from 'lit';
+    import { customElement, query } from 'lit/decorators.js';
+    import { FormElement } from '@golemui/gui-lit';
+
+    @customElement('my-app')
+    export class MyApp extends LitElement {
+      @query('gui-form') private form!: FormElement;
+
+      override createRenderRoot() { return this; }
+
+      override render() {
+        return html`<gui-form .config=${this.config}></gui-form>`;
+      }
+    }
+    ```
+
+  </Fragment>
+</IntegrationTabs>
+
+## `setData`
+
+Replaces the form's current data state. All field values are overwritten with the supplied object.
+
+<IntegrationTabs>
+  <Fragment slot="react">
+    ```tsx
+    import { useRef } from 'react';
+    import { GuiForm } from '@golemui/gui-react';
+    import type { FormComponentHandle } from '@golemui/react';
+
+    export function MyForm({ config }) {
+      const formRef = useRef<FormComponentHandle>(null);
+
+      async function loadUser(userId: string) {
+        const user = await fetchUser(userId);
+        formRef.current?.setData({ name: user.name, email: user.email });
+      }
+
+      return (
+        <>
+          <button onClick={() => loadUser('42')}>Load user</button>
+          <GuiForm ref={formRef} config={config} />
+        </>
+      );
+    }
+    ```
+
+  </Fragment>
+  <Fragment slot="angular">
+    ```ts
+    import { Component, ViewChild } from '@angular/core';
+    import { FormComponent } from '@golemui/gui-angular';
+
+    @Component({
+      imports: [FormComponent],
+      selector: 'app-my-form',
+      template: `
+        <button (click)="loadUser('42')">Load user</button>
+        <gui-form #myForm [config]="config"></gui-form>
+      `,
+    })
+    export class MyFormComponent {
+      @ViewChild('myForm') form!: FormComponent;
+
+      protected config = { /* ... */ };
+
+      async loadUser(userId: string) {
+        const user = await this.userService.fetch(userId);
+        this.form.setData({ name: user.name, email: user.email });
+      }
+    }
+    ```
+
+  </Fragment>
+  <Fragment slot="lit">
+    ```ts
+    import { LitElement, html } from 'lit';
+    import { customElement, query } from 'lit/decorators.js';
+    import { FormElement } from '@golemui/gui-lit';
+
+    @customElement('my-app')
+    export class MyApp extends LitElement {
+      @query('gui-form') private form!: FormElement;
+
+      override createRenderRoot() { return this; }
+
+      async loadUser(userId: string) {
+        const user = await fetchUser(userId);
+        this.form.setData({ name: user.name, email: user.email });
+      }
+
+      override render() {
+        return html`
+          <button @click=${() => this.loadUser('42')}>Load user</button>
+          <gui-form .config=${this.config}></gui-form>
+        `;
+      }
+    }
+    ```
+
+  </Fragment>
+</IntegrationTabs>
+
+## `setMeta`
+
+Replaces the form's current meta state. Meta values are available inside the form definition for template interpolation (`{{$meta.key}}`) and conditions (`$meta.key === true`).
+
+<IntegrationTabs>
+  <Fragment slot="react">
+    ```tsx
+    import { useRef } from 'react';
+    import { gui } from '@golemui/gui-shared';
+    import { GuiForm } from '@golemui/gui-react';
+    import type { FormComponentHandle } from '@golemui/react';
+
+    const formDef = [
+      gui.displays.alert('status-banner', {
+        text: 'Connection: {{$meta.status}}',
+      }),
+    ];
+
+    const config = { formDef, data: {}, meta: { status: 'offline' } };
+
+    export function MyForm() {
+      const formRef = useRef<FormComponentHandle>(null);
+
+      function goOnline() {
+        formRef.current?.setMeta({ status: 'online' });
+      }
+
+      return (
+        <>
+          <button onClick={goOnline}>Connect</button>
+          <GuiForm ref={formRef} config={config} />
+        </>
+      );
+    }
+    ```
+
+  </Fragment>
+  <Fragment slot="angular">
+    ```ts
+    import { Component, ViewChild } from '@angular/core';
+    import { gui } from '@golemui/gui-shared';
+    import { FormComponent } from '@golemui/gui-angular';
+
+    @Component({
+      imports: [FormComponent],
+      selector: 'app-my-form',
+      template: `
+        <button (click)="goOnline()">Connect</button>
+        <gui-form #myForm [config]="config"></gui-form>
+      `,
+    })
+    export class MyFormComponent {
+      @ViewChild('myForm') form!: FormComponent;
+
+      protected config = {
+        formDef: [
+          gui.displays.alert('status-banner', {
+            text: 'Connection: {{$meta.status}}',
+          }),
+        ],
+        data: {},
+        meta: { status: 'offline' },
+      };
+
+      goOnline() {
+        this.form.setMeta({ status: 'online' });
+      }
+    }
+    ```
+
+  </Fragment>
+  <Fragment slot="lit">
+    ```ts
+    import { LitElement, html } from 'lit';
+    import { customElement, query } from 'lit/decorators.js';
+    import { gui } from '@golemui/gui-shared';
+    import { FormElement } from '@golemui/gui-lit';
+
+    @customElement('my-app')
+    export class MyApp extends LitElement {
+      @query('gui-form') private form!: FormElement;
+
+      config = {
+        formDef: [
+          gui.displays.alert('status-banner', {
+            text: 'Connection: {{$meta.status}}',
+          }),
+        ],
+        data: {},
+        meta: { status: 'offline' },
+      };
+
+      override createRenderRoot() { return this; }
+
+      goOnline() {
+        this.form.setMeta({ status: 'online' });
+      }
+
+      override render() {
+        return html`
+          <button @click=${() => this.goOnline()}>Connect</button>
+          <gui-form .config=${this.config}></gui-form>
+        `;
+      }
+    }
+    ```
+
+  </Fragment>
+</IntegrationTabs>
+
+## API reference
+
+| Method    | Signature                             | Description                                                                     |
+| --------- | ------------------------------------- | ------------------------------------------------------------------------------- |
+| `setData` | `(data: Record<string, any>) => void` | Replaces the form's data state. All field values are overwritten.               |
+| `setMeta` | `(meta: Record<string, any>) => void` | Replaces the form's meta state. Used in template interpolations and conditions. |
+
+<Aside>
+Both methods replace the entire state object. To preserve values that are not being updated, spread the current state before calling: `form.setData({ ...currentData, name: 'Alice' })`.
+</Aside>
+
+## See also
+
+- [Features / Form Events](/features/events/) — reacting to widget events emitted by the form.
+- [Form Definition API / Runtime Functions](/form-definition/runtime-functions/) — reactive props computed from live form state.

--- a/libs/angular/src/lib/components/form/form.component.ts
+++ b/libs/angular/src/lib/components/form/form.component.ts
@@ -107,4 +107,12 @@ export class FormCoreComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.unsubscribeI18n();
   }
+
+  setData(data: Record<string, any>): void {
+    this.context.store.dispatch({ type: 'SET_DATA', payload: { data } });
+  }
+
+  setMeta(meta: Record<string, any>): void {
+    this.context.store.dispatch({ type: 'SET_META', payload: { meta } });
+  }
 }

--- a/libs/gui/angular/cypress/support/mount.ts
+++ b/libs/gui/angular/cypress/support/mount.ts
@@ -54,5 +54,14 @@ export const mountFramework = (options: MountOptions) => {
       formHealth: formHealthOutput,
       formEvent: formEventOutput,
     },
+  }).then(({ fixture }) => {
+    // toObservable()'s internal effect is scheduled, not run, during the first detectChanges() call
+    // made by mount(). A second call flushes it so config$ emits and the store is initialized
+    // before onFormReady exposes the handle to the test.
+    fixture.detectChanges();
+    options.onFormReady?.({
+      setData: (data) => fixture.componentRef.instance.setData(data),
+      setMeta: (meta) => fixture.componentRef.instance.setMeta(meta),
+    });
   });
 };

--- a/libs/gui/angular/cypress/test/core-features/set-data-set-meta.cy.ts
+++ b/libs/gui/angular/cypress/test/core-features/set-data-set-meta.cy.ts
@@ -1,0 +1,4 @@
+import { runSetDataSetMetaTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runSetDataSetMetaTests(mountFramework);

--- a/libs/gui/angular/src/lib/components/form/form.component.ts
+++ b/libs/gui/angular/src/lib/components/form/form.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, computed, input, output, Type } from '@angular/core';
+import { Component, computed, input, output, Type, viewChild } from '@angular/core';
 import * as Angular from '@golemui/angular';
 import * as Core from '@golemui/core';
 import { FormInitConfig } from '@golemui/core';
@@ -15,6 +15,8 @@ import { widgetLoaders } from '../../widget.loaders';
 export class FormComponent {
   config = input.required<GuiFormInitConfig>();
   autocomplete = input<string | undefined>(undefined);
+
+  private coreForm = viewChild(Angular.FormCoreComponent);
 
   protected resolved = computed(() =>
     resolveFormInput(this.config().formDef, this.config().formSelectors, this.config().formConfig),
@@ -54,5 +56,13 @@ export class FormComponent {
   protected onCoreFormEvent(event: Core.FormEvent): void {
     this.resolved().formEvent?.(event);
     this.formEvent.emit(event);
+  }
+
+  setData(data: Record<string, any>): void {
+    this.coreForm()?.setData(data);
+  }
+
+  setMeta(meta: Record<string, any>): void {
+    this.coreForm()?.setMeta(meta);
   }
 }

--- a/libs/gui/lit/cypress/support/mount.ts
+++ b/libs/gui/lit/cypress/support/mount.ts
@@ -1,7 +1,7 @@
 import * as Core from '@golemui/core';
-import { Type } from '@golemui/lit';
 import { GuiFormInitConfig } from '@golemui/gui-shared';
-import { MountOptions } from '@golemui/ui-testing';
+import { Type } from '@golemui/lit';
+import { FormHandle, MountOptions } from '@golemui/ui-testing';
 import { html } from 'lit';
 import '../../src/lib/components/form.element';
 
@@ -48,5 +48,11 @@ export const mountFramework = (options: MountOptions) => {
       @formEvent=${handleFormEvent}
       @formHealth=${handleFormHealth}
     ></gui-form>`,
-  );
+  ).then(() => {
+    const el = document.querySelector('gui-form') as HTMLElement & FormHandle;
+    options.onFormReady?.({
+      setData: (data) => el.setData(data),
+      setMeta: (meta) => el.setMeta(meta),
+    });
+  });
 };

--- a/libs/gui/lit/cypress/test/core-features/set-data-set-meta.cy.ts
+++ b/libs/gui/lit/cypress/test/core-features/set-data-set-meta.cy.ts
@@ -1,0 +1,4 @@
+import { runSetDataSetMetaTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runSetDataSetMetaTests(mountFramework);

--- a/libs/gui/lit/src/lib/components/form.element.ts
+++ b/libs/gui/lit/src/lib/components/form.element.ts
@@ -3,15 +3,26 @@ import { FormInitConfig, WidgetLoaders, WithWidget } from '@golemui/core';
 import { GuiFormInitConfig, resolveFormInput } from '@golemui/gui-shared';
 import { CustomValidatorSchemas, initValidators, Validator } from '@golemui/gui-validators';
 import '@golemui/lit';
+import type { FormElement as CoreFormElement } from '@golemui/lit';
 import { LitItemRenderer, Type } from '@golemui/lit';
 import { html, LitElement } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, query } from 'lit/decorators.js';
 import { widgetLoaders } from '../widget.loaders';
 
 @customElement('gui-form')
 export class FormElement extends LitElement {
   @property({ attribute: false }) config!: GuiFormInitConfig;
   @property({ type: String }) autocomplete: string | undefined = undefined;
+
+  @query('gui-core-form') private coreForm?: CoreFormElement;
+
+  setData(data: Record<string, any>): void {
+    this.coreForm?.setData(data);
+  }
+
+  setMeta(meta: Record<string, any>): void {
+    this.coreForm?.setMeta(meta);
+  }
 
   override createRenderRoot() {
     return this;

--- a/libs/gui/react/cypress/support/mount.tsx
+++ b/libs/gui/react/cypress/support/mount.tsx
@@ -1,8 +1,9 @@
 import * as Core from '@golemui/core';
 import { GuiFormInitConfig } from '@golemui/gui-shared';
+import type { FormComponentHandle } from '@golemui/react';
 import { MountOptions } from '@golemui/ui-testing';
 import { mount } from 'cypress/react';
-import { ComponentType } from 'react';
+import { ComponentType, createRef } from 'react';
 import { GuiForm } from '../../src/lib/components/Form';
 
 export const mountFramework = (options: MountOptions) => {
@@ -31,11 +32,29 @@ export const mountFramework = (options: MountOptions) => {
     customWidgetLoaders,
   };
 
+  const formRef = createRef<FormComponentHandle>();
+
   mount(
     <GuiForm
+      ref={formRef}
       config={config}
       formEvent={handleFormEvent}
       formHealth={handleFormHealth}
     />,
   );
+
+  if (options.onFormReady) {
+    // mount().then() fires before React's commit phase completes, so formRef.current
+    // is still null. The retry loop yields the browser event loop on each attempt,
+    // allowing useImperativeHandle and useEffect (store init) to run first.
+    cy.wrap(formRef)
+      .its('current')
+      .should('not.be.null')
+      .then(() => {
+        options.onFormReady!({
+          setData: (data) => formRef.current!.setData(data),
+          setMeta: (meta) => formRef.current!.setMeta(meta),
+        });
+      });
+  }
 };

--- a/libs/gui/react/cypress/test/core-features/set-data-set-meta.cy.ts
+++ b/libs/gui/react/cypress/test/core-features/set-data-set-meta.cy.ts
@@ -1,0 +1,4 @@
+import { runSetDataSetMetaTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runSetDataSetMetaTests(mountFramework);

--- a/libs/gui/react/src/lib/components/Form.tsx
+++ b/libs/gui/react/src/lib/components/Form.tsx
@@ -4,7 +4,7 @@ import { GuiFormInitConfig, resolveFormInput } from '@golemui/gui-shared';
 import { initValidators } from '@golemui/gui-validators';
 import * as React from '@golemui/react';
 import { ReactItemRenderer } from '@golemui/react';
-import { ComponentType, useMemo } from 'react';
+import { ComponentType, Ref, useMemo } from 'react';
 import { widgetLoaders as golemWidgetLoaders } from '../widget.loaders';
 
 export interface ReactFormComponentProps {
@@ -12,14 +12,16 @@ export interface ReactFormComponentProps {
   autocomplete?: string;
   formEvent?: (event: Core.FormEvent) => void;
   formHealth?: (formHealth: Core.FormHealth) => void;
+  ref?: Ref<React.FormComponentHandle>;
 }
 
-export const GuiForm = ({
+export function GuiForm({
   config,
   formHealth = undefined,
   formEvent = undefined,
   autocomplete,
-}: ReactFormComponentProps) => {
+  ref,
+}: ReactFormComponentProps) {
   const resolved = useMemo(
     () => resolveFormInput(config.formDef, config.formSelectors, config.formConfig),
     [config],
@@ -51,13 +53,14 @@ export const GuiForm = ({
   const mergedFormEvent =
     resolved.formEvent && formEvent
       ? (event: Core.FormEvent) => {
-          resolved.formEvent!(event);
+          resolved.formEvent?.(event);
           formEvent(event);
         }
       : (formEvent ?? resolved.formEvent);
 
   return (
     <React.FormComponent
+      ref={ref}
       config={coreConfig}
       validators={allValidators}
       autocomplete={autocomplete}
@@ -65,4 +68,4 @@ export const GuiForm = ({
       formEvent={mergedFormEvent}
     />
   );
-};
+}

--- a/libs/lit/src/lib/components/form/form.element.ts
+++ b/libs/lit/src/lib/components/form/form.element.ts
@@ -122,6 +122,14 @@ export class FormElement extends LitElement {
     `;
   }
 
+  setData(data: Record<string, any>): void {
+    this.context.store.dispatch({ type: 'SET_DATA', payload: { data } });
+  }
+
+  setMeta(meta: Record<string, any>): void {
+    this.context.store.dispatch({ type: 'SET_META', payload: { meta } });
+  }
+
   override disconnectedCallback() {
     super.disconnectedCallback();
     this.stateSub?.unsubscribe();

--- a/libs/react/src/lib/FormComponent.tsx
+++ b/libs/react/src/lib/FormComponent.tsx
@@ -1,9 +1,14 @@
 import * as Core from '@golemui/core';
 import { FormInitConfig } from '@golemui/core';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { ReactFormContextProvider } from './ReactFormContextProvider';
 import WidgetErrorBoundary from './WidgetErrorBoundary';
 import WidgetRenderer from './WidgetRenderer';
+
+export interface FormComponentHandle {
+  setData: (data: Record<string, any>) => void;
+  setMeta: (meta: Record<string, any>) => void;
+}
 
 export interface FormComponentProps {
   config: FormInitConfig<React.ComponentType<Core.WithWidget>>;
@@ -11,6 +16,7 @@ export interface FormComponentProps {
   formEvent?: (event: Core.FormEvent) => void;
   formHealth?: (error: Core.FormHealth) => void;
   autocomplete?: string;
+  ref?: React.Ref<FormComponentHandle>;
 }
 
 export function FormComponent({
@@ -19,6 +25,7 @@ export function FormComponent({
   formHealth,
   formEvent,
   autocomplete,
+  ref,
 }: FormComponentProps) {
   const formContextRef = useRef<Core.FormContext<React.ComponentType<Core.WithWidget>>>(
     new Core.FormContext(),
@@ -120,6 +127,19 @@ export function FormComponent({
       sub();
     };
   }, []);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      setData: (data) => {
+        formContextRef.current.store.dispatch({ type: 'SET_DATA', payload: { data } });
+      },
+      setMeta: (meta) => {
+        formContextRef.current.store.dispatch({ type: 'SET_META', payload: { meta } });
+      },
+    }),
+    [],
+  );
 
   if (!formLayoutField) {
     return null;

--- a/libs/ui-testing/src/index.ts
+++ b/libs/ui-testing/src/index.ts
@@ -9,6 +9,7 @@ export * from './lib/core-features/label.cy';
 export * from './lib/core-features/middlewares.cy';
 export * from './lib/core-features/reactive-functions.cy';
 export * from './lib/core-features/readonly.cy';
+export * from './lib/core-features/set-data-set-meta.cy';
 export * from './lib/core-features/states.cy';
 export * from './lib/core-features/string-interpolation.cy';
 export * from './lib/core-features/uid.cy';

--- a/libs/ui-testing/src/lib/core-features/set-data-set-meta.cy.ts
+++ b/libs/ui-testing/src/lib/core-features/set-data-set-meta.cy.ts
@@ -1,0 +1,95 @@
+import * as Core from '@golemui/core';
+import { FormHandle, MountComponentFn } from '../utils';
+
+export const runSetDataSetMetaTests = (mountFn: MountComponentFn) => {
+  describe('setData / setMeta', () => {
+    describe('setData', () => {
+      it('should update field value when setData is called after init', () => {
+        let handle!: FormHandle;
+        mountFn({
+          data: { name: 'initial' },
+          formDef: Core.defineForm({
+            form: [{ uid: 'name', kind: 'input', type: 'textinput', path: 'name' }],
+          }),
+          onFormReady: (h) => {
+            handle = h;
+          },
+        });
+        cy.get('[data-cy="name_textinput"]').should('have.value', 'initial');
+        cy.then(() => handle.setData({ name: 'updated' }));
+        cy.get('[data-cy="name_textinput"]').should('have.value', 'updated');
+      });
+
+      it('should replace all data when setData is called', () => {
+        let handle!: FormHandle;
+        mountFn({
+          data: { firstName: 'John', lastName: 'Doe' },
+          formDef: Core.defineForm({
+            form: [
+              { uid: 'firstName', kind: 'input', type: 'textinput', path: 'firstName' },
+              { uid: 'lastName', kind: 'input', type: 'textinput', path: 'lastName' },
+            ],
+          }),
+          onFormReady: (h) => {
+            handle = h;
+          },
+        });
+        cy.get('[data-cy="firstName_textinput"]').should('have.value', 'John');
+        cy.get('[data-cy="lastName_textinput"]').should('have.value', 'Doe');
+        cy.then(() => handle.setData({ firstName: 'Jane', lastName: 'Smith' }));
+        cy.get('[data-cy="firstName_textinput"]').should('have.value', 'Jane');
+        cy.get('[data-cy="lastName_textinput"]').should('have.value', 'Smith');
+      });
+    });
+
+    describe('setMeta', () => {
+      it('should update interpolated meta value when setMeta is called after init', () => {
+        let handle!: FormHandle;
+        mountFn({
+          meta: { status: 'offline' },
+          formDef: Core.defineForm({
+            form: [
+              {
+                uid: 'status-display',
+                kind: 'display',
+                type: 'alert',
+                props: { text: 'Status: {{$meta.status}}' },
+              },
+            ],
+          }),
+          onFormReady: (h) => {
+            handle = h;
+          },
+        });
+        cy.get('.gui-alert [role="alert"]').should('contain', 'Status: offline');
+        cy.then(() => handle.setMeta({ status: 'online' }));
+        cy.get('.gui-alert [role="alert"]').should('contain', 'Status: online');
+      });
+
+      it('should toggle meta-driven conditional field when setMeta is called', () => {
+        let handle!: FormHandle;
+        mountFn({
+          meta: { showField: false },
+          formDef: Core.defineForm({
+            states: { visible: '$meta.showField === true' },
+            form: [
+              {
+                uid: 'conditionalField',
+                kind: 'input',
+                type: 'textinput',
+                path: 'name',
+                include: { in: ['visible'] },
+              },
+            ],
+          }),
+          onFormReady: (h) => {
+            handle = h;
+          },
+        });
+        cy.get('[data-cy="conditionalField_textinput"]').should('not.exist');
+        cy.then(() => handle.setMeta({ showField: true }));
+        cy.get('[data-cy="conditionalField_textinput"]').should('exist');
+      });
+    });
+  });
+};

--- a/libs/ui-testing/src/lib/utils.ts
+++ b/libs/ui-testing/src/lib/utils.ts
@@ -3,6 +3,11 @@ import { Action, Middleware, State, ValidateOn } from '@golemui/core';
 import { Dependencies } from '@golemui/gui-shared';
 import { CustomValidatorSchemas } from '@golemui/gui-validators';
 
+export interface FormHandle {
+  setData: (data: Record<string, any>) => void;
+  setMeta: (meta: Record<string, any>) => void;
+}
+
 export interface MountOptions<StateKeys extends Core.UiState = string> {
   formDef: Core.Form<StateKeys>;
   data?: Record<string, any>;
@@ -15,6 +20,7 @@ export interface MountOptions<StateKeys extends Core.UiState = string> {
   withCustomComponent?: boolean;
   localization?: Core.I18nTranslator;
   dependencies?: Dependencies;
+  onFormReady?: (handle: FormHandle) => void;
 }
 
 export type MountComponentFn<StateKeys extends Core.UiState = string> = (


### PR DESCRIPTION
Adds `setData` and `setMeta` methods on all form components (Angular, Lit, React) to allow updating form field values and   meta values post form initialization.

`data` and `meta` can already be passed at initialization time via the config object, but this new feature allows doing it post form initialization.
```ts
// React
const formRef = useRef<FormComponentHandle>(null);

<Form config={config} ref={formRef} />

// Update field values without re-initializing
formRef.current.setData({ firstName: 'Jane', age: 30 });

// Update meta variables (e.g. to toggle conditional fields or update interpolated labels)
formRef.current.setMeta({ showAddressSection: true });
```