### PR TITLE
feat: add tags widget

### DIFF
--- a/apps/apps-shared/src/lib/mocks/kitchen-sink.dx.ts
+++ b/apps/apps-shared/src/lib/mocks/kitchen-sink.dx.ts
@@ -25,6 +25,7 @@ import { radiogroupTab } from './tabs/radiogroup.dx';
 import { repeaterTab } from './tabs/repeater.dx';
 import { buildRendererTab } from './tabs/renderer.dx';
 import { selectTab } from './tabs/select.dx';
+import { tagsTab } from './tabs/tags.dx';
 import { textareaTab } from './tabs/textarea.dx';
 import { textinputTab } from './tabs/textinput.dx';
 import { toggleTab } from './tabs/toggle.dx';
@@ -99,6 +100,28 @@ const data: Record<string, unknown> = {
       { firstName: 'Diana', lastName: 'Rodriguez' },
     ],
   },
+  tags: {
+    basic: ['hello', 'world'],
+    withIcon: [],
+    noDuplicates: ['unique'],
+    limited: [],
+    scrollable: [
+      'design',
+      'product',
+      'engineering',
+      'research',
+      'marketing',
+      'analytics',
+      'operations',
+      'support',
+      'finance',
+      'legal',
+      'people',
+    ],
+    validated: ['design', 'product'],
+    disabled: ['read', 'only'],
+    readonly: ['frozen'],
+  },
 };
 
 export const buildKitchenSinkDx = (options: KitchenSinkDxOptions = {}): KitchenSinkDx => ({
@@ -126,6 +149,7 @@ export const buildKitchenSinkDx = (options: KitchenSinkDxOptions = {}): KitchenS
         { label: 'Dropdown Component', uid: 'tabDropdown', children: [dropdownTab] },
         { label: 'List Component', uid: 'tabList', children: [listTab] },
         { label: 'Repeater Component', uid: 'tabRepeater', children: [repeaterTab] },
+        { label: 'Tags Component', uid: 'tabTags', children: [tagsTab] },
         ...(options.rendererExample !== undefined
           ? [
               {

--- a/apps/apps-shared/src/lib/mocks/kitchen-sink.equivalence.spec.ts
+++ b/apps/apps-shared/src/lib/mocks/kitchen-sink.equivalence.spec.ts
@@ -34,6 +34,8 @@ import { repeater as jsonRepeaterTab } from './tabs/repeater';
 import { repeaterTab as dxRepeaterTab } from './tabs/repeater.dx';
 import { select as jsonSelectTab } from './tabs/select';
 import { selectTab as dxSelectTab } from './tabs/select.dx';
+import { tags as jsonTagsTab } from './tabs/tags';
+import { tagsTab as dxTagsTab } from './tabs/tags.dx';
 import { textarea as jsonTextareaTab } from './tabs/textarea';
 import { textareaTab as dxTextareaTab } from './tabs/textarea.dx';
 import { textinput as jsonTextinputTab } from './tabs/textinput';
@@ -253,6 +255,12 @@ describe('Kitchen Sink — JSON ↔ DX equivalence', () => {
   it('repeater tab', () => {
     const json = buildJsonTab(jsonRepeaterTab('tabRepeater')).form;
     const dx = buildDxTab(dxRepeaterTab);
+    expect(normalise(dx)).toEqual(normalise(json));
+  });
+
+  it('tags tab', () => {
+    const json = buildJsonTab(jsonTagsTab('tabTags')).form;
+    const dx = buildDxTab(dxTagsTab);
     expect(normalise(dx)).toEqual(normalise(json));
   });
 });

--- a/apps/apps-shared/src/lib/mocks/kitchen-sink.form.json
+++ b/apps/apps-shared/src/lib/mocks/kitchen-sink.form.json
@@ -38,7 +38,8 @@
           { "label": "Select Component", "uid": "tabSelect" },
           { "label": "Dropdown Component", "uid": "tabDropdown" },
           { "label": "List Component", "uid": "tabList" },
-          { "label": "Repeater Component", "uid": "tabRepeater" }
+          { "label": "Repeater Component", "uid": "tabRepeater" },
+          { "label": "Tags Component", "uid": "tabTags" }
         ]
       },
       "on": { "change": "onTabEvent" },
@@ -61,7 +62,8 @@
         { "$ref": "./tabs/select.form-chunk.json" },
         { "$ref": "./tabs/dropdown.form-chunk.json" },
         { "$ref": "./tabs/list.form-chunk.json" },
-        { "$ref": "./tabs/repeater.form-chunk.json" }
+        { "$ref": "./tabs/repeater.form-chunk.json" },
+        { "$ref": "./tabs/tags.form-chunk.json" }
       ]
     },
     {

--- a/apps/apps-shared/src/lib/mocks/kitchen-sink.ts
+++ b/apps/apps-shared/src/lib/mocks/kitchen-sink.ts
@@ -44,6 +44,28 @@ const data = {
       },
     ],
   },
+  tags: {
+    basic: ['hello', 'world'],
+    withIcon: [],
+    noDuplicates: ['unique'],
+    limited: [],
+    scrollable: [
+      'design',
+      'product',
+      'engineering',
+      'research',
+      'marketing',
+      'analytics',
+      'operations',
+      'support',
+      'finance',
+      'legal',
+      'people',
+    ],
+    validated: ['design', 'product'],
+    disabled: ['read', 'only'],
+    readonly: ['frozen'],
+  },
 };
 
 /**

--- a/apps/apps-shared/src/lib/mocks/tabs/tags.dx.ts
+++ b/apps/apps-shared/src/lib/mocks/tabs/tags.dx.ts
@@ -1,0 +1,45 @@
+import { gui } from '@golemui/gui-shared';
+
+export const tagsTab = gui.layouts.flex([
+  gui.inputs.tags('tags.basic', { placeholder: 'Add a tag…' }),
+  gui.inputs.tags('tags.withIcon', {
+    label: 'Tags with icon',
+    icon: 'label',
+    hint: 'Press Enter, Tab or comma to add a tag',
+    placeholder: 'Type and press Enter',
+  }),
+  gui.inputs.tags('tags.noDuplicates', {
+    label: 'Tags with no duplicates',
+    hint: 'Duplicate tags are silently ignored',
+    placeholder: 'Try entering the same tag twice',
+    allowDuplicates: false,
+  }),
+  gui.inputs.tags('tags.limited', {
+    label: 'Tags with limited number of tags',
+    hint: 'Up to 5 tags',
+    placeholder: 'Add a tag…',
+    limit: 5,
+  }),
+  gui.inputs.tags('tags.scrollable', {
+    label: 'Tags with scrollable container',
+    icon: 'tag',
+    hint: 'Many tags scroll horizontally; resize the window to see the count-bubble fallback',
+    placeholder: 'Add another…',
+  }),
+  gui.inputs.tags('tags.validated', {
+    label: 'Tags with validation',
+    hint: 'At least 1, at most 3 tags — must be unique',
+    placeholder: 'Add a tag…',
+    validator: { required: true, minItems: 1, maxItems: 3 },
+  }),
+  gui.inputs.tags('tags.disabled', {
+    label: 'Disabled tags',
+    placeholder: 'You cannot type here',
+    disabled: true,
+  }),
+  gui.inputs.tags('tags.readonly', {
+    label: 'Readonly tags',
+    placeholder: 'Read-only',
+    readonly: true,
+  }),
+]);

--- a/apps/apps-shared/src/lib/mocks/tabs/tags.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/tags.form-chunk.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "uid": "tabTags",
+  "kind": "layout",
+  "type": "flex",
+  "children": [
+    {
+      "kind": "input",
+      "type": "tags",
+      "path": "tags.basic",
+      "props": {
+        "placeholder": "Add a tag…"
+      }
+    },
+    {
+      "kind": "input",
+      "type": "tags",
+      "path": "tags.withIcon",
+      "label": "Tags with icon",
+      "props": {
+        "icon": "label",
+        "hint": "Press Enter, Tab or comma to add a tag",
+        "placeholder": "Type and press Enter"
+      }
+    },
+    {
+      "kind": "input",
+      "type": "tags",
+      "path": "tags.noDuplicates",
+      "label": "Tags with no duplicates",
+      "props": {
+        "hint": "Duplicate tags are silently ignored",
+        "placeholder": "Try entering the same tag twice",
+        "allowDuplicates": false
+      }
+    },
+    {
+      "kind": "input",
+      "type": "tags",
+      "path": "tags.limited",
+      "label": "Tags with limited number of tags",
+      "props": {
+        "hint": "Up to 5 tags",
+        "placeholder": "Add a tag…",
+        "limit": 5
+      }
+    },
+    {
+      "kind": "input",
+      "type": "tags",
+      "path": "tags.scrollable",
+      "label": "Tags with scrollable container",
+      "props": {
+        "icon": "tag",
+        "hint": "Many tags scroll horizontally; resize the window to see the count-bubble fallback",
+        "placeholder": "Add another…"
+      }
+    },
+    {
+      "kind": "input",
+      "type": "tags",
+      "path": "tags.validated",
+      "label": "Tags with validation",
+      "props": {
+        "hint": "At least 1, at most 3 tags — must be unique",
+        "placeholder": "Add a tag…"
+      },
+      "validator": {
+        "type": "array",
+        "required": true,
+        "minItems": 1,
+        "maxItems": 3
+      }
+    },
+    {
+      "kind": "input",
+      "type": "tags",
+      "path": "tags.disabled",
+      "label": "Disabled tags",
+      "disabled": true,
+      "props": {
+        "placeholder": "You cannot type here"
+      }
+    },
+    {
+      "kind": "input",
+      "type": "tags",
+      "path": "tags.readonly",
+      "label": "Readonly tags",
+      "readonly": true,
+      "props": {
+        "placeholder": "Read-only"
+      }
+    }
+  ]
+}

--- a/apps/apps-shared/src/lib/mocks/tabs/tags.ts
+++ b/apps/apps-shared/src/lib/mocks/tabs/tags.ts
@@ -1,0 +1,98 @@
+export const tags = (uid: string): any => ({
+  uid,
+  kind: 'layout',
+  type: 'flex',
+  children: [
+    {
+      uid: '',
+      kind: 'input',
+      type: 'tags',
+      path: 'tags.basic',
+      props: {
+        placeholder: 'Add a tag…',
+      },
+    },
+    {
+      uid: '',
+      kind: 'input',
+      type: 'tags',
+      path: 'tags.withIcon',
+      label: 'Tags with icon',
+      props: {
+        icon: 'label',
+        hint: 'Press Enter, Tab or comma to add a tag',
+        placeholder: 'Type and press Enter',
+      },
+    },
+    {
+      uid: '',
+      kind: 'input',
+      type: 'tags',
+      path: 'tags.noDuplicates',
+      label: 'Tags with no duplicates',
+      props: {
+        hint: 'Duplicate tags are silently ignored',
+        placeholder: 'Try entering the same tag twice',
+        allowDuplicates: false,
+      },
+    },
+    {
+      uid: '',
+      kind: 'input',
+      type: 'tags',
+      path: 'tags.limited',
+      label: 'Tags with limited number of tags',
+      props: {
+        hint: 'Up to 5 tags',
+        placeholder: 'Add a tag…',
+        limit: 5,
+      },
+    },
+    {
+      uid: '',
+      kind: 'input',
+      type: 'tags',
+      path: 'tags.scrollable',
+      label: 'Tags with scrollable container',
+      props: {
+        icon: 'tag',
+        hint: 'Many tags scroll horizontally; resize the window to see the count-bubble fallback',
+        placeholder: 'Add another…',
+      },
+    },
+    {
+      uid: '',
+      kind: 'input',
+      type: 'tags',
+      path: 'tags.validated',
+      label: 'Tags with validation',
+      props: {
+        hint: 'At least 1, at most 3 tags — must be unique',
+        placeholder: 'Add a tag…',
+      },
+      validator: { type: 'array', required: true, minItems: 1, maxItems: 3 },
+    },
+    {
+      uid: '',
+      kind: 'input',
+      type: 'tags',
+      path: 'tags.disabled',
+      label: 'Disabled tags',
+      disabled: true,
+      props: {
+        placeholder: 'You cannot type here',
+      },
+    },
+    {
+      uid: '',
+      kind: 'input',
+      type: 'tags',
+      path: 'tags.readonly',
+      label: 'Readonly tags',
+      readonly: true,
+      props: {
+        placeholder: 'Read-only',
+      },
+    },
+  ],
+});

--- a/docs/public/template/widgets-dx/tags/tags-allow-duplicates.ts
+++ b/docs/public/template/widgets-dx/tags/tags-allow-duplicates.ts
@@ -1,0 +1,10 @@
+import { gui } from '@golemui/gui-shared';
+
+export default [
+  gui.inputs.tags('keywords', {
+    label: 'Keywords',
+    hint: 'Try adding the same tag twice — the second attempt is silently ignored',
+    placeholder: 'Add a tag…',
+    allowDuplicates: false,
+  }),
+];

--- a/docs/public/template/widgets-dx/tags/tags-hint.ts
+++ b/docs/public/template/widgets-dx/tags/tags-hint.ts
@@ -1,0 +1,9 @@
+import { gui } from '@golemui/gui-shared';
+
+export default [
+  gui.inputs.tags('keywords', {
+    label: 'Keywords',
+    hint: 'Use Enter, Tab or comma to add a tag',
+    placeholder: 'Add a keyword…',
+  }),
+];

--- a/docs/public/template/widgets-dx/tags/tags-icon.ts
+++ b/docs/public/template/widgets-dx/tags/tags-icon.ts
@@ -1,0 +1,9 @@
+import { gui } from '@golemui/gui-shared';
+
+export default [
+  gui.inputs.tags('keywords', {
+    label: 'Keywords',
+    icon: 'label',
+    placeholder: 'Add a keyword…',
+  }),
+];

--- a/docs/public/template/widgets-dx/tags/tags-limit.ts
+++ b/docs/public/template/widgets-dx/tags/tags-limit.ts
@@ -1,0 +1,9 @@
+import { gui } from '@golemui/gui-shared';
+
+export default [
+  gui.inputs.tags('keywords', {
+    label: 'Keywords (max 3)',
+    limit: 3,
+    placeholder: 'Up to 3 tags',
+  }),
+];

--- a/docs/public/template/widgets-dx/tags/tags-placeholder.ts
+++ b/docs/public/template/widgets-dx/tags/tags-placeholder.ts
@@ -1,0 +1,8 @@
+import { gui } from '@golemui/gui-shared';
+
+export default [
+  gui.inputs.tags('keywords', {
+    label: 'Keywords',
+    placeholder: 'Add a keyword and press Enter',
+  }),
+];

--- a/docs/public/template/widgets-dx/tags/tags-remove.ts
+++ b/docs/public/template/widgets-dx/tags/tags-remove.ts
@@ -1,0 +1,11 @@
+import { gui } from '@golemui/gui-shared';
+
+export default [
+  gui.inputs.tags('keywords', {
+    label: 'Keywords',
+    hint: 'Custom remove-button icon and ARIA label',
+    placeholder: 'Add a tag…',
+    removeIcon: 'delete',
+    removeAriaLabel: 'Discard tag',
+  }),
+];

--- a/docs/public/template/widgets-dx/tags/tags-separators.ts
+++ b/docs/public/template/widgets-dx/tags/tags-separators.ts
@@ -1,0 +1,10 @@
+import { gui } from '@golemui/gui-shared';
+
+export default [
+  gui.inputs.tags('keywords', {
+    label: 'Keywords',
+    hint: 'Only Enter or comma commit a tag — Tab and blur do not',
+    placeholder: 'Type something and press Enter or ,',
+    separators: ['Enter', ','],
+  }),
+];

--- a/docs/public/template/widgets-dx/tags/tags-trim.ts
+++ b/docs/public/template/widgets-dx/tags/tags-trim.ts
@@ -1,0 +1,10 @@
+import { gui } from '@golemui/gui-shared';
+
+export default [
+  gui.inputs.tags('keywords', {
+    label: 'Keywords',
+    hint: 'trim is off — leading/trailing whitespace is preserved verbatim',
+    placeholder: "Try adding '  spaced  '",
+    trim: false,
+  }),
+];

--- a/docs/public/template/widgets-dx/tags/tags-unique.ts
+++ b/docs/public/template/widgets-dx/tags/tags-unique.ts
@@ -1,0 +1,19 @@
+import { gui } from '@golemui/gui-shared';
+
+export default [
+  gui.inputs.tags('keywords', {
+    label: 'Keywords',
+    hint: 'Between 1 and 5 tags',
+    placeholder: 'Add a keyword…',
+    validator: {
+      required: true,
+      minItems: 1,
+      maxItems: 5,
+      messages: {
+        required: 'Please add at least one keyword',
+        minItems: 'You need at least 1 keyword to continue',
+        maxItems: 'No more than 5 keywords, please',
+      },
+    },
+  }),
+];

--- a/docs/public/template/widgets-dx/tags/tags.ts
+++ b/docs/public/template/widgets-dx/tags/tags.ts
@@ -1,0 +1,7 @@
+import { gui } from '@golemui/gui-shared';
+
+export default [
+  gui.inputs.tags('keywords', {
+    label: 'Keywords',
+  }),
+];

--- a/docs/public/template/widgets/tags/tags-allow-duplicates.json
+++ b/docs/public/template/widgets/tags/tags-allow-duplicates.json
@@ -1,0 +1,16 @@
+{
+  "form": [
+    {
+      "uid": "",
+      "kind": "input",
+      "type": "tags",
+      "path": "keywords",
+      "label": "Keywords",
+      "props": {
+        "hint": "Try adding the same tag twice — the second attempt is silently ignored",
+        "placeholder": "Add a tag…",
+        "allowDuplicates": false
+      }
+    }
+  ]
+}

--- a/docs/public/template/widgets/tags/tags-anatomy.html
+++ b/docs/public/template/widgets/tags/tags-anatomy.html
@@ -1,0 +1,49 @@
+<gui-tags>
+  <span class="gui-label" id="fieldUid_label">
+    Label
+    <div class="gui-widget-hint" id="fieldUid_hint">Hint</div>
+  </span>
+
+  <div class="gui-widget">
+    <div class="gui-tags gui-tags--icon" role="group" aria-label="Keywords">
+      <span class="gui-widget-icon label" data-icon="label"></span>
+
+      <div class="gui-tags__pills-wrapper">
+        <div class="gui-tags__pills" role="list">
+          <span class="gui-sentinel gui-sentinel__start"></span>
+          <div
+            class="gui-tags__chip"
+            role="listitem"
+            tabindex="-1"
+            aria-label="Remove tag: design"
+          >
+            <span class="gui-tags__chip-text">design</span>
+            <button class="gui-tags__chip-remove" tabindex="-1" aria-hidden="true">×</button>
+          </div>
+          <div
+            class="gui-tags__chip"
+            role="listitem"
+            tabindex="-1"
+            aria-label="Remove tag: product"
+          >
+            <span class="gui-tags__chip-text">product</span>
+            <button class="gui-tags__chip-remove" tabindex="-1" aria-hidden="true">×</button>
+          </div>
+          <span class="gui-sentinel gui-sentinel__end"></span>
+        </div>
+      </div>
+
+      <div class="gui-tags__pills-compact">
+        <button class="gui-tags__pill--count" aria-label="2 tags" aria-expanded="false">2</button>
+      </div>
+
+      <input
+        type="text"
+        id="fieldUid"
+        class="gui-tags__input"
+        placeholder="Add a tag…"
+        aria-describedby="fieldUid_hint"
+      />
+    </div>
+  </div>
+</gui-tags>

--- a/docs/public/template/widgets/tags/tags-hint.json
+++ b/docs/public/template/widgets/tags/tags-hint.json
@@ -1,0 +1,15 @@
+{
+  "form": [
+    {
+      "uid": "",
+      "kind": "input",
+      "type": "tags",
+      "path": "keywords",
+      "label": "Keywords",
+      "props": {
+        "hint": "Use Enter, Tab or comma to add a tag",
+        "placeholder": "Add a keyword…"
+      }
+    }
+  ]
+}

--- a/docs/public/template/widgets/tags/tags-icon.json
+++ b/docs/public/template/widgets/tags/tags-icon.json
@@ -1,0 +1,15 @@
+{
+  "form": [
+    {
+      "uid": "",
+      "kind": "input",
+      "type": "tags",
+      "path": "keywords",
+      "label": "Keywords",
+      "props": {
+        "icon": "label",
+        "placeholder": "Add a keyword…"
+      }
+    }
+  ]
+}

--- a/docs/public/template/widgets/tags/tags-limit.json
+++ b/docs/public/template/widgets/tags/tags-limit.json
@@ -1,0 +1,15 @@
+{
+  "form": [
+    {
+      "uid": "",
+      "kind": "input",
+      "type": "tags",
+      "path": "keywords",
+      "label": "Keywords (max 3)",
+      "props": {
+        "limit": 3,
+        "placeholder": "Up to 3 tags"
+      }
+    }
+  ]
+}

--- a/docs/public/template/widgets/tags/tags-placeholder.json
+++ b/docs/public/template/widgets/tags/tags-placeholder.json
@@ -1,0 +1,14 @@
+{
+  "form": [
+    {
+      "uid": "",
+      "kind": "input",
+      "type": "tags",
+      "path": "keywords",
+      "label": "Keywords",
+      "props": {
+        "placeholder": "Add a keyword and press Enter"
+      }
+    }
+  ]
+}

--- a/docs/public/template/widgets/tags/tags-remove.json
+++ b/docs/public/template/widgets/tags/tags-remove.json
@@ -1,0 +1,17 @@
+{
+  "form": [
+    {
+      "uid": "",
+      "kind": "input",
+      "type": "tags",
+      "path": "keywords",
+      "label": "Keywords",
+      "props": {
+        "hint": "Custom remove-button icon and ARIA label",
+        "placeholder": "Add a tag…",
+        "removeIcon": "delete",
+        "removeAriaLabel": "Discard tag"
+      }
+    }
+  ]
+}

--- a/docs/public/template/widgets/tags/tags-separators.json
+++ b/docs/public/template/widgets/tags/tags-separators.json
@@ -1,0 +1,16 @@
+{
+  "form": [
+    {
+      "uid": "",
+      "kind": "input",
+      "type": "tags",
+      "path": "keywords",
+      "label": "Keywords",
+      "props": {
+        "hint": "Only Enter or comma commit a tag — Tab and blur do not",
+        "placeholder": "Type something and press Enter or ,",
+        "separators": ["Enter", ","]
+      }
+    }
+  ]
+}

--- a/docs/public/template/widgets/tags/tags-trim.json
+++ b/docs/public/template/widgets/tags/tags-trim.json
@@ -1,0 +1,16 @@
+{
+  "form": [
+    {
+      "uid": "",
+      "kind": "input",
+      "type": "tags",
+      "path": "keywords",
+      "label": "Keywords",
+      "props": {
+        "hint": "trim is off — leading/trailing whitespace is preserved verbatim",
+        "placeholder": "Try adding '  spaced  '",
+        "trim": false
+      }
+    }
+  ]
+}

--- a/docs/public/template/widgets/tags/tags-unique.json
+++ b/docs/public/template/widgets/tags/tags-unique.json
@@ -1,0 +1,26 @@
+{
+  "form": [
+    {
+      "uid": "",
+      "kind": "input",
+      "type": "tags",
+      "path": "keywords",
+      "label": "Keywords",
+      "props": {
+        "hint": "Between 1 and 5 tags",
+        "placeholder": "Add a keyword…"
+      },
+      "validator": {
+        "type": "array",
+        "required": true,
+        "minItems": 1,
+        "maxItems": 5,
+        "messages": {
+          "required": "Please add at least one keyword",
+          "minItems": "You need at least 1 keyword to continue",
+          "maxItems": "No more than 5 keywords, please"
+        }
+      }
+    }
+  ]
+}

--- a/docs/public/template/widgets/tags/tags.json
+++ b/docs/public/template/widgets/tags/tags.json
@@ -1,0 +1,11 @@
+{
+  "form": [
+    {
+      "uid": "",
+      "kind": "input",
+      "type": "tags",
+      "path": "keywords",
+      "label": "Keywords"
+    }
+  ]
+}

--- a/docs/src/content/docs/widgets-reference/input-fields/overview.mdx
+++ b/docs/src/content/docs/widgets-reference/input-fields/overview.mdx
@@ -86,6 +86,7 @@ The same widget in JSON, with `props` nested:
 | Range Date Input  | `gui.inputs.rangeDateInput`  | [Range Date Input](/widgets-reference/input-fields/range-date-input/)   |
 | Range Date Picker | `gui.inputs.rangeDatePicker` | [Range Date Picker](/widgets-reference/input-fields/range-date-picker/) |
 | Repeater          | `gui.inputs.repeater`        | [Repeater](/widgets-reference/input-fields/repeater/)                   |
+| Tags              | `gui.inputs.tags`            | [Tags](/widgets-reference/input-fields/tags/)                           |
 | _Custom_          | `gui.inputs.custom`          | [Custom Widgets](/form-definition/custom-widgets/)                      |
 
 ## See also

--- a/docs/src/content/docs/widgets-reference/input-fields/tags.mdx
+++ b/docs/src/content/docs/widgets-reference/input-fields/tags.mdx
@@ -1,0 +1,200 @@
+---
+title: Tags
+description: A Tags widget to capture a list of free-form text values as removable chips
+---
+
+import Demo from '../../../../../src/components/landing/Demo.astro';
+
+import { Aside, Code } from '@astrojs/starlight/components';
+import DslCode from '../../../../components/DslCode.astro';
+import tagsJson from '../../../../../public/template/widgets/tags/tags.json?raw';
+import tagsDx from '../../../../../public/template/widgets-dx/tags/tags.ts?raw';
+import tagsPlaceholderJson from '../../../../../public/template/widgets/tags/tags-placeholder.json?raw';
+import tagsPlaceholderDx from '../../../../../public/template/widgets-dx/tags/tags-placeholder.ts?raw';
+import tagsHintJson from '../../../../../public/template/widgets/tags/tags-hint.json?raw';
+import tagsHintDx from '../../../../../public/template/widgets-dx/tags/tags-hint.ts?raw';
+import tagsIconJson from '../../../../../public/template/widgets/tags/tags-icon.json?raw';
+import tagsIconDx from '../../../../../public/template/widgets-dx/tags/tags-icon.ts?raw';
+import tagsSeparatorsJson from '../../../../../public/template/widgets/tags/tags-separators.json?raw';
+import tagsSeparatorsDx from '../../../../../public/template/widgets-dx/tags/tags-separators.ts?raw';
+import tagsAllowDuplicatesJson from '../../../../../public/template/widgets/tags/tags-allow-duplicates.json?raw';
+import tagsAllowDuplicatesDx from '../../../../../public/template/widgets-dx/tags/tags-allow-duplicates.ts?raw';
+import tagsTrimJson from '../../../../../public/template/widgets/tags/tags-trim.json?raw';
+import tagsTrimDx from '../../../../../public/template/widgets-dx/tags/tags-trim.ts?raw';
+import tagsLimitJson from '../../../../../public/template/widgets/tags/tags-limit.json?raw';
+import tagsLimitDx from '../../../../../public/template/widgets-dx/tags/tags-limit.ts?raw';
+import tagsRemoveJson from '../../../../../public/template/widgets/tags/tags-remove.json?raw';
+import tagsRemoveDx from '../../../../../public/template/widgets-dx/tags/tags-remove.ts?raw';
+import tagsValidatorJson from '../../../../../public/template/widgets/tags/tags-unique.json?raw';
+import tagsValidatorDx from '../../../../../public/template/widgets-dx/tags/tags-unique.ts?raw';
+import tagsAnatomyHtml from '../../../../../public/template/widgets/tags/tags-anatomy.html?raw';
+export const configJson = 'tags.json';
+export const configDx = 'tags.ts';
+export const anatomy = 'tags.html';
+
+Tags widgets are [Input Fields](/widgets-reference/input-fields/overview) that capture an
+ordered list of free-form text values. Each committed value becomes a removable pill
+shown to the left of the input, and the value bound at the widget's `path` is a `string[]`.
+
+<DslCode dxCode={tagsDx} jsonCode={tagsJson} dxTitle={configDx} jsonTitle={configJson} />
+<Demo src="/template/index.html?form=template/widgets/tags/tags.json" />
+
+## Props
+
+Use these `props` to customize your Tags widget.
+
+| prop              | type                                              | value                                                                                                       |
+| ----------------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `placeholder`     | string                                            | Placeholder text shown in the input when empty                                                              |
+| `hint`            | string                                            | A description displayed below the row                                                                       |
+| `icon`            | string                                            | CSS class string for a leading icon (rendered to the left of the pills)                                     |
+| `separators`      | `('Enter' \| ',' \| 'Tab' \| 'blur' \| string)[]` | Triggers that commit the current draft as a new chip. Defaults to `['Enter', ',', 'Tab', 'blur']`           |
+| `allowDuplicates` | boolean                                           | When `false`, typing an existing tag is silently ignored. Defaults to `true`                                |
+| `trim`            | boolean                                           | When `true` (default), whitespace is trimmed from each value before committing                              |
+| `limit`           | number                                            | Soft cap on the number of chips. The widget stops accepting new chips at the limit (no error)               |
+| `removeAriaLabel` | string                                            | ARIA label prefix used on each chip's remove button. Defaults to `Remove tag`                               |
+| `removeIcon`      | string                                            | CSS class string for a custom remove-icon. When omitted, a built-in `×` glyph is rendered                   |
+
+### Placeholder
+
+Use the property `placeholder` to set the text shown inside the empty input.
+
+<DslCode dxCode={tagsPlaceholderDx} jsonCode={tagsPlaceholderJson} dxTitle={configDx} jsonTitle={configJson} />
+<Demo src="/template/index.html?form=template/widgets/tags/tags-placeholder.json" />
+
+### Hint
+
+<Aside>A `label` is required for the `hint` to be displayed.</Aside>
+
+Use the property `hint` to add a description below the row.
+
+<DslCode dxCode={tagsHintDx} jsonCode={tagsHintJson} dxTitle={configDx} jsonTitle={configJson} />
+<Demo src="/template/index.html?form=template/widgets/tags/tags-hint.json" />
+
+### Icon
+
+Use the property `icon` to render a leading icon to the left of the pills. The value is a
+CSS class string — the same convention used by Textinput.
+
+<DslCode dxCode={tagsIconDx} jsonCode={tagsIconJson} dxTitle={configDx} jsonTitle={configJson} />
+<Demo src="/template/index.html?form=template/widgets/tags/tags-icon.json" />
+
+### Separators
+
+By default a tag is committed on `Enter`, `,`, `Tab`, or `blur`. Override the property
+`separators` to restrict the commit triggers — useful when you want the user to commit
+explicitly (e.g. `Enter` only) and treat commas as part of the tag value.
+
+Pasting text that contains any of the configured character separators (e.g. commas) also
+splits the paste into multiple chips in a single commit.
+
+<DslCode dxCode={tagsSeparatorsDx} jsonCode={tagsSeparatorsJson} dxTitle={configDx} jsonTitle={configJson} />
+<Demo src="/template/index.html?form=template/widgets/tags/tags-separators.json" />
+
+### Allow duplicates
+
+Set `allowDuplicates: false` to silently ignore tags the user has already added — no error
+message, the second attempt simply does nothing. This is a UX safeguard at commit time;
+there is no form-level error to surface.
+
+<DslCode dxCode={tagsAllowDuplicatesDx} jsonCode={tagsAllowDuplicatesJson} dxTitle={configDx} jsonTitle={configJson} />
+<Demo src="/template/index.html?form=template/widgets/tags/tags-allow-duplicates.json" />
+
+### Trim
+
+`trim` defaults to `true` so leading/trailing whitespace is removed before a tag is
+committed. Set it to `false` when surrounding whitespace is semantically meaningful (for
+example, deliberately quoting a phrase with padding).
+
+<DslCode dxCode={tagsTrimDx} jsonCode={tagsTrimJson} dxTitle={configDx} jsonTitle={configJson} />
+<Demo src="/template/index.html?form=template/widgets/tags/tags-trim.json" />
+
+### Limit
+
+Use the property `limit` to cap the number of chips a user can add. The cap is a soft UX
+limit — once reached, new entries are silently dropped. For a form-level error, combine
+with the `maxItems` validator below.
+
+<DslCode dxCode={tagsLimitDx} jsonCode={tagsLimitJson} dxTitle={configDx} jsonTitle={configJson} />
+<Demo src="/template/index.html?form=template/widgets/tags/tags-limit.json" />
+
+### Customize the remove button
+
+`removeIcon` swaps the built-in `×` glyph for any icon (CSS class string, same convention
+as `icon`). `removeAriaLabel` sets the prefix announced by assistive tech alongside the
+tag value — useful for translations or wording adjustments (e.g. `"Discard tag: foo"`).
+
+<DslCode dxCode={tagsRemoveDx} jsonCode={tagsRemoveJson} dxTitle={configDx} jsonTitle={configJson} />
+<Demo src="/template/index.html?form=template/widgets/tags/tags-remove.json" />
+
+### Validation
+
+The widget supports the standard array validator: `required`, `minItems`, `maxItems`.
+Validation errors surface like any other input — below the row, with `aria-invalid` and
+`aria-errormessage` wired automatically. Override the default error copy per-rule with a
+`messages` object — each key matches the rule it customises, and values can be a string or
+a [Localizable](/i18n/) for i18n.
+
+<DslCode dxCode={tagsValidatorDx} jsonCode={tagsValidatorJson} dxTitle={configDx} jsonTitle={configJson} />
+<Demo src="/template/index.html?form=template/widgets/tags/tags-unique.json" />
+
+## Keyboard
+
+The widget keeps the **input as the single tab stop**. Pills are reachable from the input
+via arrow keys, mirroring chip-input conventions in Gmail recipients and MUI Autocomplete.
+
+| Key                                  | Action                                                                              |
+| ------------------------------------ | ----------------------------------------------------------------------------------- |
+| `Enter` / `,` (on input)             | Commit the current draft as a new chip                                              |
+| `Tab` (on input, non-empty draft)    | Commit the current draft, then leave the widget                                     |
+| `Escape` (on input)                  | Clear the current draft without committing                                          |
+| `← Arrow` (caret at start of input)  | Enter the pill list and focus the last pill (opens the dropdown in compact mode)    |
+| `Backspace` (empty input)            | Focus the last pill (does not delete it)                                            |
+| `← Arrow` / `→ Arrow` (pill focused) | Navigate between pills. `→` past the last pill returns focus to the input           |
+| `Home` / `End` (pill focused)        | Focus the first / last pill                                                         |
+| `Delete` / `Backspace` (pill focused)| Remove the focused pill, then focus the next pill, else the previous, else the input |
+| `↑ Arrow` / `↓ Arrow` (pill in dropdown) | Navigate the dropdown list when the count bubble is open                        |
+| `Escape` (pill in dropdown)          | Close the dropdown and return focus to the input                                    |
+
+## Accessibility
+
+- The pills row, input and icon are wrapped in a `<div role="group">` that carries the
+  widget's `aria-label`, focus border and error border.
+- `aria-describedby`, `aria-invalid` and `aria-errormessage` are wired automatically on the
+  group when a hint or validation error is present.
+- Each chip is exposed as a `role="listitem"` with `aria-label="Remove tag: <value>"`, so
+  screen readers announce both the value and the destructive action that the chip's
+  `Delete` / `Backspace` key triggers.
+- The count bubble is a `<button aria-expanded>` so assistive tech can announce the
+  collapsed/expanded state of the dropdown list of pills.
+
+## Styling
+
+Tags can be styled as explained in the [Styling Guide](/styling/overview/).
+
+### CSS Variables
+
+The chip and count-badge visuals are shared with the Range Calendar / Range Date Input
+pills, so they pick up the same intent / spacing / radius tokens.
+
+| CSS Variable             | Description                                |
+| ------------------------ | ------------------------------------------ |
+| `--gui-color-border`     | Group border colour                        |
+| `--gui-color-bg`         | Group background colour and scroll-fade    |
+| `--gui-color-fg`         | Input text colour                          |
+| `--gui-color-primary`    | Group focus-ring colour                    |
+| `--gui-color-error`      | Group border colour when invalid           |
+| `--gui-intent-primary`   | Chip and count-bubble background colour    |
+| `--gui-color-white`      | Chip text / remove-icon colour             |
+| `--gui-radius-md`        | Chip corner radius                         |
+| `--gui-radius-full`      | Count-bubble corner radius                 |
+| `--gui-space-1`          | Chip vertical padding                      |
+| `--gui-space-2`          | Row gap between chips                      |
+| `--gui-space-3`          | Gap between chip text and remove button    |
+| `--gui-font-xs`          | Chip text font-size                        |
+
+### Anatomy
+
+This is the anatomy of the Tags Widget in case you want to use your CSS styles.
+
+<Code code={tagsAnatomyHtml} lang="html" title={anatomy} />

--- a/libs/gui/angular/src/lib/components/dropdown/dropdown.component.html
+++ b/libs/gui/angular/src/lib/components/dropdown/dropdown.component.html
@@ -17,6 +17,7 @@
   <input
     #inputRef
     type="text"
+    class="gui-widget-input"
     [id]="widget.uid"
     [required]="templateData.validator?.required"
     [disabled]="templateData.disabled"

--- a/libs/gui/angular/src/lib/components/tags/tags.component.html
+++ b/libs/gui/angular/src/lib/components/tags/tags.component.html
@@ -1,0 +1,23 @@
+@let templateData = adapter.templateData();
+
+<gui-tags
+  [uid]="widget.uid"
+  [label]="templateData.label"
+  [hint]="templateData.hint"
+  [errors]="templateData.errors"
+  [touched]="templateData.touched"
+  [required]="templateData.validator?.required"
+  [disabled]="templateData.disabled"
+  [readOnly]="templateData.readonly"
+  [value]="templateData.value ?? []"
+  [placeholder]="templateData.placeholder"
+  [icon]="templateData.icon"
+  [separators]="templateData.separators"
+  [allowDuplicates]="templateData.allowDuplicates ?? true"
+  [trim]="templateData.trim ?? true"
+  [limit]="templateData.limit"
+  [removeAriaLabel]="templateData.removeAriaLabel"
+  [removeIcon]="templateData.removeIcon"
+  (change)="valueChanged($event)"
+  (blur)="adapter.onBlur()"
+></gui-tags>

--- a/libs/gui/angular/src/lib/components/tags/tags.component.ts
+++ b/libs/gui/angular/src/lib/components/tags/tags.component.ts
@@ -1,0 +1,42 @@
+import { CommonModule } from '@angular/common';
+import {
+  Component,
+  CUSTOM_ELEMENTS_SCHEMA,
+  inject,
+  type OnDestroy,
+  type OnInit,
+} from '@angular/core';
+import { InputWidgetAdapter } from '@golemui/angular';
+import type { InputWidget, WithWidget } from '@golemui/core';
+import { type TagsProps } from '@golemui/gui-shared';
+import '@golemui/gui-components/tags';
+
+@Component({
+  standalone: true,
+  selector: 'gui-tags-control',
+  imports: [CommonModule],
+  providers: [InputWidgetAdapter],
+  templateUrl: './tags.component.html',
+  host: {
+    class: 'gui-tags gui-field',
+    '[style.flex]': 'this.adapter.templateData().size',
+  },
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+})
+export class TagsComponent implements OnInit, OnDestroy, WithWidget {
+  widget!: InputWidget<string[]>;
+  protected adapter: InputWidgetAdapter<string[], TagsProps> = inject(InputWidgetAdapter);
+
+  ngOnInit(): void {
+    this.adapter.init(this.widget);
+  }
+
+  ngOnDestroy(): void {
+    this.adapter.destroy();
+  }
+
+  valueChanged(event: Event) {
+    const value = (event as CustomEvent).detail.value as string[];
+    this.adapter.valueChanged(value);
+  }
+}

--- a/libs/gui/angular/src/lib/widget.loaders.ts
+++ b/libs/gui/angular/src/lib/widget.loaders.ts
@@ -41,6 +41,7 @@ export const widgetLoaders: WidgetLoaders<Type<WithWidget>, GolemWidget> = {
   list: async () => (await import('./components/list/list.component')).ListComponent,
   markdown: async () =>
     (await import('./components/markdown/markdown.component')).MarkdownComponent,
+  tags: async () => (await import('./components/tags/tags.component')).TagsComponent,
 
   // LAYOUT WIDGETS
   flex: async () => (await import('./components/flex/flex.component')).FlexComponent,

--- a/libs/gui/components/package.json
+++ b/libs/gui/components/package.json
@@ -102,6 +102,11 @@
       "import": "./lib/components/select.js",
       "require": "./lib/components/select.umd.cjs"
     },
+    "./tags": {
+      "types": "./lib/components/tags.d.ts",
+      "import": "./lib/components/tags.js",
+      "require": "./lib/components/tags.umd.cjs"
+    },
     "./textarea": {
       "types": "./lib/components/textarea.d.ts",
       "import": "./lib/components/textarea.js",

--- a/libs/gui/components/src/index.ts
+++ b/libs/gui/components/src/index.ts
@@ -34,6 +34,7 @@ export type { RangeCalendarDay } from './lib/components/range-calendar';
 
 export { GuiRangeDateInput } from './lib/components/range-date-input';
 export { GuiSelect } from './lib/components/select';
+export { GuiTags } from './lib/components/tags';
 export { GuiTextarea } from './lib/components/textarea';
 export { GuiTextinput } from './lib/components/textinput';
 export { GuiToggle } from './lib/components/toggle';

--- a/libs/gui/components/src/lib/components/currency.ts
+++ b/libs/gui/components/src/lib/components/currency.ts
@@ -88,6 +88,7 @@ export class GuiCurrency extends LitElement {
     const currencyIcon = addIcon('currency', templateData);
 
     const fieldClasses: { [key: string]: boolean } = {
+      'gui-widget-input': true,
       [`gui-currency--icon`]: !!this.icon,
     };
 

--- a/libs/gui/components/src/lib/components/date-input.ts
+++ b/libs/gui/components/src/lib/components/date-input.ts
@@ -102,7 +102,7 @@ export class GuiDate extends LitElement {
       ${this.label ? addLabel(this.uid as string, templateData) : nothing}
 
       <div class="gui-widget">
-        <div class="gui-date-input ${this.icon ? 'gui-calendar--icon' : ''}" role="group">
+        <div class="gui-widget-input gui-date-input ${this.icon ? 'gui-calendar--icon' : ''}" role="group">
           ${repeat(
             parts,
             (part: any) => part.type,

--- a/libs/gui/components/src/lib/components/markdown.ts
+++ b/libs/gui/components/src/lib/components/markdown.ts
@@ -114,6 +114,7 @@ export class GuiMarkdown extends LitElement {
 
     // Icon
     const fieldClasses: { [key: string]: boolean } = {
+      'gui-widget-input': true,
       [`gui-markdown--icon`]: false,
     };
 

--- a/libs/gui/components/src/lib/components/number.ts
+++ b/libs/gui/components/src/lib/components/number.ts
@@ -104,6 +104,7 @@ export class GuiNumber extends LitElement {
           inputmode="decimal"
           id=${this.uid}
           data-cy=${`${this.uid}_number`}
+          class="gui-widget-input"
           style=${styleMap(inputStyles)}
           value=${this.value}
           ?required=${this.required}

--- a/libs/gui/components/src/lib/components/password.ts
+++ b/libs/gui/components/src/lib/components/password.ts
@@ -77,6 +77,7 @@ export class GuiPassword extends LitElement {
     const passwordIcon = addIcon('password', templateData);
 
     const fieldClasses: { [key: string]: boolean } = {
+      'gui-widget-input': true,
       [`gui-password--icon`]: !!this.icon,
     };
 

--- a/libs/gui/components/src/lib/components/range-date-input.ts
+++ b/libs/gui/components/src/lib/components/range-date-input.ts
@@ -124,7 +124,7 @@ export class GuiRangeDateInput extends LitElement {
 
       <div class="gui-widget">
         <div
-          class="gui-range-date-input ${this.icon ? 'gui-range-date-input--icon' : ''}"
+          class="gui-widget-input gui-range-date-input ${this.icon ? 'gui-range-date-input--icon' : ''}"
           role="group"
           aria-label=${this.label ?? 'Date range input'}
         >

--- a/libs/gui/components/src/lib/components/select.ts
+++ b/libs/gui/components/src/lib/components/select.ts
@@ -118,7 +118,7 @@ export class GuiSelect extends LitElement {
           id=${this.uid as string}
           tabindex="0"
           data-cy=${`${this.uid}_select`}
-          class=${classMap(selectIcon.widgetClasses)}
+          class=${classMap({ 'gui-widget-input': true, ...selectIcon.widgetClasses })}
           ?required=${templateData.required}
           ?disabled=${templateData.disabled || templateData.readonly}
           autocomplete=${this.autocomplete || nothing}

--- a/libs/gui/components/src/lib/components/tags.ts
+++ b/libs/gui/components/src/lib/components/tags.ts
@@ -166,6 +166,7 @@ export class GuiTags extends LitElement {
             @keydown=${this.onInputKeydown}
             @blur=${this.onInputBlur}
             @paste=${this.onPaste}
+            @change=${(e: Event) => e.stopPropagation()}
           />
         </div>
         ${this._showPillsList && tags.length > 0

--- a/libs/gui/components/src/lib/components/tags.ts
+++ b/libs/gui/components/src/lib/components/tags.ts
@@ -1,0 +1,568 @@
+import { html, LitElement, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { repeat } from 'lit/directives/repeat.js';
+import { GUIAriaController } from '../controllers/aria.controller';
+import { addErrors, addLabel, type ControlTemplateData } from '../utils/templates';
+import { type TagsProps } from '@golemui/gui-shared';
+import { createIntersectionObserver } from './tabs';
+
+type TagsSeparator = 'Enter' | ',' | 'Tab' | 'blur' | string;
+
+const DEFAULT_SEPARATORS: TagsSeparator[] = ['Enter', ',', 'Tab', 'blur'];
+
+@customElement('gui-tags')
+export class GuiTags extends LitElement {
+  @property({ type: String }) uid: string | undefined = undefined;
+  @property({ type: String }) label: string | undefined = undefined;
+  @property({ type: String, attribute: 'locale-id' }) localeId = 'en';
+  @property({ type: Array }) errors: string[] | undefined = [];
+  @property({ type: Boolean }) touched: boolean | undefined = false;
+  @property({ type: Boolean }) required: boolean | undefined = false;
+  @property({ type: Boolean }) disabled: boolean | undefined = false;
+  @property({ type: Boolean, attribute: 'readonly' }) readOnly: boolean | undefined = false;
+  @property({ type: Array }) value: string[] | undefined = [];
+
+  @property({ type: String }) hint: string | undefined = undefined;
+  @property({ type: String }) placeholder: string | undefined = undefined;
+  @property({ type: String }) icon: string | undefined = undefined;
+  @property({ type: Array }) separators: TagsSeparator[] | undefined = undefined;
+  @property({ type: Boolean }) allowDuplicates: boolean | undefined = true;
+  @property({ type: Boolean }) trim: boolean | undefined = true;
+  @property({ type: Number }) limit: number | undefined = undefined;
+  @property({ type: String, attribute: 'remove-aria-label' }) removeAriaLabel: string | undefined =
+    undefined;
+  @property({ type: String, attribute: 'remove-icon' }) removeIcon: string | undefined = undefined;
+
+  @state() private _isStartVisible = true;
+  @state() private _isEndVisible = true;
+  @state() private _showPillsList = false;
+
+  private startObserver: IntersectionObserver | undefined;
+  private endObserver: IntersectionObserver | undefined;
+
+  private ariaController = new GUIAriaController(this, {
+    getTargets: () => this.querySelectorAll(`.gui-tags-input`),
+    getState: () => ({
+      uid: this.uid as string,
+      templateData: {
+        hint: this.hint,
+        errors: this.errors,
+        readonly: this.readOnly,
+        disabled: this.disabled,
+        touched: this.touched,
+      },
+    }),
+  });
+
+  override createRenderRoot() {
+    return this;
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.classList.add('gui-field');
+  }
+
+  override updated() {
+    this.setupObservers();
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    this.disconnectObservers();
+    this.removeOutsideListeners();
+  }
+
+  private getSeparators(): TagsSeparator[] {
+    return this.separators && this.separators.length > 0 ? this.separators : DEFAULT_SEPARATORS;
+  }
+
+  private getValue(): string[] {
+    return Array.isArray(this.value) ? this.value : [];
+  }
+
+  private getRemoveAriaLabel(): string {
+    return this.removeAriaLabel ?? 'Remove tag';
+  }
+
+  override render() {
+    const tags = this.getValue();
+    const templateData: ControlTemplateData<string[]> & TagsProps = {
+      uid: this.uid,
+      label: this.label,
+      hint: this.hint,
+      errors: this.errors,
+      touched: this.touched,
+      required: this.required,
+      disabled: this.disabled,
+      readonly: this.readOnly,
+      value: tags,
+      placeholder: this.placeholder,
+      icon: this.icon,
+    };
+
+    const iconClassMap = {
+      'gui-widget-icon': true,
+      [this.icon as string]: !!this.icon,
+    };
+
+    return html`
+      ${this.label ? addLabel(this.uid as string, templateData, false, undefined, false) : nothing}
+
+      <div class="gui-widget">
+        <div
+          class=${classMap({
+            'gui-widget-input': true,
+            'gui-tags-input': true,
+            'gui-tags-input--icon': !!this.icon,
+          })}
+          role="group"
+          aria-label=${this.label ?? 'Tags input'}
+        >
+          ${this.icon
+            ? html`<span class=${classMap(iconClassMap)} data-icon=${this.icon}></span>`
+            : nothing}
+          ${tags.length > 0
+            ? html`<div
+                  class=${classMap({
+                    'gui-tags__pills-wrapper': true,
+                    'gui-tags--start-shadow': !this._isStartVisible,
+                    'gui-tags--end-shadow': !this._isEndVisible,
+                  })}
+                >
+                  <div class="gui-tags__pills" role="list">
+                    <span class="gui-sentinel gui-sentinel__start"></span>
+                    ${repeat(
+                      tags,
+                      (tag, index) => `${index}-${tag}`,
+                      (tag, index) => this.renderChip(tag, index),
+                    )}
+                    <span class="gui-sentinel gui-sentinel__end"></span>
+                  </div>
+                </div>
+                <div class="gui-tags__pills-compact">
+                  <button
+                    type="button"
+                    class="gui-tags__pill--count"
+                    aria-label="${tags.length} tags"
+                    aria-expanded=${this._showPillsList}
+                    ?disabled=${this.disabled || this.readOnly}
+                    @click=${this.togglePillsList}
+                  >
+                    ${tags.length}
+                  </button>
+                </div>`
+            : nothing}
+
+          <input
+            type="text"
+            id=${this.uid}
+            data-cy=${`${this.uid}_tags-input`}
+            class="gui-tags__input"
+            ?disabled=${this.disabled}
+            ?readonly=${this.readOnly}
+            placeholder=${this.placeholder || nothing}
+            @keydown=${this.onInputKeydown}
+            @blur=${this.onInputBlur}
+            @paste=${this.onPaste}
+          />
+        </div>
+        ${this._showPillsList && tags.length > 0
+          ? html`<div class="gui-tags__pills-dropdown" role="list">
+              ${repeat(
+                tags,
+                (tag, index) => `dd-${index}-${tag}`,
+                (tag, index) => this.renderChip(tag, index, true),
+              )}
+            </div>`
+          : nothing}
+
+      </div>
+      ${addErrors(this.uid as string, templateData)}
+    `;
+  }
+
+  private renderChip(tag: string, index: number, inDropdown = false) {
+    const removeAriaLabel = `${this.getRemoveAriaLabel()}: ${tag}`;
+    return html`
+      <div
+        class="gui-tags__chip"
+        role="listitem"
+        data-cy=${`${this.uid}_tags-chip-${index}`}
+        data-index=${index}
+        data-in-dropdown=${inDropdown}
+        tabindex="-1"
+        aria-label=${removeAriaLabel}
+        @focus=${this.handleChipFocus}
+        @keydown=${(e: KeyboardEvent) => this.onChipKeydown(e, index)}
+      >
+        <span class="gui-tags__chip-text">${tag}</span>
+        <button
+          type="button"
+          class="gui-tags__chip-remove"
+          tabindex="-1"
+          aria-hidden="true"
+          ?disabled=${this.disabled || this.readOnly}
+          @click=${(e: Event) => {
+            e.stopPropagation();
+            this.removeChip(index);
+          }}
+        >
+          ${this.removeIcon
+            ? html`<span class=${`gui-widget-icon ${this.removeIcon}`} data-icon=${this.removeIcon}></span>`
+            : html`<svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 256 256"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  d="M165.66,101.66,139.31,128l26.35,26.34a8,8,0,0,1-11.32,11.32L128,139.31l-26.34,26.35a8,8,0,0,1-11.32-11.32L116.69,128,90.34,101.66a8,8,0,0,1,11.32-11.32L128,116.69l26.34-26.35a8,8,0,0,1,11.32,11.32ZM232,128A104,104,0,1,1,128,24,104.11,104.11,0,0,1,232,128Zm-16,0a88,88,0,1,0-88,88A88.1,88.1,0,0,0,216,128Z"
+                ></path>
+              </svg>`}
+        </button>
+      </div>
+    `;
+  }
+
+  private handleChipFocus = (e: FocusEvent) => {
+    (e.target as Element).scrollIntoView({
+      behavior: 'smooth',
+      block: 'nearest',
+      inline: 'nearest',
+    });
+  };
+
+  private onInputKeydown(e: KeyboardEvent) {
+    if (this.disabled || this.readOnly) return;
+
+    const input = e.target as HTMLInputElement;
+    const separators = this.getSeparators();
+    const draft = input.value;
+    const caretAtStart = input.selectionStart === 0 && input.selectionEnd === 0;
+
+    if (e.key === 'Enter' && separators.includes('Enter')) {
+      e.preventDefault();
+      if (this.commitDraft(draft)) input.value = '';
+      return;
+    }
+
+    if (e.key === ',' && separators.includes(',')) {
+      e.preventDefault();
+      if (this.commitDraft(draft)) input.value = '';
+      return;
+    }
+
+    if (e.key === 'Tab' && separators.includes('Tab') && draft.length > 0) {
+      // Commit but allow default Tab behavior (focus moves out of widget).
+      if (this.commitDraft(draft)) input.value = '';
+      return;
+    }
+
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      input.value = '';
+      return;
+    }
+
+    // ArrowLeft enters the pill list only when the caret is at position 0
+    // with no selection — otherwise it's normal cursor movement inside the draft.
+    if (e.key === 'ArrowLeft' && caretAtStart) {
+      const tags = this.getValue();
+      if (tags.length > 0) {
+        e.preventDefault();
+        this.enterPillList(tags.length - 1);
+      }
+      return;
+    }
+
+    if (e.key === 'Backspace' && draft === '') {
+      const tags = this.getValue();
+      if (tags.length > 0) {
+        e.preventDefault();
+        this.enterPillList(tags.length - 1);
+      }
+      return;
+    }
+  }
+
+  private onInputBlur(e: FocusEvent) {
+    const input = e.target as HTMLInputElement;
+    const separators = this.getSeparators();
+    const draft = input.value;
+
+    if (draft.length > 0 && separators.includes('blur') && !this.disabled && !this.readOnly) {
+      if (this.commitDraft(draft)) input.value = '';
+    }
+
+    this.dispatchEvent(
+      new CustomEvent('blur', {
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private onChipKeydown(e: KeyboardEvent, index: number) {
+    if (this.disabled || this.readOnly) return;
+
+    if (e.key === 'Delete' || e.key === 'Backspace') {
+      e.preventDefault();
+      e.stopPropagation();
+      this.removeChip(index);
+      return;
+    }
+
+    const isDropdown = this._showPillsList;
+    const prevKey = isDropdown ? 'ArrowUp' : 'ArrowLeft';
+    const nextKey = isDropdown ? 'ArrowDown' : 'ArrowRight';
+
+    if (e.key === prevKey) {
+      e.preventDefault();
+      if (index > 0) this.focusPillAt(index - 1);
+      return;
+    }
+
+    if (e.key === nextKey) {
+      e.preventDefault();
+      const tags = this.getValue();
+      if (index < tags.length - 1) {
+        this.focusPillAt(index + 1);
+      } else if (!isDropdown) {
+        this.focusInput();
+      }
+      return;
+    }
+
+    if (e.key === 'Home') {
+      e.preventDefault();
+      this.focusPillAt(0);
+      return;
+    }
+
+    if (e.key === 'End') {
+      e.preventDefault();
+      const tags = this.getValue();
+      this.focusPillAt(tags.length - 1);
+      return;
+    }
+
+    if (e.key === 'Escape' && isDropdown) {
+      e.preventDefault();
+      this._showPillsList = false;
+      this.removeOutsideListeners();
+      this.focusInput();
+      return;
+    }
+  }
+
+  private onPaste(e: ClipboardEvent) {
+    if (this.disabled || this.readOnly) return;
+    const text = e.clipboardData?.getData('text') ?? '';
+    if (!text) return;
+
+    const separators = this.getSeparators();
+    const charSeparators = separators.filter(
+      (s) => s !== 'Enter' && s !== 'Tab' && s !== 'blur',
+    );
+    if (charSeparators.length === 0) return;
+
+    const splitRegex = new RegExp(
+      `[${charSeparators.map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('')}\n]`,
+    );
+    if (!splitRegex.test(text)) return;
+
+    e.preventDefault();
+    const input = e.target instanceof HTMLInputElement ? e.target : null;
+    const draft = input?.value ?? '';
+    const parts = (draft + text).split(splitRegex);
+    const drafts = parts.slice(0, -1);
+    const tail = parts[parts.length - 1] ?? '';
+
+    if (this.commitDraftBatch(drafts) && input) {
+      input.value = tail;
+    }
+  }
+
+  private commitDraft(rawDraft: string): boolean {
+    const cleaned = this.trim ? rawDraft.trim() : rawDraft;
+    if (cleaned.length === 0) return false;
+
+    const tags = this.getValue();
+    if (this.allowDuplicates === false && tags.includes(cleaned)) return true;
+    if (this.limit !== undefined && tags.length >= this.limit) return false;
+
+    this.emitChange([...tags, cleaned]);
+    return true;
+  }
+
+  private commitDraftBatch(rawDrafts: string[]): boolean {
+    const tags = this.getValue();
+    const next = [...tags];
+    for (const raw of rawDrafts) {
+      const cleaned = this.trim ? raw.trim() : raw;
+      if (cleaned.length === 0) continue;
+      if (this.allowDuplicates === false && next.includes(cleaned)) continue;
+      if (this.limit !== undefined && next.length >= this.limit) break;
+      next.push(cleaned);
+    }
+    if (next.length === tags.length) return false;
+    this.emitChange(next);
+    return true;
+  }
+
+  private removeChip(index: number) {
+    if (this.disabled || this.readOnly) return;
+    const tags = this.getValue();
+    if (index < 0 || index >= tags.length) return;
+    const next = tags.filter((_, i) => i !== index);
+    this.emitChange(next);
+
+    if (this._showPillsList && next.length === 0) {
+      this._showPillsList = false;
+      this.removeOutsideListeners();
+    }
+
+    // After removal: focus the next pill, else the previous pill, else the input.
+    requestAnimationFrame(() => {
+      if (next.length === 0) {
+        this.focusInput();
+        return;
+      }
+      const nextIndex = index < next.length ? index : next.length - 1;
+      this.focusPillAt(nextIndex);
+    });
+  }
+
+  private emitChange(next: string[]) {
+    this.value = next;
+    this.dispatchEvent(
+      new CustomEvent('change', {
+        detail: { value: next },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private focusInput() {
+    const input = this.querySelector<HTMLInputElement>(`input[id="${this.uid}"]`);
+    input?.focus();
+  }
+
+  private focusPillAt(index: number) {
+    // Wait one frame so any DOM updates (removal, dropdown toggle) settle.
+    requestAnimationFrame(() => {
+      const selector = this._showPillsList
+        ? '.gui-tags__pills-dropdown .gui-tags__chip'
+        : '.gui-tags__pills .gui-tags__chip';
+      const pills = this.querySelectorAll<HTMLElement>(selector);
+      if (pills.length === 0) {
+        this.focusInput();
+        return;
+      }
+      const safeIndex = Math.max(0, Math.min(index, pills.length - 1));
+      pills[safeIndex].focus();
+    });
+  }
+
+  /**
+   * Enter the pill list at `index`. In compact mode the pill strip is
+   * `display: none`, so we open the dropdown overlay first so the user can
+   * actually see the focused pill.
+   */
+  private enterPillList(index: number) {
+    const wrapper = this.querySelector<HTMLElement>('.gui-tags__pills-wrapper');
+    const wrapperHidden = wrapper ? getComputedStyle(wrapper).display === 'none' : false;
+    if (wrapperHidden && !this._showPillsList) {
+      this.togglePillsList();
+      // togglePillsList focuses the first dropdown pill — override to land
+      // on the requested index after the next frame.
+      requestAnimationFrame(() => this.focusPillAt(index));
+      return;
+    }
+    this.focusPillAt(index);
+  }
+
+  private togglePillsList = () => {
+    if (this.disabled || this.readOnly) return;
+    this._showPillsList = !this._showPillsList;
+    if (this._showPillsList) {
+      requestAnimationFrame(() => {
+        document.addEventListener('pointerdown', this.handleOutsideInteraction);
+        document.addEventListener('focusin', this.handleOutsideInteraction);
+        const firstPill = this.querySelector<HTMLElement>(
+          '.gui-tags__pills-dropdown .gui-tags__chip',
+        );
+        firstPill?.focus();
+      });
+    } else {
+      this.removeOutsideListeners();
+    }
+  };
+
+  private removeOutsideListeners() {
+    document.removeEventListener('pointerdown', this.handleOutsideInteraction);
+    document.removeEventListener('focusin', this.handleOutsideInteraction);
+  }
+
+  private handleOutsideInteraction = (e: Event) => {
+    const compact = this.querySelector('.gui-tags__pills-compact');
+    const dropdown = this.querySelector('.gui-tags__pills-dropdown');
+    const target = e.composedPath()[0] as Node;
+    if (!compact?.contains(target) && !dropdown?.contains(target)) {
+      this._showPillsList = false;
+      this.removeOutsideListeners();
+    }
+  };
+
+  private setupObservers() {
+    const startSentinel = this.querySelector('.gui-sentinel__start');
+    const endSentinel = this.querySelector('.gui-sentinel__end');
+
+    if (startSentinel && !this.startObserver) {
+      this.startObserver = createIntersectionObserver(
+        startSentinel,
+        (isIntersecting) => (this._isStartVisible = isIntersecting),
+      );
+    }
+
+    if (endSentinel && !this.endObserver) {
+      this.endObserver = createIntersectionObserver(
+        endSentinel,
+        (isIntersecting) => (this._isEndVisible = isIntersecting),
+      );
+    }
+
+    if (!startSentinel && this.startObserver) {
+      this.startObserver.disconnect();
+      this.startObserver = undefined;
+      this._isStartVisible = true;
+    }
+    if (!endSentinel && this.endObserver) {
+      this.endObserver.disconnect();
+      this.endObserver = undefined;
+      this._isEndVisible = true;
+    }
+  }
+
+  private disconnectObservers() {
+    this.startObserver?.disconnect();
+    this.endObserver?.disconnect();
+    this.startObserver = undefined;
+    this.endObserver = undefined;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'gui-tags': GuiTags;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('gui-tags')) {
+  customElements.define('gui-tags', GuiTags);
+}

--- a/libs/gui/components/src/lib/components/textarea.ts
+++ b/libs/gui/components/src/lib/components/textarea.ts
@@ -119,6 +119,7 @@ export class GuiTextarea extends LitElement {
         <textarea
           id=${this.uid}
           data-cy=${`${this.uid}_textarea`}
+          class="gui-widget-input"
           style=${styleMap(autoGrowStyles)}
           ?required=${templateData.required}
           ?disabled=${templateData.disabled}

--- a/libs/gui/components/src/lib/components/textinput.ts
+++ b/libs/gui/components/src/lib/components/textinput.ts
@@ -67,6 +67,7 @@ export class GuiTextinput extends LitElement {
     const textinputIcon = addIcon('textinput', templateData);
 
     const fieldClasses: { [key: string]: boolean } = {
+      'gui-widget-input': true,
       [`gui-textinput--icon`]: !!this.icon,
     };
 

--- a/libs/gui/components/src/styles/_pill.scss
+++ b/libs/gui/components/src/styles/_pill.scss
@@ -1,0 +1,63 @@
+// Shared pill / chip visual rules.
+// Consumed by `gui-range-calendar` (date range pills) and `gui-tags` (chips).
+// Host selectors apply these mixins to their own scoped class names so the
+// visual treatment stays in a single source of truth.
+
+@mixin gui-pill {
+  display: flex;
+  flex-wrap: nowrap;
+  flex-shrink: 0;
+  gap: var(--gui-space-3);
+  color: var(--gui-color-white);
+  background-color: var(--gui-intent-primary);
+  border-radius: var(--gui-radius-md);
+  padding: var(--gui-space-1);
+  cursor: pointer;
+
+  &:focus {
+    outline: 0;
+    border-color: var(--gui-border-focus);
+    box-shadow: var(--gui-shadow-focus);
+  }
+}
+
+@mixin gui-pill-text {
+  font-size: var(--gui-font-xs);
+}
+
+@mixin gui-pill-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  color: white;
+  padding: 0;
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
+// Pill-count badge (the "+N" bubble shown in compact-width fallback layouts).
+// Used by `gui-tags` and mirrored by the equivalent in `gui-range-date-input`.
+@mixin gui-pill-count {
+  display: flex;
+  flex-wrap: nowrap;
+  flex-shrink: 0;
+  gap: var(--gui-space-3);
+  color: var(--gui-color-white);
+  background-color: var(--gui-intent-primary);
+  padding: var(--gui-space-1);
+  cursor: pointer;
+  min-width: 24px;
+  font-size: var(--gui-font-xs);
+  border: none;
+  justify-content: center;
+  border-radius: var(--gui-radius-full);
+
+  &:focus {
+    outline: 0;
+    border-color: var(--gui-border-focus);
+    box-shadow: var(--gui-shadow-focus);
+  }
+}

--- a/libs/gui/components/src/styles/checkbox.scss
+++ b/libs/gui/components/src/styles/checkbox.scss
@@ -39,9 +39,30 @@ gui-checkbox {
     width: 1rem;
     height: 1rem;
     border-radius: var(--gui-radius-sm);
+    background: var(--gui-bg-surface);
+    border: 1px solid var(--gui-border-default);
     accent-color: var(--gui-intent-primary);
     appearance: none;
     margin-top: 1px;
+    transition:
+      border-color var(--gui-transition-normal, 0.2s),
+      box-shadow var(--gui-transition-normal, 0.2s);
+
+    &:focus {
+      outline: 0;
+      border-color: var(--gui-border-focus);
+      box-shadow: var(--gui-shadow-focus);
+    }
+
+    &[aria-invalid='true'] {
+      border-color: var(--gui-intent-error);
+
+      &:focus {
+        outline: 0;
+        border-color: var(--gui-intent-error);
+        box-shadow: var(--gui-shadow-focus-error);
+      }
+    }
 
     &::before {
       content: '';

--- a/libs/gui/components/src/styles/index.scss
+++ b/libs/gui/components/src/styles/index.scss
@@ -26,6 +26,7 @@
 @use 'range-date-picker';
 @use 'repeater';
 @use 'select';
+@use 'tags';
 @use 'textarea';
 @use 'textinput';
 @use 'toggle';

--- a/libs/gui/components/src/styles/radiogroup.scss
+++ b/libs/gui/components/src/styles/radiogroup.scss
@@ -21,9 +21,30 @@ gui-radiogroup {
       height: 0.5em;
       padding: 0.6em;
       border-radius: 50%;
+      background: var(--gui-bg-surface);
+      border: 1px solid var(--gui-border-default);
 
       appearance: none;
       margin: 0;
+      transition:
+        border-color var(--gui-transition-normal, 0.2s),
+        box-shadow var(--gui-transition-normal, 0.2s);
+
+      &:focus {
+        outline: 0;
+        border-color: var(--gui-border-focus);
+        box-shadow: var(--gui-shadow-focus);
+      }
+
+      &[aria-invalid='true'] {
+        border-color: var(--gui-intent-error);
+
+        &:focus {
+          outline: 0;
+          border-color: var(--gui-intent-error);
+          box-shadow: var(--gui-shadow-focus-error);
+        }
+      }
 
       &::before {
         content: '';

--- a/libs/gui/components/src/styles/range-calendar.scss
+++ b/libs/gui/components/src/styles/range-calendar.scss
@@ -1,3 +1,5 @@
+@use 'pill' as *;
+
 :root {
   --gui-radius-range: calc(var(--gui-radius-md) * 2);
 }
@@ -130,37 +132,14 @@ gui-range-calendar {
   }
 
   .gui-range-calendar__pill {
-    display: flex;
-    flex-wrap: nowrap;
-    flex-shrink: 0;
-    gap: var(--gui-space-3);
-    color: var(--gui-color-white);
-    background-color: var(--gui-intent-primary);
-    border-radius: var(--gui-radius-md);
-    padding: var(--gui-space-1);
-    cursor: pointer;
+    @include gui-pill;
 
     &-text {
-      font-size: var(--gui-font-xs);
+      @include gui-pill-text;
     }
 
     &-remove {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      background: transparent;
-      border: 0;
-      color: white;
-      padding: 0;
-      width: 16px;
-      height: 16px;
-      cursor: pointer;
-    }
-
-    &:focus {
-      outline: 0;
-      border-color: var(--gui-border-focus);
-      box-shadow: var(--gui-shadow-focus);
+      @include gui-pill-remove;
     }
   }
 

--- a/libs/gui/components/src/styles/range-date.scss
+++ b/libs/gui/components/src/styles/range-date.scss
@@ -1,3 +1,5 @@
+@use 'pill' as *;
+
 gui-range-date {
   display: block;
   container-type: inline-size;
@@ -122,37 +124,14 @@ gui-range-date {
   }
 
   .gui-range-date-input__pill {
-    display: flex;
-    flex-wrap: nowrap;
-    flex-shrink: 0;
-    gap: var(--gui-space-3);
-    color: var(--gui-color-white);
-    background-color: var(--gui-intent-primary);
-    border-radius: var(--gui-radius-md);
-    padding: var(--gui-space-1);
-    cursor: pointer;
+    @include gui-pill;
 
     &-text {
-      font-size: var(--gui-font-xs);
+      @include gui-pill-text;
     }
 
     &-remove {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      background: transparent;
-      border: 0;
-      color: white;
-      padding: 0;
-      width: 16px;
-      height: 16px;
-      cursor: pointer;
-    }
-
-    &:focus {
-      outline: 0;
-      border-color: var(--gui-border-focus);
-      box-shadow: var(--gui-shadow-focus);
+      @include gui-pill-remove;
     }
   }
 
@@ -246,19 +225,7 @@ gui-range-date {
   }
 
   .gui-range-date-input__pill--count {
-    display: flex;
-    flex-wrap: nowrap;
-    flex-shrink: 0;
-    gap: var(--gui-space-3);
-    color: var(--gui-color-white);
-    background-color: var(--gui-intent-primary);
-    padding: var(--gui-space-1);
-    cursor: pointer;
-    min-width: 24px;
-    font-size: var(--gui-font-xs);
-    border: none;
-    justify-content: center;
-    border-radius: var(--gui-radius-full);
+    @include gui-pill-count;
   }
 
   .gui-range-date-input__pills-dropdown {

--- a/libs/gui/components/src/styles/tags.scss
+++ b/libs/gui/components/src/styles/tags.scss
@@ -1,0 +1,200 @@
+@use 'pill' as *;
+
+gui-tags {
+  display: block;
+  container-type: inline-size;
+  container-name: gui-tags-widget;
+
+  .gui-tags-input {
+    display: flex;
+    align-items: center;
+    position: relative;
+    border: 1px solid var(--gui-color-border);
+    border-radius: var(--gui-radius);
+    background-color: var(--gui-bg-default);
+    padding: var(--gui-padding);
+    gap: var(--gui-space-2);
+
+    input:focus {
+      box-shadow: none;
+    }
+
+    &--icon {
+      & > .gui-widget-icon {
+        flex-shrink: 0;
+      }
+
+      .gui-tags__pills-compact {
+        padding-inline-start: 2.5rem;
+      }
+      .gui-tags__input {
+        padding-inline-start: 2.5rem;
+      }
+      .gui-tags__pills-wrapper {
+        margin-inline-start: 2.5rem;
+      }
+    }
+
+    &[aria-invalid='true'] {
+      border-color: var(--gui-intent-error);
+
+      &:has(.gui-tags__chip:focus),
+      &:has(.gui-tags__input:focus),
+      &:has(.gui-tags__pill--count:focus) {
+        outline: 0;
+        border-color: var(--gui-intent-error);
+        box-shadow: var(--gui-shadow-focus-error);
+      }
+    }
+
+    &:has(.gui-tags__chip:focus),
+    &:has(.gui-tags__input:focus),
+    &:has(.gui-tags__pill--count:focus) {
+      outline: 0;
+      border-color: var(--gui-border-focus);
+      box-shadow: var(--gui-shadow-focus);
+    }
+  }
+
+  .gui-tags__pills-wrapper {
+    display: flex;
+    min-height: 40px;
+    border-inline-end: 1px solid var(--gui-border-default);
+    border-inline-start: 1px solid var(--gui-border-default);
+    position: relative;
+    overflow: hidden;
+    min-width: 0;
+
+    &::before,
+    &::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      width: 60px;
+      z-index: 2;
+      pointer-events: none;
+      transition: opacity 0.3s ease;
+      opacity: 0;
+    }
+
+    &::before {
+      left: 0;
+      background: linear-gradient(to right, var(--gui-bg-default) 20%, transparent);
+    }
+
+    &::after {
+      right: 0;
+      background: linear-gradient(to left, var(--gui-bg-default) 20%, transparent);
+    }
+
+    &.gui-tags--start-shadow::before {
+      opacity: 1;
+    }
+    &.gui-tags--end-shadow::after {
+      opacity: 1;
+    }
+  }
+
+  .gui-tags__pills {
+    display: flex;
+    align-items: center;
+    padding: 0 var(--gui-space-1);
+    gap: var(--gui-space-2);
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+  }
+
+  .gui-sentinel {
+    width: 0;
+    height: 0;
+    flex-shrink: 0;
+    opacity: 0;
+    pointer-events: none;
+
+    &__start {
+      margin-inline-end: 0;
+    }
+    &__end {
+      margin-inline-start: -1px;
+    }
+  }
+
+  .gui-tags__chip {
+    @include gui-pill;
+
+    cursor: default;
+  }
+
+  .gui-tags__chip-text {
+    @include gui-pill-text;
+  }
+
+  .gui-tags__chip-remove {
+    @include gui-pill-remove;
+  }
+
+  .gui-tags__pills-compact {
+    display: none;
+    align-items: center;
+  }
+
+  .gui-tags__pill--count {
+    @include gui-pill-count;
+  }
+
+  .gui-tags__pills-dropdown {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    background-color: var(--gui-bg-default);
+    border: 1px solid var(--gui-border-default);
+    border-radius: var(--gui-radius-md);
+    box-shadow: var(--gui-shadow-md);
+    padding: var(--gui-space-2);
+    gap: var(--gui-space-2);
+    max-height: 200px;
+    overflow-y: auto;
+
+    .gui-tags__chip {
+      justify-content: space-between;
+    }
+  }
+
+  .gui-tags__input {
+    flex: 1 1 300px;
+    min-width: 300px;
+    border: 0;
+    outline: 0;
+    background: transparent;
+    color: var(--gui-text-default);
+    padding: 0 var(--gui-space-2);
+    font: inherit;
+    align-self: stretch;
+  }
+
+  .gui-tags__pills-compact + .gui-tags__input {
+    padding-inline-start: 0;
+  }
+
+  @container gui-tags-widget (max-width: 540px) {
+    .gui-tags__pills-wrapper {
+      display: none;
+    }
+
+    .gui-tags__pills-compact {
+      display: flex;
+      padding-inline-start: var(--gui-space-2);
+    }
+
+    .gui-tags__pills-dropdown {
+      display: flex;
+    }
+  }
+}

--- a/libs/gui/components/src/styles/widget.scss
+++ b/libs/gui/components/src/styles/widget.scss
@@ -45,11 +45,14 @@
     cursor: not-allowed;
   }
 
-  input,
-  select,
-  textarea,
-  .gui-date-input,
-  .gui-range-date-input {
+  // `.gui-widget-input` is the marker for "this element acts as the field"
+  // — applied to the native form element in simple widgets (textinput's
+  // `<input>`, textarea's `<textarea>`, etc.) and to the wrapper `<div>` in
+  // composite widgets (tags, date-input, range-date-input). It lets us style
+  // the field as a single unit without enumerating every wrapper class, and
+  // without accidentally re-styling inner inputs that live INSIDE a
+  // composite-widget field (e.g. the text input nested inside `<gui-tags>`).
+  .gui-widget-input {
     font-family: var(--gui-font-family);
     font-size: var(--gui-font-sm);
     padding: 0 0.75rem;
@@ -78,7 +81,11 @@
       }
     }
 
-    &:disabled {
+    // Disabled — `:disabled` fires when the field IS a form element;
+    // `:has(input:disabled)` fires when the field is a wrapper whose inner
+    // input is disabled. One rule covers both shapes.
+    &:disabled,
+    &:has(input:disabled) {
       background-color: var(--gui-bg-disabled);
       color: var(--gui-text-disabled);
       pointer-events: none;
@@ -107,6 +114,7 @@
   }
 }
 
+.gui-widget .gui-tags-input,
 .gui-widget .gui-range-date-input {
   padding: 0;
   min-height: 40px;

--- a/libs/gui/components/vite.config.ts
+++ b/libs/gui/components/vite.config.ts
@@ -41,6 +41,7 @@ export default defineConfig(() => ({
         'lib/components/range-calendar': 'src/lib/components/range-calendar.ts',
         'lib/components/range-date-input': 'src/lib/components/range-date-input.ts',
         'lib/components/select': 'src/lib/components/select.ts',
+        'lib/components/tags': 'src/lib/components/tags.ts',
         'lib/components/textarea': 'src/lib/components/textarea.ts',
         'lib/components/textinput': 'src/lib/components/textinput.ts',
         'lib/components/toggle': 'src/lib/components/toggle.ts',

--- a/libs/gui/lit/src/lib/components/dropdown.element.ts
+++ b/libs/gui/lit/src/lib/components/dropdown.element.ts
@@ -281,6 +281,7 @@ export class DropdownElement extends LitElement implements WithWidget {
           type="text"
           id=${this.widget.uid}
           data-cy=${`${this.widget.uid}_textinput`}
+          class="gui-widget-input"
           .value=${selectedItemValue ?? templateData.value ?? ''}
           ?required=${templateData.validator?.required}
           ?disabled=${templateData.disabled}

--- a/libs/gui/lit/src/lib/components/tags.element.ts
+++ b/libs/gui/lit/src/lib/components/tags.element.ts
@@ -1,0 +1,88 @@
+import type { InputWidget, WithWidget } from '@golemui/core';
+import { InputWidgetAdapter, type LitFormContext, formContext, inputContext } from '@golemui/lit';
+import { type TagsProps } from '@golemui/gui-shared';
+import '@golemui/gui-components/tags';
+import { consume, provide } from '@lit/context';
+import { html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { type Subscription } from 'rxjs';
+
+@customElement('gui-tags-input')
+export class TagsElement extends LitElement implements WithWidget {
+  widget!: InputWidget<string[]>;
+
+  @consume({ context: formContext })
+  @property({ attribute: false })
+  formContext!: LitFormContext<any>;
+
+  @provide({ context: inputContext })
+  adapter = new InputWidgetAdapter<string[], TagsProps>();
+
+  subscriptions: Subscription[] = [];
+
+  override createRenderRoot() {
+    return this;
+  }
+
+  override updated(changedProperties: any) {
+    super.updated(changedProperties);
+
+    const size = this.adapter.templateData.size;
+
+    if (size) {
+      this.style.flex = String(size);
+    } else {
+      this.style.removeProperty('flex');
+    }
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.classList.add('gui-tags', 'gui-field');
+    this.adapter.context = this.formContext;
+    this.adapter.init(this.widget);
+
+    this.subscriptions.push(
+      this.adapter.templateDataChanged$.subscribe(() => this.requestUpdate()),
+    );
+  }
+
+  override render() {
+    super.render();
+
+    return html`
+      <gui-tags
+        .uid=${this.widget.uid}
+        .label=${this.adapter.templateData.label}
+        .hint=${this.adapter.templateData.hint}
+        .errors=${this.adapter.templateData.errors}
+        ?touched=${this.adapter.templateData.touched}
+        ?required=${this.adapter.templateData.validator?.required}
+        ?disabled=${this.adapter.templateData.disabled}
+        ?readonly=${this.adapter.templateData.readonly}
+        .value=${this.adapter.templateData.value}
+        .placeholder=${this.adapter.templateData.placeholder}
+        .icon=${this.adapter.templateData.icon}
+        .separators=${this.adapter.templateData.separators}
+        .allowDuplicates=${this.adapter.templateData.allowDuplicates ?? true}
+        .trim=${this.adapter.templateData.trim ?? true}
+        .limit=${this.adapter.templateData.limit}
+        .removeAriaLabel=${this.adapter.templateData.removeAriaLabel}
+        .removeIcon=${this.adapter.templateData.removeIcon}
+        @change=${this.valueChanged}
+        @blur=${() => this.adapter.onBlur()}
+      ></gui-tags>
+    `;
+  }
+
+  valueChanged(event: CustomEvent) {
+    const value = event.detail.value as string[];
+    this.adapter.valueChanged(value);
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    this.adapter.destroy();
+    this.subscriptions.forEach((s) => s.unsubscribe());
+  }
+}

--- a/libs/gui/lit/src/lib/widget.loaders.ts
+++ b/libs/gui/lit/src/lib/widget.loaders.ts
@@ -28,6 +28,7 @@ export const widgetLoaders: WidgetLoaders<Type<WithWidget>, GolemWidget> = {
   number: async () => (await import('./components/number.element')).NumberElement,
   radiogroup: async () => (await import('./components/radiogroup.element')).RadiogroupElement,
   select: async () => (await import('./components/select.element')).SelectElement,
+  tags: async () => (await import('./components/tags.element')).TagsElement,
 
   // REPEATER
   repeater: async () => (await import('./components/repeater.element')).RepeaterElement,

--- a/libs/gui/react/src/custom-elements.ts
+++ b/libs/gui/react/src/custom-elements.ts
@@ -15,6 +15,7 @@ import type { GuiRadiogroup } from '@golemui/gui-components/radiogroup';
 import type { GuiRangeCalendar } from '@golemui/gui-components/range-calendar';
 import type { GuiRangeDateInput } from '@golemui/gui-components/range-date-input';
 import type { GuiSelect } from '@golemui/gui-components/select';
+import type { GuiTags } from '@golemui/gui-components/tags';
 import type { GuiTextarea } from '@golemui/gui-components/textarea';
 import type { GuiTextinput } from '@golemui/gui-components/textinput';
 import type { GuiToggle } from '@golemui/gui-components/toggle';
@@ -62,6 +63,8 @@ declare module 'react' {
 
       'gui-select': DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> &
         Partial<GuiSelect>;
+
+      'gui-tags': DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> & Partial<GuiTags>;
 
       'gui-textarea': DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> &
         Partial<GuiTextarea>;

--- a/libs/gui/react/src/lib/components/Dropdown.tsx
+++ b/libs/gui/react/src/lib/components/Dropdown.tsx
@@ -305,6 +305,7 @@ export function Dropdown(widgetInstance: WithWidget) {
           type="text"
           id={uid}
           data-cy={`${uid}_textinput`}
+          className="gui-widget-input"
           defaultValue={value ?? ''}
           required={isRequired}
           disabled={isDisabled}

--- a/libs/gui/react/src/lib/components/Tags.tsx
+++ b/libs/gui/react/src/lib/components/Tags.tsx
@@ -1,0 +1,60 @@
+import type { InputWidget, Validator, WithWidget } from '@golemui/core';
+import { useInputWidget } from '@golemui/react';
+import { type TagsProps } from '@golemui/gui-shared';
+import { useCallback } from 'react';
+import '@golemui/gui-components/tags';
+import '../styles.scss';
+
+export function Tags(widgetInstance: WithWidget) {
+  const widget = widgetInstance.widget as InputWidget<string[]>;
+  const { uid, errors, value, isTouched, templateData, onValueChanged, onBlur } = useInputWidget<
+    string[],
+    TagsProps
+  >(widget);
+
+  const handleChange = useCallback(
+    (e: React.SyntheticEvent<HTMLElement>) =>
+      onValueChanged((e.nativeEvent as CustomEvent).detail.value),
+    [onValueChanged],
+  );
+
+  const label = templateData.label as string;
+  const hint = templateData.hint;
+  const placeholder = templateData.placeholder;
+  const icon = templateData.icon;
+  const separators = templateData.separators;
+  const allowDuplicates = templateData.allowDuplicates ?? true;
+  const trim = templateData.trim ?? true;
+  const limit = templateData.limit;
+  const removeAriaLabel = templateData.removeAriaLabel;
+  const removeIcon = templateData.removeIcon;
+  const isDisabled = templateData.disabled as boolean;
+  const isReadonly = templateData.readonly as boolean;
+  const isRequired = (templateData.validator as Validator)?.required;
+
+  return (
+    <div className="gui-tags gui-field" style={{ flex: templateData.size }}>
+      <gui-tags
+        uid={uid}
+        label={label}
+        hint={hint}
+        errors={errors}
+        touched={isTouched}
+        required={isRequired}
+        disabled={isDisabled}
+        readOnly={isReadonly}
+        value={value}
+        placeholder={placeholder ?? undefined}
+        icon={icon}
+        separators={separators}
+        allowDuplicates={allowDuplicates}
+        trim={trim}
+        limit={limit}
+        removeAriaLabel={removeAriaLabel}
+        removeIcon={removeIcon}
+        onChange={handleChange}
+        onBlur={onBlur}
+      ></gui-tags>
+    </div>
+  );
+}

--- a/libs/gui/react/src/lib/widget.loaders.ts
+++ b/libs/gui/react/src/lib/widget.loaders.ts
@@ -24,6 +24,7 @@ export const widgetLoaders: WidgetLoaders<React.ComponentType<WithWidget>, Golem
   rangeCalendar: async () => (await import('./components/RangeCalendar')).RangeCalendar,
   rangeDateInput: async () => (await import('./components/RangeDateInput')).RangeDateInput,
   rangeDatePicker: async () => (await import('./components/RangeDatePicker')).RangeDatePicker,
+  tags: async () => (await import('./components/Tags')).Tags,
 
   // REPEATER
   repeater: async () => (await import('./components/Repeater')).Repeater,

--- a/libs/gui/shared/src/index.ts
+++ b/libs/gui/shared/src/index.ts
@@ -246,6 +246,8 @@ export type {
   RepeaterProps,
   SelectProps,
   TabsProps,
+  TagsProps,
+  TagsSeparator,
   TextareaProps,
   TextinputProps,
   ToggleProps,

--- a/libs/gui/shared/src/lib/dx/core/selectorResolver.service.ts
+++ b/libs/gui/shared/src/lib/dx/core/selectorResolver.service.ts
@@ -37,6 +37,7 @@ const UMBRELLA_ITEMTYPES: Record<string, ReadonlySet<string>> = {
     'LIST',
     'CUSTOM_INPUT',
     'REPEATER',
+    'TAGS',
   ]),
   ACTIONS: new Set(['ACTIONS', 'CUSTOM_ACTION']),
   DISPLAYS: new Set(['DISPLAYS', 'ALERTS', 'CUSTOM_DISPLAY']),

--- a/libs/gui/shared/src/lib/dx/gui.ts
+++ b/libs/gui/shared/src/lib/dx/gui.ts
@@ -53,6 +53,9 @@ import { _guiCustomLayout } from './shortcuts/custom-layout/guiCustomLayout.impl
 // ─── Repeater ───
 import { _guiRepeater } from './shortcuts/repeater/guiRepeater.impl';
 
+// ─── Tags ───
+import { _guiTags } from './shortcuts/tags/guiTags.impl';
+
 // ─── Selectors — chain root ───
 import { ScopeChain } from './shortcuts/scopes/scopeChain';
 
@@ -77,6 +80,7 @@ export const gui = {
     rangeDateInput: _guiRangeDateInput,
     rangeDatePicker: _guiRangeDatePicker,
     repeater: _guiRepeater,
+    tags: _guiTags,
     custom: _guiCustomInput,
   },
   actions: {

--- a/libs/gui/shared/src/lib/dx/index.ts
+++ b/libs/gui/shared/src/lib/dx/index.ts
@@ -43,6 +43,7 @@ export { _guiRangeDatePicker } from './shortcuts/range-date-picker/guiRangeDateP
 export { _guiRepeater } from './shortcuts/repeater/guiRepeater.impl';
 export { _guiSelect } from './shortcuts/select/guiSelect.impl';
 export { _guiTabs } from './shortcuts/tabs/guiTabs.impl';
+export { _guiTags } from './shortcuts/tags/guiTags.impl';
 export { _guiTextarea } from './shortcuts/textarea/guiTextarea.impl';
 
 // ─── GSL selectors (behavior) ───
@@ -84,6 +85,7 @@ export {
 export { _gslRepeaterByUid, _gslRepeaters } from './shortcuts/repeater/register';
 export { _gslSelectByUid, _gslSelects } from './shortcuts/select/register';
 export { _gslTabs, _gslTabsByUid } from './shortcuts/tabs/register';
+export { _gslTags, _gslTagsByUid } from './shortcuts/tags/register';
 export { _gslTextareaByUid, _gslTextareas } from './shortcuts/textarea/register';
 
 // ─── Scope selectors ───
@@ -179,6 +181,7 @@ export type {
 export type { GslRepeaterConfig, RepeaterDecorator } from './shortcuts/repeater/repeater.domain';
 export type { GslSelectConfig, SelectDecorator } from './shortcuts/select/select.domain';
 export type { GslTabsConfig, TabsDecorator } from './shortcuts/tabs/tabs.domain';
+export type { GslTagsConfig, TagsDecorator } from './shortcuts/tags/tags.domain';
 export type { GslTextareaConfig, TextareaDecorator } from './shortcuts/textarea/textarea.domain';
 
 // ─── Extension API (for adding custom shortcut types) ───

--- a/libs/gui/shared/src/lib/dx/shortcuts/tags/guiTags.impl.ts
+++ b/libs/gui/shared/src/lib/dx/shortcuts/tags/guiTags.impl.ts
@@ -1,0 +1,36 @@
+import { type DxRuntimeParams } from '../../core/dxUtilityTypes';
+import type { GuiTagsShortcut, TagsDecorator, TagsEntry } from './tags.domain';
+
+export function _guiTags(path: string): GuiTagsShortcut;
+export function _guiTags(
+  path: string,
+  props: Partial<Omit<TagsDecorator, 'type'>>,
+): GuiTagsShortcut;
+export function _guiTags(
+  path: string,
+  props: Partial<Omit<TagsDecorator, 'type'>>,
+  tags: string[],
+): GuiTagsShortcut;
+export function _guiTags(
+  path: string,
+  callback: (params: DxRuntimeParams) => Partial<Omit<TagsDecorator, 'type'>>,
+  tags?: string[],
+): GuiTagsShortcut;
+export function _guiTags(
+  path: string,
+  propsOrCallback?:
+    | Partial<Omit<TagsDecorator, 'type'>>
+    | ((params: DxRuntimeParams) => Partial<Omit<TagsDecorator, 'type'>>),
+  tags?: string[],
+): GuiTagsShortcut {
+  if (typeof propsOrCallback === 'function') {
+    const callback = propsOrCallback;
+    const def = (params: DxRuntimeParams) => ({ type: 'tags' as const, ...callback(params) });
+    const items: TagsEntry[] = [{ key: path, def }];
+    return { type: 'ITEMS', itemType: 'TAGS', items, tags: tags ?? [] };
+  }
+
+  const def: TagsDecorator = { type: 'tags', ...propsOrCallback };
+  const items: TagsEntry[] = [{ key: path, def }];
+  return { type: 'ITEMS', itemType: 'TAGS', items, tags: tags ?? [] };
+}

--- a/libs/gui/shared/src/lib/dx/shortcuts/tags/register.ts
+++ b/libs/gui/shared/src/lib/dx/shortcuts/tags/register.ts
@@ -1,0 +1,35 @@
+import { defineShortcutType } from '../../core/defineShortcutType';
+import { buildTypedValidator } from '../../core/dxValidatorHelper';
+import { extractWidgetProps } from '../../core/dxPropsHelper';
+import {
+  processAutoLabel,
+  processAutoPlaceholder,
+} from '../../core/sharedSensibleDefaults.service';
+import type { GslTagsConfig, TagsDecorator, TagsEntry } from './tags.domain';
+
+export const { gsl: _gslTags, gslByUid: _gslTagsByUid } = defineShortcutType<
+  TagsEntry,
+  TagsDecorator,
+  GslTagsConfig
+>({
+  itemType: 'TAGS',
+  entryShape: 'keyed',
+  sensibleDefaults: {
+    base: { suppressAutomaticLabels: false, suppressAutomaticPlaceholders: false },
+    fields: ['suppressAutomaticLabels', 'suppressAutomaticPlaceholders'],
+    apply: (def, config) => processAutoPlaceholder(processAutoLabel(def, config), config),
+  },
+  mapToWidget: (def) => ({
+    uid: def.uid ?? '',
+    kind: 'input',
+    type: 'tags',
+    path: def.path ?? '',
+    ...(def.label != null ? { label: def.label } : {}),
+    ...(def.disabled != null ? { disabled: def.disabled } : {}),
+    ...(def.readonly != null ? { readonly: def.readonly } : {}),
+    ...(def.validator != null
+      ? { validator: buildTypedValidator(def.validator as any, 'array') }
+      : {}),
+    props: extractWidgetProps(def),
+  }),
+});

--- a/libs/gui/shared/src/lib/dx/shortcuts/tags/tags.domain.ts
+++ b/libs/gui/shared/src/lib/dx/shortcuts/tags/tags.domain.ts
@@ -1,0 +1,18 @@
+import type { ArrayValidator } from '@golemui/gui-validators';
+import type { TagsProps } from '../../../widget.props';
+import type { DxCommonFields, DxInputBase } from '../../core/dxBase.types';
+import type { DefOrCallback, GslConfigBase, GuiShortcutOf } from '../../core/dxUtilityTypes';
+import type { DxValidator } from '../../core/dxValidatorHelper';
+
+export interface TagsDecorator extends DxInputBase, DxCommonFields, Partial<TagsProps> {
+  type: 'tags';
+  validator?: DxValidator<ArrayValidator>;
+}
+
+export interface GslTagsConfig extends GslConfigBase<TagsDecorator> {
+  suppressAutomaticLabels?: boolean;
+  suppressAutomaticPlaceholders?: boolean;
+}
+
+export type TagsEntry = { key: string; def: DefOrCallback<TagsDecorator> };
+export type GuiTagsShortcut = GuiShortcutOf<'TAGS', TagsEntry>;

--- a/libs/gui/shared/src/lib/schemas/components/tags.schema.json
+++ b/libs/gui/shared/src/lib/schemas/components/tags.schema.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://golemui.com/schemas/components/tags.schema.json",
+  "title": "Tags Widget",
+  "type": "object",
+  "$defs": {
+    "disabledDef": {
+      "$ref": "../common.schema.json#/$defs/boolOrWhen"
+    },
+    "readonlyDef": {
+      "$ref": "../common.schema.json#/$defs/boolOrWhen"
+    },
+    "labelDef": {
+      "$ref": "../common.schema.json#/$defs/localizable"
+    },
+    "hintProp": {
+      "$ref": "../common.schema.json#/$defs/localizable"
+    },
+    "placeholderProp": {
+      "$ref": "../common.schema.json#/$defs/localizable"
+    },
+    "iconProp": {
+      "type": "string"
+    },
+    "separatorsProp": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "allowDuplicatesProp": {
+      "type": "boolean"
+    },
+    "trimProp": {
+      "type": "boolean"
+    },
+    "limitProp": {
+      "type": "number"
+    },
+    "removeAriaLabelProp": {
+      "$ref": "../common.schema.json#/$defs/localizable"
+    },
+    "removeIconProp": {
+      "type": "string"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "../common.schema.json#/$defs/baseWidget"
+    }
+  ],
+  "properties": {
+    "kind": {
+      "const": "input"
+    },
+    "type": {
+      "const": "tags"
+    },
+    "path": {
+      "$ref": "../common.schema.json#/$defs/dotPath"
+    },
+    "label": {
+      "$ref": "#/$defs/labelDef"
+    },
+    "disabled": {
+      "$ref": "#/$defs/disabledDef"
+    },
+    "readonly": {
+      "$ref": "#/$defs/readonlyDef"
+    },
+    "on": {
+      "$ref": "../common.schema.json#/$defs/on"
+    },
+    "validator": {
+      "$ref": "../validators.schema.json#/$defs/validator"
+    },
+    "defaultValue": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "props": {
+      "type": "object",
+      "properties": {
+        "hint": {
+          "$ref": "#/$defs/hintProp"
+        },
+        "placeholder": {
+          "$ref": "#/$defs/placeholderProp"
+        },
+        "icon": {
+          "$ref": "#/$defs/iconProp"
+        },
+        "separators": {
+          "$ref": "#/$defs/separatorsProp"
+        },
+        "allowDuplicates": {
+          "$ref": "#/$defs/allowDuplicatesProp"
+        },
+        "trim": {
+          "$ref": "#/$defs/trimProp"
+        },
+        "limit": {
+          "$ref": "#/$defs/limitProp"
+        },
+        "removeAriaLabel": {
+          "$ref": "#/$defs/removeAriaLabelProp"
+        },
+        "removeIcon": {
+          "$ref": "#/$defs/removeIconProp"
+        }
+      },
+      "patternProperties": {
+        "^hint\\.[^.]+$": {
+          "$ref": "#/$defs/hintProp"
+        },
+        "^placeholder\\.[^.]+$": {
+          "$ref": "#/$defs/placeholderProp"
+        },
+        "^icon\\.[^.]+$": {
+          "$ref": "#/$defs/iconProp"
+        },
+        "^separators\\.[^.]+$": {
+          "$ref": "#/$defs/separatorsProp"
+        },
+        "^allowDuplicates\\.[^.]+$": {
+          "$ref": "#/$defs/allowDuplicatesProp"
+        },
+        "^trim\\.[^.]+$": {
+          "$ref": "#/$defs/trimProp"
+        },
+        "^limit\\.[^.]+$": {
+          "$ref": "#/$defs/limitProp"
+        },
+        "^removeAriaLabel\\.[^.]+$": {
+          "$ref": "#/$defs/removeAriaLabelProp"
+        },
+        "^removeIcon\\.[^.]+$": {
+          "$ref": "#/$defs/removeIconProp"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "patternProperties": {
+    "^disabled\\.[^.]+$": {
+      "$ref": "#/$defs/disabledDef"
+    },
+    "^readonly\\.[^.]+$": {
+      "$ref": "#/$defs/readonlyDef"
+    },
+    "^label\\.[^.]+$": {
+      "$ref": "#/$defs/labelDef"
+    }
+  },
+  "required": ["kind", "type", "path"],
+  "unevaluatedProperties": false
+}

--- a/libs/gui/shared/src/lib/schemas/components/tags.schema.spec.ts
+++ b/libs/gui/shared/src/lib/schemas/components/tags.schema.spec.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Ajv2020 from 'ajv/dist/2020';
+import {
+  type GetSchema,
+  registerGolemSchemas,
+  specValidationErrorsLogger,
+} from '../schema.spec.utils';
+import { golemForm } from '../../golem-form';
+
+const SCHEMA_ID_UNDER_TEST = 'https://golemui.com/schemas/components/tags.schema.json';
+
+describe('Tags schema validation', () => {
+  let ajv: Ajv2020;
+  let validate: GetSchema;
+
+  beforeEach(() => {
+    ajv = new Ajv2020({
+      allErrors: true,
+      strict: false,
+      verbose: true,
+    });
+    registerGolemSchemas(ajv);
+    validate = ajv.getSchema(SCHEMA_ID_UNDER_TEST) as GetSchema;
+    if (!validate) {
+      throw new Error(`Schema ${SCHEMA_ID_UNDER_TEST} was not found in the registry.`);
+    }
+  });
+
+  describe('Valid configurations', () => {
+    it('should validate a minimum valid tags definition', () => {
+      const formDef = golemForm().create({
+        form: [
+          {
+            uid: 'tags-1',
+            path: 'keywords',
+            kind: 'input',
+            type: 'tags',
+          },
+        ],
+      });
+
+      const widget = formDef.form.children[0];
+      const isValid = validate(widget);
+      if (!isValid) specValidationErrorsLogger(validate, widget);
+      expect(isValid).toBe(true);
+    });
+
+    it('should validate all valid props', () => {
+      const formDef = golemForm().create({
+        form: [
+          {
+            uid: 'tags-1',
+            path: 'keywords',
+            kind: 'input',
+            type: 'tags',
+            props: {
+              hint: 'Press Enter to add',
+              placeholder: 'Add a tag…',
+              separators: ['Enter', ','],
+              allowDuplicates: false,
+              trim: true,
+              limit: 5,
+              removeAriaLabel: 'Remove tag',
+              removeIcon: 'mdi-close',
+            },
+          },
+        ],
+      });
+
+      const widget = formDef.form.children[0];
+      const isValid = validate(widget);
+      if (!isValid) specValidationErrorsLogger(validate, widget);
+      expect(isValid).toBe(true);
+    });
+
+    it('should validate state-scoped properties', () => {
+      const formDef = golemForm().create({
+        form: [
+          {
+            uid: 'tags-1',
+            path: 'keywords',
+            kind: 'input',
+            type: 'tags',
+            props: {
+              limit: 5,
+              'limit.isFreePlan': 3,
+            },
+          },
+        ],
+      });
+
+      const widget = formDef.form.children[0];
+      const isValid = validate(widget);
+      if (!isValid) specValidationErrorsLogger(validate, widget);
+      expect(isValid).toBe(true);
+    });
+
+    it('should validate i18n localizable properties', () => {
+      const formDef = golemForm().create({
+        form: [
+          {
+            uid: 'tags-1',
+            path: 'keywords',
+            kind: 'input',
+            type: 'tags',
+            label: { key: 'tags.label', default: 'Tags' },
+            props: {
+              hint: { key: 'tags.hint', default: 'Press Enter' },
+              placeholder: { key: 'tags.placeholder', default: 'Add a tag…' },
+              removeAriaLabel: { key: 'tags.remove', default: 'Remove tag' },
+            },
+          },
+        ],
+      });
+
+      const widget = formDef.form.children[0];
+      const isValid = validate(widget);
+      if (!isValid) specValidationErrorsLogger(validate, widget);
+      expect(isValid).toBe(true);
+    });
+
+    it('should validate a defaultValue array of strings', () => {
+      const formDef = golemForm().create({
+        form: [
+          {
+            uid: 'tags-1',
+            path: 'keywords',
+            kind: 'input',
+            type: 'tags',
+            defaultValue: ['hello', 'world'],
+          },
+        ],
+      });
+
+      const widget = formDef.form.children[0];
+      const isValid = validate(widget);
+      if (!isValid) specValidationErrorsLogger(validate, widget);
+      expect(isValid).toBe(true);
+    });
+  });
+
+  describe('validator field', () => {
+    it('should validate an array validator with required, minItems, maxItems, uniqueItems', () => {
+      const formDef = golemForm().create({
+        form: [
+          {
+            path: 'keywords',
+            kind: 'input',
+            type: 'tags',
+            validator: {
+              type: 'array',
+              required: true,
+              minItems: 1,
+              maxItems: 5,
+              uniqueItems: true,
+              messages: {
+                required: 'At least one tag is required',
+                minItems: 'Add at least one tag',
+                maxItems: 'No more than 5 tags',
+              },
+            },
+          },
+        ],
+      });
+
+      const widget = formDef.form.children[0];
+      const isValid = validate(widget);
+      if (!isValid) specValidationErrorsLogger(validate, widget);
+      expect(isValid).toBe(true);
+    });
+  });
+
+  describe('Invalid configurations', () => {
+    it('should fail on invalid type for limit', () => {
+      const formDef = golemForm().create({
+        form: [
+          // @ts-expect-error Expected, invalid type for limit
+          {
+            uid: 'tags-1',
+            path: 'keywords',
+            kind: 'input',
+            type: 'tags',
+            props: {
+              limit: 'five',
+            },
+          },
+        ],
+      });
+
+      const widget = formDef.form.children[0];
+      const isValid = validate(widget);
+      expect(isValid).toBe(false);
+      expect(
+        validate.errors?.some((e) => e.keyword === 'type' && e.instancePath === '/props/limit'),
+      ).toBe(true);
+    });
+
+    it('should fail on unknown prop', () => {
+      const formDef = golemForm().create({
+        form: [
+          // @ts-expect-error Expected, unknown prop
+          {
+            uid: 'tags-1',
+            path: 'keywords',
+            kind: 'input',
+            type: 'tags',
+            props: {
+              foo: 'bar',
+            },
+          },
+        ],
+      });
+
+      const widget = formDef.form.children[0];
+      const isValid = validate(widget);
+      expect(isValid).toBe(false);
+    });
+  });
+});

--- a/libs/gui/shared/src/lib/schemas/form.schema.json
+++ b/libs/gui/shared/src/lib/schemas/form.schema.json
@@ -103,6 +103,9 @@
           "$ref": "./components/tabs.schema.json"
         },
         {
+          "$ref": "./components/tags.schema.json"
+        },
+        {
           "$ref": "./components/textarea.schema.json"
         },
         {

--- a/libs/gui/shared/src/lib/widget.props.ts
+++ b/libs/gui/shared/src/lib/widget.props.ts
@@ -28,6 +28,20 @@ export type TextinputProps = {
   autocomplete?: Autocomplete;
 };
 
+export type TagsSeparator = 'Enter' | ',' | 'Tab' | 'blur' | (string & {});
+
+export type TagsProps = {
+  hint?: string;
+  placeholder?: string;
+  icon?: string;
+  separators?: TagsSeparator[];
+  allowDuplicates?: boolean;
+  trim?: boolean;
+  limit?: number;
+  removeAriaLabel?: string;
+  removeIcon?: string;
+};
+
 export type PasswordProps = {
   hint?: string;
   placeholder?: string;

--- a/libs/gui/shared/src/lib/widgets.ts
+++ b/libs/gui/shared/src/lib/widgets.ts
@@ -15,6 +15,7 @@ export const inputWidgets = [
   'rangeDatePicker',
   'repeater',
   'select',
+  'tags',
   'textarea',
   'textinput',
   'toggle',

--- a/libs/gui/vue/src/lib/components/Dropdown.vue
+++ b/libs/gui/vue/src/lib/components/Dropdown.vue
@@ -264,6 +264,7 @@ const ItemRenderer = computed<Component>(() => {
         type="text"
         :id="uid"
         :data-cy="`${uid}_textinput`"
+        class="gui-widget-input"
         :required="required"
         :disabled="isDisabled"
         :readonly="isReadOnly"

--- a/libs/gui/vue/src/lib/components/Tags.vue
+++ b/libs/gui/vue/src/lib/components/Tags.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import type { InputWidget, Validator, WithWidget } from '@golemui/core';
+import { useInputWidget } from '@golemui/vue';
+import type { TagsProps } from '@golemui/gui-shared';
+import { computed } from 'vue';
+import '@golemui/gui-components/tags';
+
+const props = defineProps<WithWidget>();
+const widget = props.widget as InputWidget<string[]>;
+const { uid, errors, value, isTouched, templateData, onValueChanged, onBlur } = useInputWidget<
+  string[],
+  TagsProps
+>(widget);
+
+const handleChange = (e: Event) =>
+  onValueChanged((e as CustomEvent).detail.value as string[]);
+
+const required = computed(() => (templateData.value.validator as Validator)?.required);
+</script>
+
+<template>
+  <div class="gui-tags gui-field" :style="{ flex: templateData.size }">
+    <gui-tags
+      :uid="uid"
+      :label="templateData.label"
+      :hint="templateData.hint"
+      :errors="errors"
+      :touched="isTouched"
+      :required="required"
+      :disabled="templateData.disabled"
+      :readOnly="templateData.readonly"
+      :value="value"
+      :placeholder="templateData.placeholder ?? undefined"
+      :icon="templateData.icon"
+      :separators="templateData.separators"
+      :allowDuplicates="templateData.allowDuplicates ?? true"
+      :trim="templateData.trim ?? true"
+      :limit="templateData.limit"
+      :removeAriaLabel="templateData.removeAriaLabel"
+      :removeIcon="templateData.removeIcon"
+      @change="handleChange"
+      @blur="onBlur"
+    ></gui-tags>
+  </div>
+</template>

--- a/libs/gui/vue/src/lib/widget.loaders.ts
+++ b/libs/gui/vue/src/lib/widget.loaders.ts
@@ -25,6 +25,7 @@ export const widgetLoaders: WidgetLoaders<Component<WithWidget>, GolemWidget> = 
   rangeCalendar: async () => (await import('./components/RangeCalendar.vue')).default,
   rangeDateInput: async () => (await import('./components/RangeDateInput.vue')).default,
   rangeDatePicker: async () => (await import('./components/RangeDatePicker.vue')).default,
+  tags: async () => (await import('./components/Tags.vue')).default,
 
   // REPEATER
   repeater: async () => (await import('./components/Repeater.vue')).default,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -52,6 +52,7 @@
         "libs/gui/components/src/lib/components/range-date-input.ts"
       ],
       "@golemui/gui-components/select": ["libs/gui/components/src/lib/components/select.ts"],
+      "@golemui/gui-components/tags": ["libs/gui/components/src/lib/components/tags.ts"],
       "@golemui/gui-components/textarea": ["libs/gui/components/src/lib/components/textarea.ts"],
       "@golemui/gui-components/textinput": ["libs/gui/components/src/lib/components/textinput.ts"],
       "@golemui/gui-components/toggle": ["libs/gui/components/src/lib/components/toggle.ts"],


### PR DESCRIPTION
- Add tags widget
- Add new `.gui-widget-input` class to mark the element that acts as an input
- Add tags to dx
- Create new pill mixin to share with other widgets
- Update docs
- Update schemas
- Update kitchen sink