### PR TITLE
ci: Add a build step to catch build errors before continuing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build affected
+        run: npx nx affected --target=build
+
       - run: npm run lint:affected

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,6 @@ jobs:
         run: npm ci
 
       - name: Build affected
-        run: npx nx affected --target=build
+        run: npx nx affected --target=build --exclude=docs
 
       - run: npm run lint:affected


### PR DESCRIPTION
## Description

Add a build step to catch build errors before continuing with any other checks.