### PR TITLE
fix(gui-shared): simplify button event handling

### DIFF
--- a/apps/apps-shared/src/lib/mocks/appetizer.ts
+++ b/apps/apps-shared/src/lib/mocks/appetizer.ts
@@ -270,7 +270,7 @@ const formDef: DxDefinitions = [
       key: 'travelPlanner.btn.submit',
       default: 'Search My Trip',
     },
-    on: { click: 'handleSubmit' },
+    onClick: () => 'handleSubmit',
   }),
 ];
 

--- a/apps/apps-shared/src/lib/mocks/kitchen-sink.dx.ts
+++ b/apps/apps-shared/src/lib/mocks/kitchen-sink.dx.ts
@@ -121,7 +121,7 @@ export const buildKitchenSinkDx = (options: KitchenSinkDxOptions = {}): KitchenS
       ],
       { defaultOpen: 'tabAlert', onChange: 'onTabEvent' },
     ),
-    gui.actions.button({ label: 'Create', icon: 'save', iconPosition: 'right', onClick: 'submit' }),
+    gui.actions.submitButton({ label: 'Create', icon: 'save', iconPosition: 'right' }),
   ],
   formSelectors: [
     // Suppress DX-layer auto-labels and auto-placeholders on every input —

--- a/apps/apps-shared/src/lib/mocks/tests.dx.ts
+++ b/apps/apps-shared/src/lib/mocks/tests.dx.ts
@@ -34,7 +34,7 @@ const formDef: DxDefinitionItem[] = [
     uid: 'button',
     label: 'Send',
     disabled: { when: '$formIsInvalid' },
-    on: { click: 'send' },
+    onClick: () => 'send',
   }),
   gui.displays.alert({
     uid: 'send-result',

--- a/apps/template/src/app/forms/events/index.ts
+++ b/apps/template/src/app/forms/events/index.ts
@@ -6,7 +6,7 @@ export const eventsClickDemo = {
   form: [
     gui.actions.button({
       label: 'Click me',
-      onClick: 'evClick',
+      onClick: () => 'evClick',
     }),
     gui.inputs.textInput('evClickResult', {
       label: 'Last click',
@@ -76,7 +76,6 @@ export const eventsSubmitDemo = {
     gui.inputs.textInput('evEmail', {
       label: 'Email',
       validator: {
-        type: 'string',
         required: true,
         format: 'email',
         messages: {

--- a/docs/public/template/getting-started-dx/rent-a-car/01-form.ts
+++ b/docs/public/template/getting-started-dx/rent-a-car/01-form.ts
@@ -99,9 +99,5 @@ export default [
   gui.inputs.textInput('discountCode', {
     label: 'Discount code',
   }),
-  gui.actions.button({
-    label: 'Reserve',
-    uid: 'submit',
-    onClick: 'submit',
-  }),
+  gui.actions.submitButton({ label: 'Reserve' }),
 ];

--- a/docs/public/template/getting-started-dx/rent-a-car/02-states.ts
+++ b/docs/public/template/getting-started-dx/rent-a-car/02-states.ts
@@ -135,9 +135,5 @@ export default [
       in: ['hasDiscount'],
     },
   }),
-  gui.actions.button({
-    label: 'Reserve',
-    uid: 'submit',
-    onClick: 'submit',
-  }),
+  gui.actions.submitButton({ label: 'Reserve' }),
 ];

--- a/docs/public/template/getting-started-dx/rent-a-car/03-messages.ts
+++ b/docs/public/template/getting-started-dx/rent-a-car/03-messages.ts
@@ -167,9 +167,5 @@ export default [
       in: ['hasDiscount'],
     },
   }),
-  gui.actions.button({
-    label: 'Reserve',
-    uid: 'submit',
-    onClick: 'submit',
-  }),
+  gui.actions.submitButton({ label: 'Reserve' }),
 ];

--- a/docs/public/template/getting-started-dx/rent-a-car/04-renderer.ts
+++ b/docs/public/template/getting-started-dx/rent-a-car/04-renderer.ts
@@ -170,9 +170,5 @@ export default [
       in: ['hasDiscount'],
     },
   }),
-  gui.actions.button({
-    label: 'Reserve',
-    uid: 'submit',
-    onClick: 'submit',
-  }),
+  gui.actions.submitButton({ label: 'Reserve' }),
 ];

--- a/docs/public/template/getting-started-dx/rent-a-car/05-search.ts
+++ b/docs/public/template/getting-started-dx/rent-a-car/05-search.ts
@@ -147,9 +147,5 @@ export default [
       in: ['hasDiscount'],
     },
   }),
-  gui.actions.button({
-    label: 'Reserve',
-    uid: 'submit',
-    onClick: 'submit',
-  }),
+  gui.actions.submitButton({ label: 'Reserve' }),
 ];

--- a/docs/public/template/getting-started-dx/rent-a-car/06-final.ts
+++ b/docs/public/template/getting-started-dx/rent-a-car/06-final.ts
@@ -147,9 +147,5 @@ export default [
       in: ['hasDiscount'],
     },
   }),
-  gui.actions.button({
-    label: 'Reserve',
-    uid: 'submit',
-    onClick: 'handleReservation',
-  }),
+  gui.actions.submitButton({ label: 'Reserve' }),
 ];

--- a/docs/src/components/landing/paradigm-snippets.ts
+++ b/docs/src/components/landing/paradigm-snippets.ts
@@ -485,7 +485,7 @@ export const signupForm = [
     label: 'I accept the terms of service',
     validator: { const: true },
   }),
-  gui.actions.button({ label: 'Sign up', onClick: 'submit' }),
+  gui.actions.submitButton({ label: 'Sign up' }),
 ];`,
 };
 

--- a/docs/src/content/docs/extending/widgets/overview.mdx
+++ b/docs/src/content/docs/extending/widgets/overview.mdx
@@ -125,11 +125,10 @@ The declarative form engine.`,
     gui.actions.custom('productShare', {
       onClick: 'shareEvent',
     }),
-    gui.actions.button({
+    gui.actions.submitButton({
       label: 'Submit',
       icon: 'save',
       iconPosition: 'right',
-      onClick: 'submit',
     }),
   ],
   { title: 'Product Card Name' },

--- a/docs/src/content/docs/features/events.mdx
+++ b/docs/src/content/docs/features/events.mdx
@@ -26,7 +26,10 @@ const formDef = [
     onChange: 'countryChanged',
     items: ['US', 'CA', 'MX'],
   }),
-  gui.actions.button('submit', { label: 'Submit', onClick: 'submitForm' }),
+  gui.actions.button('submit', {
+    label: 'Submit',
+    onClick: () => 'submitForm',
+  }),
 ];
 ```
 
@@ -73,7 +76,7 @@ const formDef = [
 
     const formDef = [
       gui.inputs.dropdown('country', { onChange: 'countryChanged', items: ['US', 'CA', 'MX'] }),
-      gui.actions.button('submit', { label: 'Submit', onClick: 'submitForm' }),
+      gui.actions.button('submit', { label: 'Submit', onClick: () => 'submitForm' }),
     ];
     const formConfig = { widgetLoaders: React.widgetLoaders };
 
@@ -113,7 +116,7 @@ const formDef = [
       protected config = {
         formDef: [
           gui.inputs.dropdown('country', { onChange: 'countryChanged', items: ['US', 'CA', 'MX'] }),
-          gui.actions.button('submit', { label: 'Submit', onClick: 'submitForm' }),
+          gui.actions.button('submit', { label: 'Submit', onClick: () => 'submitForm' }),
         ],
         data: {},
         formConfig: { widgetLoaders: Angular.widgetLoaders },
@@ -146,7 +149,7 @@ const formDef = [
       config = {
         formDef: [
           gui.inputs.dropdown('country', { onChange: 'countryChanged', items: ['US', 'CA', 'MX'] }),
-          gui.actions.button('submit', { label: 'Submit', onClick: 'submitForm' }),
+          gui.actions.button('submit', { label: 'Submit', onClick: () => 'submitForm' }),
         ],
         data: {},
         formConfig: { widgetLoaders: Lit.widgetLoaders },

--- a/docs/src/content/docs/features/states/composing.mdx
+++ b/docs/src/content/docs/features/states/composing.mdx
@@ -5,8 +5,8 @@ sidebar:
   order: 4
 ---
 
-import DslTabs from '../../../../components/DslTabs.astro';
 import { Aside } from '@astrojs/starlight/components';
+import DslTabs from '../../../../components/DslTabs.astro';
 
 States are simple boolean expressions, so you can compose them inline with `&&` and `||`. The convention in GolemUI is to **define one canonical expression per state** — don't reference state names inside other state expressions; recombine raw `$form.*` reads instead.
 
@@ -184,9 +184,7 @@ gui.actions.button('login', {
     'register:minor:canSubmit': { disabled: false },
     'register:adult:canSubmit': { disabled: false },
   },
-  on: {
-    click: 'handleLogin',
-  },
+  onClick: () => 'handleLogin',
 });
 ```
 

--- a/docs/src/content/docs/form-definition/custom-widgets.mdx
+++ b/docs/src/content/docs/form-definition/custom-widgets.mdx
@@ -5,8 +5,8 @@ sidebar:
   order: 3
 ---
 
-import Demo from '../../../components/landing/Demo.astro';
 import DslTabs from '../../../components/DslTabs.astro';
+import Demo from '../../../components/landing/Demo.astro';
 
 Each shortcut group exposes a `.custom()` factory for widgets you've implemented yourself. The shape mirrors the built-in shortcuts but takes the widget `type` as the first argument.
 
@@ -111,11 +111,10 @@ const formDef = [
         ],
         onClick: 'shareEvent',
       }),
-      gui.actions.button({
+      gui.actions.submitButton({
         label: 'Submit',
         icon: 'save',
         iconPosition: 'right',
-        onClick: 'submit',
       }),
     ],
     { title: 'Rate Our Product' },

--- a/docs/src/content/docs/form-definition/events.mdx
+++ b/docs/src/content/docs/form-definition/events.mdx
@@ -108,7 +108,7 @@ Buttons fire `onClick` events. The handler matches by `event.name` and dispatche
 const formDef = [
   gui.actions.button({
     label: 'Click me',
-    onClick: 'evClick',
+    onClick: () => 'evClick',
   }),
   gui.inputs.textInput('evClickResult', {
     label: 'Last click',
@@ -276,7 +276,7 @@ const formDef = [
   }),
   gui.actions.submitButton({ label: 'Submit' }),
   // — or equivalently —
-  // gui.actions.button({ label: 'Submit', onClick: 'submit' }),
+  // gui.actions.button({ label: 'Submit', onClick: () => 'submit' }),
   gui.inputs.textInput('evSubmittedEmail', {
     label: 'Result',
     readonly: true,

--- a/docs/src/content/docs/form-definition/how-it-works.mdx
+++ b/docs/src/content/docs/form-definition/how-it-works.mdx
@@ -84,7 +84,7 @@ through the `formEvent` callback when clicked.
 
 ```ts
 gui.actions.submitButton({ label: 'Save' });
-gui.actions.button({ label: 'Cancel', onClick: 'cancelForm' });
+gui.actions.button({ label: 'Cancel', onClick: () => 'cancelForm' });
 ```
 
 → See the full list at **[`gui.actions` reference](/form-definition/reference/gui-actions/)**.

--- a/docs/src/content/docs/form-definition/reference/gui-actions.mdx
+++ b/docs/src/content/docs/form-definition/reference/gui-actions.mdx
@@ -24,7 +24,7 @@ gui.actions.button(
     iconPosition: 'right',
     disabled: false,
     uid: 'save-btn',
-    onClick: 'saveChanges', // event name routed through `formEvent` (or 'submit' to trigger validation)
+    onClick: () => 'saveChanges', // event name routed through `formEvent`
     states: {
       // per-state overrides — see /form-definition/states/
       submitting: { label: 'Saving…', disabled: true },
@@ -33,10 +33,10 @@ gui.actions.button(
   ['primary'], // tags — addressable groups for selectors
 );
 
-gui.actions.submitButton({ label: 'Submit' }); // shorthand for { uid: '#submit', label: '…' }
+gui.actions.submitButton({ label: 'Submit' }); // shorthand for { uid: '#submit', on: {click: 'submit'}, label: '…' } - triggers validation - doesn't accept onClick (it's pre-baked)
 ```
 
-`onClick` accepts a literal `'submit'` (triggers form-level validation first), any other string (the event name your `formEvent` callback receives), or a function callback that runs on click. See [Events](/form-definition/events/) for the full table.
+`onClick` accepts a string (the event name your `formEvent` callback receives), or a function callback that runs on click. See [Events](/form-definition/events/) for the full table.
 
 ## Shortcuts
 

--- a/docs/src/content/docs/widgets-reference/interactive-fields/overview.mdx
+++ b/docs/src/content/docs/widgets-reference/interactive-fields/overview.mdx
@@ -17,18 +17,18 @@ const formDef = [
   gui.actions.submitButton({ label: 'Submit' }),
 
   // A free-form button — emits whatever event name you provide.
-  gui.actions.button({ label: 'Cancel', on: { click: 'cancelForm' } }),
+  gui.actions.button({ label: 'Cancel', onClick: () => 'cancelForm' }),
 
   // Plug in your own action widget.
-  gui.actions.custom('productShare', { onClick: 'shareEvent' }),
+  gui.actions.custom('productShare', { onClick: () => 'shareEvent' }),
 ];
 ```
 
-| Shortcut                   | Description                                                                                                                                                                             |
-| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `gui.actions.button`       | A button widget ([Button](/widgets-reference/interactive-fields/button/)). Use `onClick: 'submit'` for the form-submit literal, or `on: { click: '<eventName>' }` for arbitrary events. |
-| `gui.actions.submitButton` | A button preconfigured with `onClick: 'submit'`.                                                                                                                                        |
-| `gui.actions.custom`       | Plug in your own action widget ([Custom Widgets](/form-definition/custom-widgets/)).                                                                                                    |
+| Shortcut                   | Description                                                                                                                                                                                   |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gui.actions.button`       | A button widget ([Button](/widgets-reference/interactive-fields/button/)). Use `onClick: () => 'submit'` for the form-submit literal, or `onClick: () => '<eventName>'` for arbitrary events. |
+| `gui.actions.submitButton` | A button preconfigured with `onClick: () => 'submit'`.                                                                                                                                        |
+| `gui.actions.custom`       | Plug in your own action widget ([Custom Widgets](/form-definition/custom-widgets/)).                                                                                                          |
 
 ## JSON form
 

--- a/libs/gui/shared/src/lib/dx/__tests__/actions.pipeline.spec.ts
+++ b/libs/gui/shared/src/lib/dx/__tests__/actions.pipeline.spec.ts
@@ -1,9 +1,9 @@
 import { type LayoutWidget } from '@golemui/core';
 import { describe, expect, it, vi } from 'vitest';
-import { processDx, getRawChild, resolveDynamic } from './helpers';
-import { _guiButton } from '../shortcuts/actions/guiActions.impl';
 import { formDefs } from '../dx.service';
 import { _guiTextInput } from '../index';
+import { _guiButton, _guiSubmitButton } from '../shortcuts/actions/guiActions.impl';
+import { getRawChild, processDx, resolveDynamic } from './helpers';
 
 function getRootFromFacadeResult(
   result: ReturnType<typeof formDefs.processDxFacade>,
@@ -14,7 +14,7 @@ function getRootFromFacadeResult(
 describe('DX Pipeline — Actions', () => {
   describe('Basic action expansion', () => {
     it('maps explicit onClick button with click event wiring', () => {
-      const myFn = () => null;
+      const myFn = () => undefined;
       const root = processDx([_guiTextInput('name'), _guiButton({ label: 'Save', onClick: myFn })]);
 
       const saveButton = root.children?.find(
@@ -42,8 +42,8 @@ describe('DX Pipeline — Actions', () => {
     it('wires multiple buttons with unique uids and unique click event names', () => {
       const root = processDx([
         _guiTextInput('name'),
-        _guiButton({ label: 'A', onClick: () => null }),
-        _guiButton({ label: 'B', onClick: () => null }),
+        _guiButton({ label: 'A', onClick: () => undefined }),
+        _guiButton({ label: 'B', onClick: () => undefined }),
       ]);
 
       const actions = (root.children ?? []).filter(
@@ -61,12 +61,8 @@ describe('DX Pipeline — Actions', () => {
   });
 
   describe('Submit button handling', () => {
-    it("promotes onClick: 'submit' action to #submit with submit event", () => {
-      const result = formDefs.processDxFacade(
-        [_guiButton({ label: 'Go', onClick: 'submit' })],
-        [],
-        {},
-      );
+    it('_guiSubmitButton wires uid and on.click: submit', () => {
+      const result = formDefs.processDxFacade([_guiSubmitButton({ label: 'Go' })], [], {});
       const root = getRootFromFacadeResult(result);
       const submit = root.children?.find(
         (child) => typeof child !== 'function' && (child as { kind?: string }).kind === 'action',
@@ -76,20 +72,20 @@ describe('DX Pipeline — Actions', () => {
       expect(submit.on?.click).toBe('submit');
     });
 
-    it("treats uid '#submit' action as submit and wires submit event", () => {
+    it('plain _guiButton with uid #submit does NOT get submit wiring', () => {
       const result = formDefs.processDxFacade([_guiButton({ uid: '#submit', label: 'Send' })], []);
       const root = getRootFromFacadeResult(result);
-      const submit = root.children?.find(
-        (child) => typeof child !== 'function' && (child as { uid?: string }).uid === '#submit',
-      ) as { on?: { click?: string } };
+      const btn = root.children?.find(
+        (child) => typeof child !== 'function' && (child as { kind?: string }).kind === 'action',
+      ) as { uid?: string; on?: { click?: string } };
 
-      expect(submit.on?.click).toBe('submit');
+      expect(btn.on?.click).not.toBe('submit');
     });
 
-    it('registers root onSubmit callback into form events when submit action is present', () => {
+    it('registers root onSubmit callback into form events when _guiSubmitButton is present', () => {
       const submitFn = vi.fn();
       const result = formDefs.processDxFacade(
-        [_guiTextInput('name'), _guiButton({ label: 'Go', onClick: 'submit' })],
+        [_guiTextInput('name'), _guiSubmitButton({ label: 'Go' })],
         [],
         { onSubmit: submitFn },
       );
@@ -124,6 +120,44 @@ describe('DX Pipeline — Actions', () => {
     });
   });
 
+  describe('Return-value dispatch', () => {
+    it('onClick returning a registered event name dispatches to its handler', () => {
+      const submitFn = vi.fn();
+      const result = formDefs.processDxFacade(
+        [
+          _guiTextInput('x'),
+          _guiSubmitButton({ label: 'S' }),
+          _guiButton({ label: 'Trigger', onClick: () => 'submit' }),
+        ],
+        [],
+        { onSubmit: submitFn },
+      );
+      const root = result.form.form as LayoutWidget;
+      const triggerBtn = root.children?.find(
+        (c) => typeof c !== 'function' && (c as any).label === 'Trigger',
+      ) as any;
+
+      result.events!({ name: triggerBtn.on.click, data: { x: 1 }, callback: vi.fn() });
+      expect(submitFn).toHaveBeenCalledWith({ x: 1 });
+    });
+
+    it('onClick returning an unregistered name is a no-op', () => {
+      const result = formDefs.processDxFacade(
+        [_guiButton({ label: 'Go', onClick: () => 'ghost' })],
+        [],
+      );
+      const root = result.form.form as LayoutWidget;
+      const btn = root.children?.find(
+        (c) => typeof c !== 'function' && (c as any).label === 'Go',
+      ) as any;
+      const cb = vi.fn();
+
+      expect(result.events).toBeDefined();
+      result.events?.({ name: btn.on.click, data: {}, callback: cb });
+      expect(cb).not.toHaveBeenCalled();
+    });
+  });
+
   describe('No auto-submit', () => {
     it('does not inject a submit button when none is declared', () => {
       const result = formDefs.processDxFacade([_guiTextInput('name')], []);
@@ -138,7 +172,7 @@ describe('DX Pipeline — Actions', () => {
 
   describe('Dynamic (callback) actions', () => {
     it('keeps callback action dynamic and wires on.click after resolving', () => {
-      const myFn = () => null;
+      const myFn = () => undefined;
       const defs = [
         _guiTextInput('name'),
         _guiButton((p: any) => ({
@@ -170,7 +204,7 @@ describe('DX Pipeline — Actions', () => {
   describe('Return type handling', () => {
     it('includes events in DxResult when at least one onClick callback exists', () => {
       const result = formDefs.processDxFacade(
-        [_guiButton({ label: 'Go', onClick: () => null })],
+        [_guiButton({ label: 'Go', onClick: () => undefined })],
         [],
       );
 

--- a/libs/gui/shared/src/lib/dx/__tests__/containerTypes.pipeline.spec.ts
+++ b/libs/gui/shared/src/lib/dx/__tests__/containerTypes.pipeline.spec.ts
@@ -1,8 +1,15 @@
 import { type LayoutWidget } from '@golemui/core';
 import { describe, expect, it } from 'vitest';
-import { _guiTabs, _guiList, _guiCheckbox, _guiButton, _gslTabs, _gslLists } from '../index';
-import { processDx, getStaticChild, getRawChild, resolveDynamic } from './helpers';
-import { _guiTextInput } from '../index';
+import {
+  _gslLists,
+  _gslTabs,
+  _guiCheckbox,
+  _guiList,
+  _guiSubmitButton,
+  _guiTabs,
+  _guiTextInput,
+} from '../index';
+import { getRawChild, getStaticChild, processDx, resolveDynamic } from './helpers';
 
 describe('DX Pipeline — Container Types (Phase 6.3)', () => {
   describe('Tabs', () => {
@@ -119,7 +126,7 @@ describe('DX Pipeline — Container Types (Phase 6.3)', () => {
         _guiTabs([
           {
             label: 'Main',
-            children: [_guiTextInput('name'), _guiButton({ label: 'Submit', onClick: 'submit' })],
+            children: [_guiTextInput('name'), _guiSubmitButton({ label: 'Submit' })],
           },
         ]),
       );

--- a/libs/gui/shared/src/lib/dx/__tests__/customWidgets.pipeline.spec.ts
+++ b/libs/gui/shared/src/lib/dx/__tests__/customWidgets.pipeline.spec.ts
@@ -1,22 +1,22 @@
 import { type LayoutWidget } from '@golemui/core';
 import { describe, expect, it, vi } from 'vitest';
-import { processDx, getStaticChild, getRawChild, resolveDynamic } from './helpers';
+import { formDefs } from '../dx.service';
 import {
+  _gslCustomActionByUid,
+  _gslCustomActions,
+  _gslCustomDisplayByUid,
+  _gslCustomDisplays,
+  _gslCustomInputByUid,
+  _gslCustomInputs,
+  _gslCustomLayoutByUid,
+  _gslCustomLayouts,
+  _guiCustomAction,
   _guiCustomDisplay,
   _guiCustomInput,
-  _guiCustomAction,
   _guiCustomLayout,
-  _gslCustomDisplays,
-  _gslCustomDisplayByUid,
-  _gslCustomInputs,
-  _gslCustomInputByUid,
-  _gslCustomActions,
-  _gslCustomActionByUid,
-  _gslCustomLayouts,
-  _gslCustomLayoutByUid,
+  _guiTextInput,
 } from '../index';
-import { formDefs } from '../dx.service';
-import { _guiTextInput } from '../index';
+import { getRawChild, getStaticChild, processDx, resolveDynamic } from './helpers';
 
 describe('DX Pipeline — Custom Display', () => {
   it('expands _guiCustomDisplay into a display widget with custom type', () => {
@@ -162,21 +162,6 @@ describe('DX Pipeline — Custom Action', () => {
 
     dxResult.events!({ name: btn.on.click, data: { ok: true }, callback: vi.fn() });
     expect(handler).toHaveBeenCalledWith({ ok: true });
-  });
-
-  it('supports onClick: "submit" for custom action', () => {
-    const dxResult = formDefs.processDxFacade(
-      [_guiCustomAction('matButton', { label: 'Submit', onClick: 'submit' })],
-      [],
-      {},
-    );
-    const root = dxResult.form.form as LayoutWidget;
-    const submit = root.children?.find(
-      (c) => typeof c !== 'function' && (c as any).kind === 'action',
-    ) as any;
-
-    expect(submit.uid).toBe('#submit');
-    expect(submit.on?.click).toBe('submit');
   });
 
   it('passes through custom props', () => {

--- a/libs/gui/shared/src/lib/dx/__tests__/edgeCases.pipeline.spec.ts
+++ b/libs/gui/shared/src/lib/dx/__tests__/edgeCases.pipeline.spec.ts
@@ -1,11 +1,11 @@
 import { type LayoutWidget } from '@golemui/core';
 import { describe, expect, it } from 'vitest';
-import { processDx, getStaticChild, getRawChild, resolveDynamic } from './helpers';
-import { _guiDisplay } from '../shortcuts/display/guiDisplay.impl';
+import { _guiTextInput } from '../index';
 import { _guiButton } from '../shortcuts/actions/guiActions.impl';
+import { _guiDisplay } from '../shortcuts/display/guiDisplay.impl';
 import { _guiHorizontalFlex, _guiVerticalFlex } from '../shortcuts/layouts/guiFlex.impl';
 import { _guiTabs } from '../shortcuts/tabs/guiTabs.impl';
-import { _guiTextInput } from '../index';
+import { getRawChild, getStaticChild, processDx, resolveDynamic } from './helpers';
 
 describe('DX Pipeline — Edge Cases', () => {
   describe('Deeply nested layouts', () => {
@@ -32,7 +32,7 @@ describe('DX Pipeline — Edge Cases', () => {
       const root = processDx([
         _guiTextInput('name'),
         _guiDisplay(() => 'mid'),
-        _guiButton({ label: 'Go', onClick: () => null }),
+        _guiButton({ label: 'Go', onClick: () => undefined }),
       ]);
 
       // child 0: static input

--- a/libs/gui/shared/src/lib/dx/__tests__/eventWiring.pipeline.spec.ts
+++ b/libs/gui/shared/src/lib/dx/__tests__/eventWiring.pipeline.spec.ts
@@ -1,12 +1,12 @@
 import { type FormEvent, type LayoutWidget } from '@golemui/core';
 import { describe, expect, it, vi } from 'vitest';
-import { processDx, getStaticChild, getRawChild, resolveDynamic } from './helpers';
-import { _guiSelect } from '../shortcuts/select/guiSelect.impl';
-import { _guiDropdown } from '../shortcuts/dropdown/guiDropdown.impl';
-import { _guiTabs } from '../shortcuts/tabs/guiTabs.impl';
-import { _guiButton } from '../shortcuts/actions/guiActions.impl';
 import { formDefs } from '../dx.service';
-import { _guiTextInput, _guiNumberInput } from '../index';
+import { _guiNumberInput, _guiTextInput } from '../index';
+import { _guiButton } from '../shortcuts/actions/guiActions.impl';
+import { _guiDropdown } from '../shortcuts/dropdown/guiDropdown.impl';
+import { _guiSelect } from '../shortcuts/select/guiSelect.impl';
+import { _guiTabs } from '../shortcuts/tabs/guiTabs.impl';
+import { getRawChild, getStaticChild, processDx, resolveDynamic } from './helpers';
 
 function getRootFromFacadeResult(
   result: ReturnType<typeof formDefs.processDxFacade>,
@@ -289,39 +289,6 @@ describe('DX Pipeline — Event Wiring', () => {
 
       result.events!({ name: button.on.click, data: { x: 1 }, callback: vi.fn() });
       expect(clickFn).toHaveBeenCalledWith({ x: 1 });
-    });
-
-    it('onSubmit still receives event.data (backward compat)', () => {
-      const submitFn = vi.fn();
-      const result = formDefs.processDxFacade(
-        [_guiTextInput('name'), _guiButton({ label: 'Go', onClick: 'submit' })],
-        [],
-        { onSubmit: submitFn },
-      );
-
-      result.events!({ name: 'submit', data: { ok: true }, callback: vi.fn() });
-      expect(submitFn).toHaveBeenCalledWith({ ok: true });
-    });
-
-    it('arbitrary string onClick lands as on.click for host-managed dispatch', () => {
-      const result = formDefs.processDxFacade(
-        [_guiButton({ label: 'Click me', onClick: 'evClick' })],
-        [],
-        {},
-      );
-
-      const root = getRootFromFacadeResult(result);
-      const button = (root.children ?? []).find(
-        (c) => typeof c !== 'function' && (c as any).kind === 'action',
-      ) as any;
-
-      // The DX layer translates `onClick: 'evClick'` to `on: { click: 'evClick' }`
-      // — exactly the shape host applications listen for via formEvent.
-      expect(button.on?.click).toBe('evClick');
-      // No internal event registry entry — the engine just routes the name through.
-      const clickFn = vi.fn();
-      result.events?.({ name: 'evClick', data: {}, callback: clickFn });
-      expect(clickFn).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/gui/shared/src/lib/dx/core/eventWiring.service.ts
+++ b/libs/gui/shared/src/lib/dx/core/eventWiring.service.ts
@@ -1,6 +1,6 @@
 import { type FormEvent, type FunctionWidgetParams } from '@golemui/core';
-import { type FormConfig, type MergeResult, type RuntimeFunction } from './dx.domain';
 import { type ActionDecorator } from '../shortcuts/actions/actions.domain';
+import { type FormConfig, type MergeResult, type RuntimeFunction } from './dx.domain';
 import { type EventIdGenerator } from './itemTypeRegistry';
 
 export type EventRegistry = Map<string, (event: FormEvent) => void>;
@@ -17,6 +17,8 @@ const INPUT_LAYOUT_EVENT_PROPS: Record<string, string> = {
 };
 
 const INPUT_LAYOUT_EVENT_KEYS = Object.keys(INPUT_LAYOUT_EVENT_PROPS);
+
+type ActionDecoratorWithPresetClick = ActionDecorator & { on?: { click: string } };
 
 /**
  * Generalisation of ActionOnClickService.
@@ -39,49 +41,64 @@ export class EventWiringService {
     if (mergeResult.kind === 'dynamic') {
       const originalFn = mergeResult.fn;
       const wrappedFn: RuntimeFunction = (params: FunctionWidgetParams<any>) => {
-        const result = originalFn(params) as ActionDecorator & Record<string, any>;
+        const result = originalFn(params) as ActionDecoratorWithPresetClick;
         return this.wireOnClick(result, eventRegistry, formConfig, eventIdGenerator);
       };
       return { kind: 'dynamic', fn: wrappedFn };
     }
 
-    const actionDef = mergeResult.def as ActionDecorator & Record<string, any>;
+    const actionDef = mergeResult.def as ActionDecoratorWithPresetClick;
     const wired = this.wireOnClick(actionDef, eventRegistry, formConfig, eventIdGenerator);
     return { kind: 'static', def: wired as ActionDecorator };
   }
 
   private wireOnClick(
-    actionDef: ActionDecorator & Record<string, any>,
+    actionDef: ActionDecoratorWithPresetClick,
     eventRegistry: EventRegistry,
     formConfig: FormConfig,
     eventIdGenerator: EventIdGenerator,
   ): Record<string, any> {
-    const isSubmit = actionDef.uid === '#submit' || actionDef.onClick === 'submit';
-    const actionId = isSubmit ? '#submit' : eventIdGenerator.next();
-    const eventName = isSubmit ? 'submit' : actionId;
+    const rawOnClick = actionDef.onClick as ((data: any) => string | void) | undefined;
+    const preSetEventName = actionDef.on?.click as string | undefined;
 
-    const rawOnClick = actionDef.onClick;
-    const explicitCallback = typeof rawOnClick === 'function' ? rawOnClick : undefined;
-    const effectiveOnClick = explicitCallback ?? (isSubmit ? formConfig.onSubmit : undefined);
-
-    if (effectiveOnClick) {
-      // Wrap action onClick: callback receives event.data for backward compat
-      eventRegistry.set(eventName, (event: FormEvent) => effectiveOnClick(event.data));
+    // Case 1: on.click already set (only _guiSubmitButton pre-sets this)
+    // Register formConfig.onSubmit or user onClick against the pre-set event name.
+    if (preSetEventName) {
+      const effectiveOnClick =
+        rawOnClick ?? (preSetEventName === 'submit' ? formConfig.onSubmit : undefined);
+      if (effectiveOnClick) {
+        eventRegistry.set(preSetEventName, (event: FormEvent) => {
+          const returned = effectiveOnClick(event.data);
+          if (typeof returned === 'string') {
+            const secondary = eventRegistry.get(returned);
+            if (secondary) {
+              secondary(event);
+            }
+          }
+        });
+      }
       const { onClick: _, ...rest } = actionDef;
-      return { ...rest, uid: actionId, on: { click: eventName } };
+      return rest;
     }
 
-    if (isSubmit) {
+    // Case 2: user-provided onClick - generate event name and register handler.
+    if (rawOnClick) {
+      const eventName = eventIdGenerator.next();
+      eventRegistry.set(eventName, (event: FormEvent) => {
+        const returned = rawOnClick(event.data);
+        if (typeof returned === 'string') {
+          const secondary = eventRegistry.get(returned);
+          if (secondary) {
+            secondary(event);
+          }
+        }
+      });
       const { onClick: _, ...rest } = actionDef;
-      return { ...rest, uid: actionId, on: { click: 'submit' } };
+      return { ...rest, uid: actionDef.uid ?? eventName, on: { click: eventName } };
     }
 
-    if (typeof rawOnClick === 'string') {
-      const { onClick: _, ...rest } = actionDef;
-      return { ...rest, uid: actionId, on: { click: rawOnClick } };
-    }
-
-    return { ...actionDef, uid: actionId };
+    // Case 3: no onClick, no pre-set on.click - no event wiring, ensure uid exists.
+    return { ...actionDef, uid: actionDef.uid ?? eventIdGenerator.next() };
   }
 
   // ── Universal: onLoad, onChange, onFilter ──────────────────────

--- a/libs/gui/shared/src/lib/dx/shortcuts/actions/actions.domain.ts
+++ b/libs/gui/shared/src/lib/dx/shortcuts/actions/actions.domain.ts
@@ -4,9 +4,9 @@ import {
   type DxCommonFields,
   type DxInternalFields,
 } from '../../core/dxBase.types';
-import { type DxRuntimeParams } from '../../core/dxUtilityTypes';
 import {
   type DefOrCallback,
+  type DxRuntimeParams,
   type GslConfigBase,
   type GuiShortcutOf,
 } from '../../core/dxUtilityTypes';
@@ -18,8 +18,7 @@ import {
 export interface ActionDecorator extends DxActionBase, DxCommonFields, Partial<ButtonProps> {
   data?: any | null;
   type?: 'button';
-  on?: { click: string };
-  onClick?: ((data: any) => void) | string;
+  onClick?: (data: any) => void | string;
 }
 
 /**

--- a/libs/gui/shared/src/lib/dx/shortcuts/actions/guiActions.impl.ts
+++ b/libs/gui/shared/src/lib/dx/shortcuts/actions/guiActions.impl.ts
@@ -1,11 +1,7 @@
-import { GuiItemTypes } from '../../core/dx.domain';
-import { type DxRuntimeParams } from '../../core/dxUtilityTypes';
-import {
-  type ActionDecorator,
-  type ActionDefOrCallback,
-  type GuiActionsShortcut,
-} from './actions.domain';
 import { objectUtils } from '../../../utils/objectUtils.service';
+import { GuiItemTypes } from '../../core/dx.domain';
+import { type DefOrCallback, type DxRuntimeParams } from '../../core/dxUtilityTypes';
+import { type ActionDecorator, type GuiActionsShortcut } from './actions.domain';
 
 export function _guiButton(props: ActionDecorator): GuiActionsShortcut;
 export function _guiButton(props: ActionDecorator, tags: string[]): GuiActionsShortcut;
@@ -28,12 +24,18 @@ export function _guiButton(
   };
 }
 
+type ActionWithoutOnClickDefOrCallback = DefOrCallback<Omit<ActionDecorator, 'onClick'>>;
+type ActionDecoratorWithoutClick = Omit<ActionDecorator, 'onClick'>;
+
 export const _guiSubmitButton = (
-  defs?: ActionDecorator | ActionDefOrCallback,
+  defs?: ActionDecoratorWithoutClick | ActionWithoutOnClickDefOrCallback,
 ): GuiActionsShortcut => {
-  const baseSubmit: ActionDecorator = {
+  const baseSubmit: ActionDecorator & { on: { click: string } } = {
     uid: '#submit',
     label: 'Submit',
+    // `on` on `gui.actions.button` is hidden, but we need to preset it to 'sumbit'
+    // here so it can be properly handled by `EventWiringService`
+    on: { click: 'submit' },
   };
   const merged = defs != null ? objectUtils.deepMerge(baseSubmit, defs) : baseSubmit;
   return _guiButton(merged);

--- a/libs/gui/shared/src/lib/dx/shortcuts/actions/register.ts
+++ b/libs/gui/shared/src/lib/dx/shortcuts/actions/register.ts
@@ -2,11 +2,11 @@
 // The hook pattern is straightforward; the onClick service does the heavy lifting.
 import { type ActionWidget, type NonFunctionWidget, type UiState } from '@golemui/core';
 import { defineShortcutType } from '../../core/defineShortcutType';
-import { type ActionDecorator, type ActionEntry, type GslActionsConfig } from './actions.domain';
 import eventWiringService from '../../core/eventWiring.service';
+import { type ActionDecorator, type ActionEntry, type GslActionsConfig } from './actions.domain';
 
 function mapToWidget<StateKeys extends UiState = never, FormData extends Record<string, any> = any>(
-  def: ActionDecorator,
+  def: ActionDecorator & { on: { click: string } },
 ): NonFunctionWidget<StateKeys, FormData> {
   const {
     uid,
@@ -36,7 +36,7 @@ function mapToWidget<StateKeys extends UiState = never, FormData extends Record<
 
 export const { gsl: _gslActions, gslByUid: _gslActionByUid } = defineShortcutType<
   ActionEntry,
-  ActionDecorator,
+  ActionDecorator & { on: { click: string } },
   GslActionsConfig
 >({
   itemType: 'ACTIONS',

--- a/libs/gui/shared/src/lib/dx/shortcuts/custom-action/customAction.domain.ts
+++ b/libs/gui/shared/src/lib/dx/shortcuts/custom-action/customAction.domain.ts
@@ -8,7 +8,7 @@ import type { DefOrCallback, GslConfigBase, GuiShortcutOf } from '../../core/dxU
 export interface CustomActionDecorator extends DxActionBase, DxCommonFields {
   customType: string;
   props?: Record<string, unknown>;
-  onClick?: ((data: any) => void) | 'submit';
+  onClick?: (data: any) => void | 'submit';
   data?: any | null;
   on?: { click: string };
 }


### PR DESCRIPTION
## Description

Simplified how `gui.actions.button` and `gui.actions.submitButton` are declared and handled:

| Shortcut                   | Description                                                                                                                     |
| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
| `gui.actions.button`       | Use `onClick: () => '<eventName>'` for arbitrary events or perform side-effects `onClick: (data) => console.log('Data:', data)` |
| `gui.actions.submitButton` | A button preconfigured with `onClick: () => 'submit'` - triggers form-level validation first, then emits `submit`                                                                          |
| `gui.actions.custom`       | Plug in your own action widget                                                                                                  |
