### PR TITLE
chore: unbump vue versions to have v0.0.1 as the other packages do

### DIFF
--- a/libs/gui/vue/package.json
+++ b/libs/gui/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@golemui/gui-vue",
-  "version": "0.13.3",
+  "version": "0.0.1",
   "type": "module",
   "main": "./index.umd.cjs",
   "module": "./index.js",

--- a/libs/vue/package.json
+++ b/libs/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@golemui/vue",
-  "version": "0.13.3",
+  "version": "0.0.1",
   "type": "module",
   "main": "./index.umd.cjs",
   "module": "./index.js",


### PR DESCRIPTION
Now that vue has been released in v0.14.0 we can unbump the manually bumped versions for the release.