### PR TITLE
fix(schemas): move archiveSchemas above releaseChangelog

### DIFF
--- a/libs/gui/shared/CHANGELOG.md
+++ b/libs/gui/shared/CHANGELOG.md
@@ -4,4 +4,4 @@ This was a version bump only for gui-shared to align it with other projects, the
 
 ## 0.12.0 (2026-05-16)
 
-This was a version bump only for gui-shared to align it with other projects, there were no code changes.
+This was a version bump only for gui-shared to align it with other projects, there were no code changes

--- a/tools/archive-schemas.ts
+++ b/tools/archive-schemas.ts
@@ -52,7 +52,7 @@ export async function archiveSchemas(version: string, dryRun: boolean): Promise<
       );
     }
 
-    // Copy to /schemas/v{VERSION}/ with versioned $id
+    // Copy to /schemas/archive/v{VERSION}/ with versioned $id
     for (const entry of rootFiles) {
       rewriteAndCopy(join(SCHEMAS_SOURCE, entry.name), join(versionedDir, entry.name), version);
     }

--- a/tools/release.ts
+++ b/tools/release.ts
@@ -44,6 +44,11 @@ function updateLatestDistTag(projectsVersionData: VersionData) {
     releaseType === 'rc' ? { preid: 'rc', dryRun } : { dryRun },
   );
 
+  // Note: this will be pushed at the same time as the changelog. One push for all.
+  if (releaseType === 'stable' && workspaceVersion) {
+    await archiveSchemas(workspaceVersion, dryRun);
+  }
+
   await releaseChangelog({
     versionData: projectsVersionData,
     version: workspaceVersion,
@@ -58,10 +63,6 @@ function updateLatestDistTag(projectsVersionData: VersionData) {
 
   if (releaseType === 'stable' && !dryRun) {
     updateLatestDistTag(projectsVersionData);
-  }
-
-  if (releaseType === 'stable' && workspaceVersion) {
-    await archiveSchemas(workspaceVersion, dryRun);
   }
 
   const ok = Object.values(publishResult).every((result) => result.code === 0);


### PR DESCRIPTION
## Description

Move `archiveSchemas` above `releaseChangelog`.