### PR TITLE
chore: remove json schema generation from deploy

### DIFF
--- a/tools/build-docs-apps.sh
+++ b/tools/build-docs-apps.sh
@@ -30,9 +30,4 @@ cp -R dist/apps/headless docs/public/
 cp -R dist/apps/serializable docs/public/
 cp -R dist/apps/freedom docs/public/
 
-echo "Copying json schemas..."
-mkdir -p docs/public/schemas/components
-cp -R libs/gui/shared/src/lib/schemas/*.json docs/public/schemas
-cp -R libs/gui/shared/src/lib/schemas/components/*.json docs/public/schemas/components
-
 echo "Build and copy completely successfully! 🎉"


### PR DESCRIPTION
Json schemas are now taken care of during release, not documentation deployment.
**release.yml -> npm run release -> release.ts -> archive-schemas.ts::archiveSchemas()**