### PR TITLE
fix(schemas): fix json schema deployment when releasing (pt.2)

### DIFF
--- a/libs/core/src/lib/store/reducers/calculate-widget-flags.ts
+++ b/libs/core/src/lib/store/reducers/calculate-widget-flags.ts
@@ -223,8 +223,6 @@ function expandRepeaterFlags(
       const uid = toRepeaterItemUid(resolved.uid, currentIndexes);
       flags[uid] = flags[uid] || {};
 
-      // TODO: this is partially duplicating the logic in calculateFlags(). Is it worth abstracting?
-
       // show
       if (resolved.include && 'in' in resolved.include) {
         flags[uid].hidden = !resolved.include.in.some((s) => state.currentStates.includes(s));

--- a/nx.json
+++ b/nx.json
@@ -148,13 +148,6 @@
         "buildDepsTargetName": "build-deps",
         "typecheckTargetName": "typecheck"
       }
-    },
-    {
-      "plugin": "@nx/vitest",
-      "options": {
-        "testTargetName": "vitest:test",
-        "ciTargetName": "test-ci"
-      }
     }
   ]
 }

--- a/tools/release.ts
+++ b/tools/release.ts
@@ -28,7 +28,7 @@ function updateLatestDistTag(projectsVersionData: VersionData) {
           stdio: 'inherit',
         });
       } catch (e) {
-        console.warn(`Tag update failed: ${e.message}`);
+        console.warn(`Tag update failed: ${(e as Error).message}`);
       }
     });
   }


### PR DESCRIPTION
## Description

- Remove the `@nx/vitest` plugin entry from the `plugins` array in `nx.json` to avoid _MaxListenersExceededWarning_.
- Include at least code change in **libs/** to trigger a release.