### PR TITLE
ci: add pr title check GH action

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,3 +29,10 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have made corresponding changes to the documentation
+
+## PR Title Format
+
+> **PR Title** must follow Conventional Commits: `type(scope): subject`
+> (e.g. `feat(react): add Tooltip`, `fix(angular): correct focus trap`).
+> This title becomes the squash commit message and drives changelog + versioning.
+> An automated check will fail if the format is wrong. See [CONTRIBUTING.md](../CONTRIBUTING.md#squash-merge--pr-title) for the full type list.

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,7 +1,7 @@
 name: PR Title Lint
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,31 @@
+name: PR Title Lint
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate-pr-title:
+    name: Validate PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            refactor
+            test
+            chore
+            perf
+            build
+            ci
+            style
+            revert
+          requireScope: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,29 @@ Please open a discussion first for large or cross-cutting changes — it avoids 
 
 PRs are reviewed by maintainers. Expect feedback and possible requests for changes; this is normal and part of keeping the codebase healthy. Once approved and all checks are green, a maintainer will merge it.
 
+### Squash Merge & PR Title
+
+This repository uses **squash merges** exclusively. When your PR is merged, all commits on your branch are collapsed into a single commit whose message is taken directly from the **PR title**. That commit is what lands on `main` and what the release pipeline reads.
+
+This means: **your PR title is your commit message.** It must follow [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```text
+type(scope): subject
+```
+
+A **Validate PR title** GitHub Actions check enforces this automatically and will block the merge if the title is invalid. See [Commit Messages](#commit-messages) for the full list of allowed types and examples.
+
+Good PR titles:
+
+```text
+feat(react): add Tooltip component
+fix(angular): correct focus trap on Dialog close
+docs: clarify peerDependencies section
+chore: bump Nx to 21
+```
+
+Individual commits on your branch are squashed away and don't need to follow any format, only the PR title matters for the changelog and version bump.
+
 ### Keep PRs Focused
 
 One PR should address one concern. If you find unrelated bugs along the way, please open separate PRs for them. Smaller PRs get reviewed and merged faster.
@@ -118,7 +141,7 @@ Most editors can be set up to format on save — this is the smoothest experienc
 
 We follow [Conventional Commits](https://www.conventionalcommits.org/). The format is:
 
-```
+```text
 <type>(<scope>): <subject>
 ```
 
@@ -140,7 +163,7 @@ Common types:
 
 Examples:
 
-```
+```text
 feat(react): add Tooltip component
 fix(angular): correct focus trap on Dialog close
 docs(readme): clarify peerDependencies section


### PR DESCRIPTION
## Description

To enforce Conventional Commits, a new `.github/workflows/pr-title-lint.yml` workflow was created using `amannn/action-semantic-pull-request@v5` to block merges on non-compliant PR titles, which is supported by a new explanatory section and fixed code fences in `CONTRIBUTING.md` alongside a reminder section in `.github/PULL_REQUEST_TEMPLATE.md`