### PR TITLE
fix(angular): add signals interface for angular item renderers

### DIFF
--- a/apps/angular-playground/src/app/item-renderers/airport.item-renderer.ts
+++ b/apps/angular-playground/src/app/item-renderers/airport.item-renderer.ts
@@ -1,5 +1,5 @@
-import { Component, Input } from '@angular/core';
-import { type ItemRenderContext } from '@golemui/core';
+import { Component, input } from '@angular/core';
+import { type AngularItemRenderContext } from '@golemui/angular';
 import { type AirportItem } from '@golemui/apps-shared';
 
 @Component({
@@ -39,24 +39,24 @@ import { type AirportItem } from '@golemui/apps-shared';
   `,
   template: `<div
     class="airport-renderer"
-    [class.disabled]="disabled"
-    [class.selected]="selected"
-    [class.focused]="focused"
-    [class.odd]="index % 2"
+    [class.disabled]="disabled()"
+    [class.selected]="selected()"
+    [class.focused]="focused()"
+    [class.odd]="index() % 2"
   >
     <div>
-      <p>{{ template.name }}</p>
+      <p>{{ template().name }}</p>
     </div>
     <div>
-      <h2>{{ template.iata }}</h2>
+      <h2>{{ template().iata }}</h2>
     </div>
   </div>`,
 })
-export class AirportItemRenderer implements ItemRenderContext<AirportItem> {
-  @Input({ required: true }) template!: AirportItem;
-  @Input({ required: true }) value!: string | number;
-  @Input({ required: true }) index!: number;
-  @Input() selected?: boolean;
-  @Input() disabled?: boolean;
-  @Input() focused?: boolean;
+export class AirportItemRenderer implements AngularItemRenderContext<AirportItem> {
+  template = input.required<AirportItem>();
+  value = input.required<string | number>();
+  index = input.required<number>();
+  selected = input<boolean | undefined>(undefined);
+  disabled = input<boolean | undefined>(undefined);
+  focused = input<boolean | undefined>(undefined);
 }

--- a/apps/angular-playground/src/app/item-renderers/complex-list.item-renderer.ts
+++ b/apps/angular-playground/src/app/item-renderers/complex-list.item-renderer.ts
@@ -1,5 +1,5 @@
-import { Component, Input } from '@angular/core';
-import { type ItemRenderContext } from '@golemui/core';
+import { Component, input } from '@angular/core';
+import { type AngularItemRenderContext } from '@golemui/angular';
 
 type ComplexItem = {
   title: string;
@@ -42,20 +42,20 @@ type ComplexItem = {
   `,
   template: `<div
     class="product-renderer"
-    [class.disabled]="disabled"
-    [class.selected]="selected"
-    [class.focused]="focused"
-    [class.odd]="index % 2"
+    [class.disabled]="disabled()"
+    [class.selected]="selected()"
+    [class.focused]="focused()"
+    [class.odd]="index() % 2"
   >
-    <h2>{{ template.title }}</h2>
-    <p>{{ template.description }}</p>
+    <h2>{{ template().title }}</h2>
+    <p>{{ template().description }}</p>
   </div>`,
 })
-export class ComplexListItemRenderer implements ItemRenderContext<ComplexItem> {
-  @Input({ required: true }) template!: ComplexItem;
-  @Input({ required: true }) value!: string | number;
-  @Input({ required: true }) index!: number;
-  @Input() selected?: boolean;
-  @Input() disabled?: boolean;
-  @Input() focused?: boolean;
+export class ComplexListItemRenderer implements AngularItemRenderContext<ComplexItem> {
+  template = input.required<ComplexItem>();
+  value = input.required<string | number>();
+  index = input.required<number>();
+  selected = input<boolean | undefined>(undefined);
+  disabled = input<boolean | undefined>(undefined);
+  focused = input<boolean | undefined>(undefined);
 }

--- a/apps/angular-playground/src/app/item-renderers/country.item-renderer.ts
+++ b/apps/angular-playground/src/app/item-renderers/country.item-renderer.ts
@@ -1,5 +1,5 @@
-import { Component, Input } from '@angular/core';
-import { type ItemRenderContext } from '@golemui/core';
+import { Component, input } from '@angular/core';
+import { type AngularItemRenderContext } from '@golemui/angular';
 
 type CountryItem = {
   id: string;
@@ -47,19 +47,19 @@ type CountryItem = {
   `,
   template: `<div
     class="country-renderer"
-    [class.selected]="selected"
-    [class.focused]="focused"
-    [class.odd]="index % 2"
+    [class.selected]="selected()"
+    [class.focused]="focused()"
+    [class.odd]="index() % 2"
   >
-    <span>{{ template.label }}</span>
-    <span>{{ template.flag }}</span>
+    <span>{{ template().label }}</span>
+    <span>{{ template().flag }}</span>
   </div>`,
 })
-export class CountryItemRenderer implements ItemRenderContext<CountryItem> {
-  @Input({ required: true }) template!: CountryItem;
-  @Input({ required: true }) value!: string | number;
-  @Input({ required: true }) index!: number;
-  @Input() selected?: boolean;
-  @Input() disabled?: boolean;
-  @Input() focused?: boolean;
+export class CountryItemRenderer implements AngularItemRenderContext<CountryItem> {
+  template = input.required<CountryItem>();
+  value = input.required<string | number>();
+  index = input.required<number>();
+  selected = input<boolean | undefined>(undefined);
+  disabled = input<boolean | undefined>(undefined);
+  focused = input<boolean | undefined>(undefined);
 }

--- a/apps/angular-playground/src/app/item-renderers/product.item-renderer.ts
+++ b/apps/angular-playground/src/app/item-renderers/product.item-renderer.ts
@@ -1,5 +1,5 @@
-import { Component, Input } from '@angular/core';
-import { type ItemRenderContext } from '@golemui/core';
+import { Component, input } from '@angular/core';
+import { type AngularItemRenderContext } from '@golemui/angular';
 
 type ProductItem = {
   product: string;
@@ -44,25 +44,25 @@ type ProductItem = {
   `,
   template: `<div
     class="product-renderer"
-    [class.disabled]="disabled"
-    [class.selected]="selected"
-    [class.focused]="focused"
-    [class.odd]="index % 2"
+    [class.disabled]="disabled()"
+    [class.selected]="selected()"
+    [class.focused]="focused()"
+    [class.odd]="index() % 2"
   >
     <div>
-      <h2>{{ template.product }}</h2>
-      <p>{{ template.description }}</p>
+      <h2>{{ template().product }}</h2>
+      <p>{{ template().description }}</p>
     </div>
     <div>
-      <p>{{ template.price }}</p>
+      <p>{{ template().price }}</p>
     </div>
   </div>`,
 })
-export class ProductItemRenderer implements ItemRenderContext<ProductItem> {
-  @Input({ required: true }) template!: ProductItem;
-  @Input({ required: true }) value!: string | number;
-  @Input({ required: true }) index!: number;
-  @Input() selected?: boolean;
-  @Input() disabled?: boolean;
-  @Input() focused?: boolean;
+export class ProductItemRenderer implements AngularItemRenderContext<ProductItem> {
+  template = input.required<ProductItem>();
+  value = input.required<string | number>();
+  index = input.required<number>();
+  selected = input<boolean | undefined>(undefined);
+  disabled = input<boolean | undefined>(undefined);
+  focused = input<boolean | undefined>(undefined);
 }

--- a/docs/src/content/docs/extending/item-renderers.mdx
+++ b/docs/src/content/docs/extending/item-renderers.mdx
@@ -14,12 +14,12 @@ Item renderers are framework-specific functions or components that the form engi
 
 Each framework adapts the same `ItemRenderContext<T>` to its idiomatic shape:
 
-| Framework | Type                     | What the engine passes                                                                              |
-| --------- | ------------------------ | --------------------------------------------------------------------------------------------------- |
-| React     | `ReactItemRenderer<T>`   | A `React.ComponentType<ItemRenderContext<T>>` — the context fields arrive as props.                 |
-| Angular   | `AngularItemRenderer<T>` | A `Type<ItemRenderContext<T>>` — the component declares a signal `input()` for each context field.  |
-| Lit       | `LitItemRenderer<T>`     | A `(ctx: ItemRenderContext<T>) => TemplateResult` — called as a function, **not** a custom element. |
-| Vue       | `VueItemRenderer<T>`     | A `Component<Partial<ItemRenderContext<T>>>` — the context fields arrive as props on the SFC.       |
+| Framework | Type                     | What the engine passes                                                                                                    |
+| --------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| React     | `ReactItemRenderer<T>`   | A `React.ComponentType<ItemRenderContext<T>>` — the context fields arrive as props.                                       |
+| Angular   | `AngularItemRenderer<T>` | A component class structurally matching `AngularItemRenderContext<T>` — one signal `input()` per context field. |
+| Lit       | `LitItemRenderer<T>`     | A `(ctx: ItemRenderContext<T>) => TemplateResult` — called as a function, **not** a custom element.                       |
+| Vue       | `VueItemRenderer<T>`     | A `Component<Partial<ItemRenderContext<T>>>` — the context fields arrive as props on the SFC.                             |
 
 The shared context shape comes from `@golemui/core`:
 
@@ -69,6 +69,7 @@ export interface ItemRenderContext<T extends ItemRenderItemData> {
   <Fragment slot="angular">
     ```ts
     import { Component, input } from '@angular/core';
+    import { type AngularItemRenderContext } from '@golemui/angular';
 
     type Country = { id: string; flag: string; label: string };
 
@@ -88,17 +89,40 @@ export interface ItemRenderContext<T extends ItemRenderItemData> {
         </div>
       `,
     })
-    export class CountryItemRenderer {
+    export class CountryItemRenderer implements AngularItemRenderContext<Country> {
       template = input.required<Country>();
       value = input.required<string | number>();
       index = input.required<number>();
-      selected = input<boolean>();
-      disabled = input<boolean>();
-      focused = input<boolean>();
+      selected = input<boolean | undefined>(undefined);
+      disabled = input<boolean | undefined>(undefined);
+      focused = input<boolean | undefined>(undefined);
     }
     ```
 
-    The component declares one signal input per context field; the engine binds each one when rendering an item. Read each value by calling the signal — `template().flag`, `selected()`, etc.
+    Declare one signal input per context field; the engine binds each one when rendering an item. Read each value by calling the signal — `template().flag`, `selected()`, etc.
+
+    `implements AngularItemRenderContext<T>` is the recommended contract for signal-based renderers: TypeScript enforces the full set of inputs and their signal types, so a missing or mistyped field is a compile error.
+
+    :::note[Backwards compatibility with `@Input()`]
+    Renderers written with the classic `@Input()` decorator stay supported — `AngularItemRenderer<T>` accepts both styles. For those, keep using `implements ItemRenderContext<T>` from `@golemui/core`:
+
+    ```ts
+    import { Component, Input } from '@angular/core';
+    import { type ItemRenderContext } from '@golemui/core';
+
+    @Component({ /* ... */ })
+    export class CountryItemRenderer implements ItemRenderContext<Country> {
+      @Input({ required: true }) template!: Country;
+      @Input({ required: true }) value!: string | number;
+      @Input({ required: true }) index!: number;
+      @Input() selected?: boolean;
+      @Input() disabled?: boolean;
+      @Input() focused?: boolean;
+    }
+    ```
+
+    Reach for `AngularItemRenderContext<T>` only when you opt in to signal inputs — the field types are different (`InputSignal<T>` vs. plain `T`), so the two interfaces are not interchangeable on the same class.
+    :::
 
   </Fragment>
   <Fragment slot="lit">

--- a/docs/src/content/docs/getting-started/rent-a-car-renderer.mdx
+++ b/docs/src/content/docs/getting-started/rent-a-car-renderer.mdx
@@ -53,8 +53,8 @@ Item renderers are framework-specific components.
   <Fragment slot="angular">
     ```ts
     // car-item-renderer.component.ts
-    import { Component } from '@angular/core';
-    import type { AngularItemRenderer } from '@golemui/angular';
+    import { Component, input } from '@angular/core';
+    import { type AngularItemRenderContext } from '@golemui/angular';
 
     type Car = { id: string; label: string; img: string; price: number };
 
@@ -63,16 +63,23 @@ Item renderers are framework-specific components.
       selector: 'car-item-renderer',
       template: `
         <div class="car-item">
-          <span class="car-item__img">{{ item.img }}</span>
-          <span class="car-item__label">{{ item.label }}</span>
-          <span class="car-item__price">\${{ item.price }}/day</span>
+          <span class="car-item__img">{{ template().img }}</span>
+          <span class="car-item__label">{{ template().label }}</span>
+          <span class="car-item__price">\${{ template().price }}/day</span>
         </div>
       `,
     })
-    export class CarItemRenderer implements AngularItemRenderer<Car> {
-      item!: Car;
+    export class CarItemRenderer implements AngularItemRenderContext<Car> {
+      template = input.required<Car>();
+      value = input.required<string | number>();
+      index = input.required<number>();
+      selected = input<boolean | undefined>(undefined);
+      disabled = input<boolean | undefined>(undefined);
+      focused = input<boolean | undefined>(undefined);
     }
     ```
+
+    `implements AngularItemRenderContext<Car>` is the contract for signal-based renderers — TypeScript enforces every input. If you prefer the classic `@Input()` decorator style, `implements ItemRenderContext<Car>` from `@golemui/core` works instead; see [Extending / Item Renderers](/extending/item-renderers/) for both forms.
 
   </Fragment>
   <Fragment slot="lit">

--- a/libs/angular/src/index.ts
+++ b/libs/angular/src/index.ts
@@ -4,7 +4,10 @@ export { InputWidgetAdapter } from './lib/adapters/input-widget-adapter.service'
 export { LayoutWidgetAdapter } from './lib/adapters/layout-widget-adapter.service';
 
 export { FormCoreComponent } from './lib/components/form/form.component';
-export type { AngularItemRenderer } from './lib/components/item-renderers/item-renderer';
+export type {
+  AngularItemRenderContext,
+  AngularItemRenderer,
+} from './lib/components/item-renderers/item-renderer';
 export { AngularFormContext } from './lib/context/form.context';
 export { RepeaterWidgetDirective } from './lib/directives/repeater-widget.directive';
 export { WidgetDirective } from './lib/directives/widget.directive';

--- a/libs/angular/src/lib/components/item-renderers/item-renderer.ts
+++ b/libs/angular/src/lib/components/item-renderers/item-renderer.ts
@@ -3,13 +3,33 @@ import type { ItemRenderContext, ItemRenderItemData } from '@golemui/core';
 
 type SignalOrValue<T> = T | InputSignal<T> | InputSignalWithTransform<T, any>;
 
-type AngularItemRenderContext<T extends ItemRenderItemData> = {
+type AngularItemRendererInputs<T extends ItemRenderItemData> = {
   [K in keyof ItemRenderContext<T>]: SignalOrValue<ItemRenderContext<T>[K]>;
 };
+
+/**
+ * The author-facing contract for signal-based Angular item renderers.
+ * Declare a renderer class with `implements AngularItemRenderContext<T>` so the
+ * TypeScript compiler enforces the full set of inputs (`template`, `value`,
+ * `index`, `selected`, `disabled`, `focused`) and their signal types.
+ *
+ * For `@Input()`-decorator renderers, keep using `ItemRenderContext<T>` from
+ * `@golemui/core` — its plain-value fields match decorator-typed properties.
+ *
+ * @template T The type of the data item.
+ */
+export interface AngularItemRenderContext<T extends ItemRenderItemData> {
+  template: InputSignal<T>;
+  value: InputSignal<string | number>;
+  index: InputSignal<number>;
+  selected: InputSignal<boolean | undefined>;
+  disabled: InputSignal<boolean | undefined>;
+  focused: InputSignal<boolean | undefined>;
+}
 
 /**
  * The Angular-specific Core.ItemRenderer type.
  * Accepts components declared with either `@Input()` or signal `input()`.
  * @template T The type of the data item.
  */
-export type AngularItemRenderer<T extends ItemRenderItemData> = Type<AngularItemRenderContext<T>>;
+export type AngularItemRenderer<T extends ItemRenderItemData> = Type<AngularItemRendererInputs<T>>;

--- a/libs/gui/angular/src/index.ts
+++ b/libs/gui/angular/src/index.ts
@@ -1,2 +1,3 @@
 export { FormComponent } from './lib/components/form/form.component';
 export { widgetLoaders } from './lib/widget.loaders';
+export type { AngularItemRenderContext, AngularItemRenderer } from '@golemui/angular';

--- a/libs/gui/angular/src/lib/components/list/default-list.item-renderer.ts
+++ b/libs/gui/angular/src/lib/components/list/default-list.item-renderer.ts
@@ -1,4 +1,5 @@
 import { Component, input } from '@angular/core';
+import { type AngularItemRenderContext } from '@golemui/angular';
 
 @Component({
   selector: 'gui-default-list-item-renderer',
@@ -15,7 +16,7 @@ import { Component, input } from '@angular/core';
     class: 'gui-default-list-item-renderer',
   },
 })
-export class DefaultListItemRenderer {
+export class DefaultListItemRenderer implements AngularItemRenderContext<string> {
   template = input.required<string>();
   value = input.required<string | number>();
   index = input.required<number>();

--- a/templates/angular/src/app/currency-item-renderer.component.ts
+++ b/templates/angular/src/app/currency-item-renderer.component.ts
@@ -1,4 +1,5 @@
 import { Component, input } from '@angular/core';
+import { type AngularItemRenderContext } from '@golemui/angular';
 
 export type CurrencyItem = { code: string; symbol: string; name: string };
 
@@ -51,7 +52,7 @@ export type CurrencyItem = { code: string; symbol: string; name: string };
     </div>
   `,
 })
-export class CurrencyItemRenderer {
+export class CurrencyItemRenderer implements AngularItemRenderContext<CurrencyItem> {
   template = input.required<CurrencyItem>();
   value = input.required<string | number>();
   index = input.required<number>();


### PR DESCRIPTION
Add `AngularItemRenderContext` signals interface for Angular item renderers.

```ts
export class AirportItemRenderer implements AngularItemRenderContext<AirportItem> {
  template = input.required<AirportItem>();
  value = input.required<string | number>();
  index = input.required<number>();
  selected = input<boolean | undefined>(undefined);
  disabled = input<boolean | undefined>(undefined);
  focused = input<boolean | undefined>(undefined);
}
```