### PR TITLE
fix(mcp): add missing rollup-generated chunk files

### DIFF
--- a/libs/gui/mcp/package.json
+++ b/libs/gui/mcp/package.json
@@ -16,9 +16,13 @@
     "golemui-mcp": "./cli.js"
   },
   "files": [
-    "lib.js",
-    "lib.d.ts",
-    "cli.js",
+    "*.js",
+    "*.d.ts",
+    "tools",
+    "mapping",
+    "schemas",
+    "utils",
+    "lint",
     "*.md"
   ],
   "keywords": [
@@ -30,10 +34,15 @@
     "json-schema"
   ],
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "@golemui/gui-schemas": "*"
+  },
+  "peerDependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "devDependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/libs/gui/mcp/vite.config.ts
+++ b/libs/gui/mcp/vite.config.ts
@@ -35,8 +35,6 @@ export default defineConfig(() => ({
       output: {
         // shebang only on the CLI bundle
         banner: (chunk) => (chunk.name === 'cli' ? '#!/usr/bin/env node' : ''),
-        // deterministic chunk names - no content hash, easier to inspect
-        chunkFileNames: '[name].js',
       },
     },
   },

--- a/libs/gui/mcp/vite.config.ts
+++ b/libs/gui/mcp/vite.config.ts
@@ -35,6 +35,8 @@ export default defineConfig(() => ({
       output: {
         // shebang only on the CLI bundle
         banner: (chunk) => (chunk.name === 'cli' ? '#!/usr/bin/env node' : ''),
+        // deterministic chunk names - no content hash, easier to inspect
+        chunkFileNames: '[name].js',
       },
     },
   },


### PR DESCRIPTION
## Description

- **libs/gui/mcp/package.json**: files changed from `["lib.js", "lib.d.ts", "cli.js", "*.md"]` to `["*.js", "*.d.ts", "tools", "mapping", ...]`. Without it, rollup-generated chunk files are silently missing from the published package and any consumer gets a broken import.