### PR TITLE
fix(gui-react): make the React adapter work on React 18

### DIFF
--- a/libs/gui/components/src/lib/components/radiogroup.ts
+++ b/libs/gui/components/src/lib/components/radiogroup.ts
@@ -24,7 +24,7 @@ export class GuiRadiogroup extends LitElement {
   @property({ type: String }) value: OptionValue | undefined = undefined;
 
   @property({ type: String }) hint: string | undefined = undefined;
-  @property({ type: String }) options: Option[] = [];
+  @property({ type: Array }) options: Option[] = [];
   @property({ type: String }) labelField: string | undefined = undefined;
   @property({ type: String }) valueField: string | undefined = undefined;
   @property({ type: String }) direction: 'row' | 'column' | undefined = 'column';

--- a/libs/gui/components/src/lib/components/select.ts
+++ b/libs/gui/components/src/lib/components/select.ts
@@ -27,7 +27,7 @@ export class GuiSelect extends LitElement {
   @property({ type: String }) hint: string | undefined = undefined;
   @property({ type: String }) icon: string | undefined = undefined;
   @property({ type: String }) autocomplete: string | undefined = undefined;
-  @property({ type: String }) options: Option[] = [];
+  @property({ type: Array }) options: Option[] = [];
   @property({ type: String }) placeholder: string | undefined = undefined;
   @property({ type: String }) labelField: string | undefined = undefined;
   @property({ type: String }) valueField: string | undefined = undefined;

--- a/libs/gui/react/cypress/test/golem-features/radiogroup.react18.cy.ts
+++ b/libs/gui/react/cypress/test/golem-features/radiogroup.react18.cy.ts
@@ -1,14 +1,8 @@
 import { gui } from '@golemui/gui-shared';
 import { mountFramework } from '../../support/mount';
 
-// Consumption-boundary regression: render the radiogroup through the React adapter on
-// React 18 — the floor @golemui/gui-react advertises ("react": ">=18.0.0").
-//
-// React <=18 passes object props to custom elements as *stringified attributes*; the
-// gui-radiogroup declares `options` with a String converter, so on React 18 `options`
-// arrives as a string and `this.options.find(...)` throws during render → no radios.
-// React 19 (and Lit/Vue/Angular) property-bind, which masks the bug — and the monorepo
-// runs React 19, so nothing else catches it. Run this spec with REACT18=1.
+// Pinned to React 18 (run with REACT18=1): red on 18, green on 19 — guards the adapter
+// against the React <=18 prop-stringification crash the React-19 monorepo can't otherwise see.
 describe('radiogroup via @golemui/gui-react on React 18', () => {
   it('renders its options without crashing', () => {
     mountFramework({

--- a/libs/gui/react/cypress/test/golem-features/radiogroup.react18.cy.ts
+++ b/libs/gui/react/cypress/test/golem-features/radiogroup.react18.cy.ts
@@ -1,0 +1,32 @@
+import { gui } from '@golemui/gui-shared';
+import { mountFramework } from '../../support/mount';
+
+// Consumption-boundary regression: render the radiogroup through the React adapter on
+// React 18 — the floor @golemui/gui-react advertises ("react": ">=18.0.0").
+//
+// React <=18 passes object props to custom elements as *stringified attributes*; the
+// gui-radiogroup declares `options` with a String converter, so on React 18 `options`
+// arrives as a string and `this.options.find(...)` throws during render → no radios.
+// React 19 (and Lit/Vue/Angular) property-bind, which masks the bug — and the monorepo
+// runs React 19, so nothing else catches it. Run this spec with REACT18=1.
+describe('radiogroup via @golemui/gui-react on React 18', () => {
+  it('renders its options without crashing', () => {
+    mountFramework({
+      formDef: [
+        gui.inputs.radiogroup('rentalType', {
+          label: 'Rental type',
+          options: [
+            { label: 'Daily', value: 'daily' },
+            { label: 'Weekly', value: 'weekly' },
+            { label: 'Monthly', value: 'monthly' },
+          ],
+        }),
+      ] as never,
+      data: {},
+    });
+
+    cy.get('gui-radiogroup').should('exist');
+    cy.get('gui-radiogroup input[type="radio"]').should('have.length', 3);
+    cy.get('gui-radiogroup').should('contain.text', 'Daily');
+  });
+});

--- a/libs/gui/react/package.json
+++ b/libs/gui/react/package.json
@@ -20,6 +20,9 @@
     "*.js",
     "*.md"
   ],
+  "dependencies": {
+    "@lit/react": "^1.0.8"
+  },
   "peerDependencies": {
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0",

--- a/libs/gui/react/src/lib/components/Button.tsx
+++ b/libs/gui/react/src/lib/components/Button.tsx
@@ -1,8 +1,9 @@
 import type { ActionWidget, WithWidget } from '@golemui/core';
 import { useActionWidget } from '@golemui/react';
-import '@golemui/gui-components/button';
+import { GuiButtonReact } from '../web-components';
 import '../styles.scss';
 import { type ButtonProps } from '@golemui/gui-shared';
+
 
 export function Button(widgetInstance: WithWidget) {
   const widget = widgetInstance.widget as ActionWidget;
@@ -10,7 +11,7 @@ export function Button(widgetInstance: WithWidget) {
 
   return (
     <div className="gui-button gui-field" style={{ flex: templateData.size }}>
-      <gui-button
+      <GuiButtonReact
         uid={uid}
         actionType={templateData.actionType ?? 'button'}
         label={templateData.label as string}

--- a/libs/gui/react/src/lib/components/Calendar.tsx
+++ b/libs/gui/react/src/lib/components/Calendar.tsx
@@ -2,7 +2,7 @@ import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useInputWidget } from '@golemui/react';
 import { type CalendarProps } from '@golemui/gui-shared';
 import { useCallback } from 'react';
-import '@golemui/gui-components/calendar';
+import { GuiCalendarReact } from '../web-components';
 import '../styles.scss';
 
 export function Calendar(widgetInstance: WithWidget) {
@@ -52,7 +52,7 @@ export function Calendar(widgetInstance: WithWidget) {
 
   return (
     <div className="gui-calendar gui-field" style={{ flex: templateData.size }}>
-      <gui-calendar
+      <GuiCalendarReact
         ref={handleRef}
         uid={uid}
         label={label}

--- a/libs/gui/react/src/lib/components/Checkbox.tsx
+++ b/libs/gui/react/src/lib/components/Checkbox.tsx
@@ -2,8 +2,9 @@ import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useInputWidget } from '@golemui/react';
 import { type CheckboxProps } from '@golemui/gui-shared';
 import { useCallback } from 'react';
-import '@golemui/gui-components/checkbox';
+import { GuiCheckboxReact } from '../web-components';
 import '../styles.scss';
+
 
 export function Checkbox(widgetInstance: WithWidget) {
   const widget = widgetInstance.widget as InputWidget<boolean>;
@@ -13,8 +14,7 @@ export function Checkbox(widgetInstance: WithWidget) {
   >(widget);
 
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) =>
-      onValueChanged((e.nativeEvent as CustomEvent).detail.value),
+    (e: Event) => onValueChanged((e as CustomEvent).detail.value),
     [onValueChanged],
   );
 
@@ -27,7 +27,7 @@ export function Checkbox(widgetInstance: WithWidget) {
 
   return (
     <div className={`gui-checkbox gui-field`} style={{ flex: templateData.size }}>
-      <gui-checkbox
+      <GuiCheckboxReact
         uid={uid}
         label={label}
         errors={errors}

--- a/libs/gui/react/src/lib/components/Currency.tsx
+++ b/libs/gui/react/src/lib/components/Currency.tsx
@@ -2,8 +2,9 @@ import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useInputWidget } from '@golemui/react';
 import { type CurrencyProps } from '@golemui/gui-shared';
 import { useCallback } from 'react';
-import '@golemui/gui-components/currency';
+import { GuiCurrencyReact } from '../web-components';
 import '../styles.scss';
+
 
 export function Currency(widgetInstance: WithWidget) {
   const widget = widgetInstance.widget as InputWidget<number>;
@@ -13,8 +14,7 @@ export function Currency(widgetInstance: WithWidget) {
   >(widget);
 
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) =>
-      onValueChanged((e.nativeEvent as CustomEvent).detail.value),
+    (e: Event) => onValueChanged((e as CustomEvent).detail.value),
     [onValueChanged],
   );
 
@@ -34,7 +34,7 @@ export function Currency(widgetInstance: WithWidget) {
 
   return (
     <div className="gui-currency gui-field" style={{ flex: templateData.size }}>
-      <gui-currency
+      <GuiCurrencyReact
         uid={uid}
         label={label}
         hint={hint}
@@ -54,7 +54,7 @@ export function Currency(widgetInstance: WithWidget) {
         localeId={lang}
         onInput={handleChange}
         onBlur={onBlur}
-      ></gui-currency>
+      ></GuiCurrencyReact>
     </div>
   );
 }

--- a/libs/gui/react/src/lib/components/DateInput.tsx
+++ b/libs/gui/react/src/lib/components/DateInput.tsx
@@ -2,7 +2,7 @@ import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useInputWidget } from '@golemui/react';
 import { type DatePickerProps } from '@golemui/gui-shared';
 import { useCallback } from 'react';
-import '@golemui/gui-components/date-input';
+import { GuiDateReact } from '../web-components';
 import '../styles.scss';
 
 export function DateInput(widgetInstance: WithWidget) {
@@ -54,7 +54,7 @@ export function DateInput(widgetInstance: WithWidget) {
 
   return (
     <div className="gui-date gui-field" style={{ flex: templateData.size }}>
-      <gui-date
+      <GuiDateReact
         ref={handleRef}
         uid={uid}
         label={label}

--- a/libs/gui/react/src/lib/components/DatePicker.tsx
+++ b/libs/gui/react/src/lib/components/DatePicker.tsx
@@ -2,10 +2,9 @@ import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useInputWidget } from '@golemui/react';
 import { type DatePickerProps } from '@golemui/gui-shared';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import '@golemui/gui-components/date-input';
-import '@golemui/gui-components/calendar';
 import '../styles.scss';
 import { Errors } from './shared/Errors';
+import { GuiCalendarReact, GuiDateReact } from '../web-components';
 
 export function DatePicker(widgetInstance: WithWidget) {
   const widget = widgetInstance.widget as InputWidget<string>;
@@ -175,7 +174,7 @@ export function DatePicker(widgetInstance: WithWidget) {
         }}
         aria-expanded={isCalendarOpen}
       >
-        <gui-date
+        <GuiDateReact
           ref={handleDateRef}
           uid={uid}
           hint={hint}
@@ -196,7 +195,7 @@ export function DatePicker(widgetInstance: WithWidget) {
         </span>
 
         {isCalendarOpen && (
-          <gui-calendar
+          <GuiCalendarReact
             ref={handleCalendarRef}
             uid={uid}
             hint={hint}

--- a/libs/gui/react/src/lib/components/Dropdown.tsx
+++ b/libs/gui/react/src/lib/components/Dropdown.tsx
@@ -1,21 +1,12 @@
+import { GuiErrorsReact, GuiLabelReact, GuiListReact } from '../web-components';
 import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useDebounceCallback, useInputWidget, useItemRenderer } from '@golemui/react';
 import { type DropdownProps, type ListItem, type OptionValue } from '@golemui/gui-shared';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DefaultListItemRenderer } from './item-renderers/DefaultListItemRenderer';
 import { type ListItemRendererProps } from './item-renderers/props';
-import '@golemui/gui-components/label';
-import '@golemui/gui-components/list';
-import '@golemui/gui-components/errors';
-
-interface GuiListElement extends HTMLElement {
-  focusItemAtIndex(index: number): void;
-  scrollToSelectedIndex(): void;
-}
-
-interface GuiLabelElement extends HTMLElement {
-  targetElement?: HTMLElement | HTMLElement[];
-}
+import type { GuiList } from '@golemui/gui-components/list';
+import type { GuiLabel } from '@golemui/gui-components/label';
 
 export function Dropdown(widgetInstance: WithWidget) {
   const widget = widgetInstance.widget as InputWidget<string | null>;
@@ -31,9 +22,9 @@ export function Dropdown(widgetInstance: WithWidget) {
   const [isListVisible, setIsListVisible] = useState(false);
   const [selectedItem, setSelectedItem] = useState<ListItem<never> | undefined>(undefined);
 
-  const listRef = useRef<GuiListElement>(null);
+  const listRef = useRef<GuiList>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const labelRef = useRef<GuiLabelElement>(null);
+  const labelRef = useRef<GuiLabel>(null);
 
   const visibleItems = useMemo(() => listItems.slice(range.start, range.end), [listItems, range]);
 
@@ -288,7 +279,7 @@ export function Dropdown(widgetInstance: WithWidget) {
 
   return (
     <div className="gui-dropdown gui-field" style={{ flex: templateData.size }}>
-      <gui-label
+      <GuiLabelReact
         ref={labelRef}
         uid={uid}
         label={label}
@@ -297,7 +288,7 @@ export function Dropdown(widgetInstance: WithWidget) {
         touched={isTouched}
         required={isRequired}
         native={false}
-      ></gui-label>
+      ></GuiLabelReact>
 
       <div className="gui-widget" aria-expanded={isListVisible}>
         <input
@@ -325,7 +316,7 @@ export function Dropdown(widgetInstance: WithWidget) {
           </svg>
         </span>
 
-        <gui-list
+        <GuiListReact
           ref={listRef}
           id={`${uid}-list`}
           uid={uid}
@@ -376,10 +367,12 @@ export function Dropdown(widgetInstance: WithWidget) {
               </div>
             );
           })}
-        </gui-list>
+        </GuiListReact>
       </div>
 
-      {showErrors && <gui-errors uid={uid} errors={errors} touched={isTouched}></gui-errors>}
+      {showErrors && (
+        <GuiErrorsReact uid={uid} errors={errors} touched={isTouched}></GuiErrorsReact>
+      )}
     </div>
   );
 }

--- a/libs/gui/react/src/lib/components/Form.tsx
+++ b/libs/gui/react/src/lib/components/Form.tsx
@@ -10,7 +10,7 @@ import { type GuiFormInitConfig } from '@golemui/gui-shared';
 import { resolveFormInput } from '@golemui/gui-shared/internals';
 import { initValidators } from '@golemui/gui-validators';
 import { FormComponent, type FormComponentHandle, type ReactItemRenderer } from '@golemui/react';
-import { type ComponentType, type Ref, useCallback, useMemo } from 'react';
+import { type ComponentType, forwardRef, useCallback, useMemo } from 'react';
 import { widgetLoaders as golemWidgetLoaders } from '../widget.loaders';
 
 export interface ReactFormComponentProps {
@@ -19,17 +19,12 @@ export interface ReactFormComponentProps {
   formEvent?: (event: FormEvent) => void;
   formSubmit?: (event: FormSubmitEvent) => void;
   formHealth?: (formHealth: FormHealth) => void;
-  ref?: Ref<FormComponentHandle>;
 }
 
-export function GuiForm({
-  config,
-  formHealth,
-  formEvent,
-  formSubmit,
-  autocomplete,
+export const GuiForm = forwardRef<FormComponentHandle, ReactFormComponentProps>(function GuiForm(
+  { config, formHealth, formEvent, formSubmit, autocomplete },
   ref,
-}: ReactFormComponentProps) {
+) {
   const resolved = useMemo(
     () => resolveFormInput(config.formDef, config.formSelectors, config.formConfig),
     [config],
@@ -83,4 +78,4 @@ export function GuiForm({
       formSubmit={formSubmit}
     />
   );
-}
+});

--- a/libs/gui/react/src/lib/components/List.tsx
+++ b/libs/gui/react/src/lib/components/List.tsx
@@ -1,16 +1,11 @@
+import { GuiErrorsReact, GuiLabelReact, GuiListReact } from '../web-components';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useInputWidget, useItemRenderer } from '@golemui/react';
 import { type ListItem, type ListProps, type OptionValue } from '@golemui/gui-shared';
 import { DefaultListItemRenderer } from './item-renderers/DefaultListItemRenderer';
 import { type ListItemRendererProps } from './item-renderers/props';
-import '@golemui/gui-components/label';
-import '@golemui/gui-components/list';
-import '@golemui/gui-components/errors';
-
-interface GuiListElement extends HTMLElement {
-  focusItemAtIndex(index: number): void;
-}
+import type { GuiList } from '@golemui/gui-components/list';
 
 export function List(widgetInstance: WithWidget) {
   const widget = widgetInstance.widget as InputWidget<OptionValue>;
@@ -36,7 +31,7 @@ export function List(widgetInstance: WithWidget) {
   const [listItems, setListItems] = useState<ListItem<any>[]>([]);
   const [focusedIndex, setFocusedIndex] = useState<number>(-1);
 
-  const listRef = useRef<GuiListElement>(null);
+  const listRef = useRef<GuiList>(null);
 
   const visibleItems = useMemo(() => {
     const items = listItems.length > 0 ? listItems : templateData.items || [];
@@ -106,7 +101,7 @@ export function List(widgetInstance: WithWidget) {
 
   return (
     <div className="gui-list gui-field" style={{ flex: templateData.size }}>
-      <gui-label
+      <GuiLabelReact
         targetElement={listRef.current || undefined}
         uid={uid}
         label={label}
@@ -115,10 +110,10 @@ export function List(widgetInstance: WithWidget) {
         touched={isTouched}
         required={isRequired}
         native={false}
-      ></gui-label>
+      ></GuiLabelReact>
 
       <div className="gui-widget">
-        <gui-list
+        <GuiListReact
           ref={listRef}
           id={uid}
           uid={uid}
@@ -168,10 +163,12 @@ export function List(widgetInstance: WithWidget) {
               </div>
             );
           })}
-        </gui-list>
+        </GuiListReact>
       </div>
 
-      {showErrors && <gui-errors uid={uid} errors={errors} touched={isTouched}></gui-errors>}
+      {showErrors && (
+        <GuiErrorsReact uid={uid} errors={errors} touched={isTouched}></GuiErrorsReact>
+      )}
     </div>
   );
 }

--- a/libs/gui/react/src/lib/components/Markdown.tsx
+++ b/libs/gui/react/src/lib/components/Markdown.tsx
@@ -2,8 +2,9 @@ import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useInputWidget } from '@golemui/react';
 import { type MarkdownProps } from '@golemui/gui-shared';
 import { useCallback } from 'react';
-import '@golemui/gui-components/markdown';
+import { GuiMarkdownReact } from '../web-components';
 import '../styles.scss';
+
 
 export function Markdown(widgetInstance: WithWidget) {
   const widget = widgetInstance.widget as InputWidget<string>;
@@ -13,8 +14,7 @@ export function Markdown(widgetInstance: WithWidget) {
   >(widget);
 
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLTextAreaElement>) =>
-      onValueChanged((e.nativeEvent as CustomEvent).detail.value),
+    (e: Event) => onValueChanged((e as CustomEvent).detail.value),
     [onValueChanged],
   );
 
@@ -43,7 +43,7 @@ export function Markdown(widgetInstance: WithWidget) {
 
   return (
     <div className="gui-markdown gui-field" style={{ flex: templateData.size }}>
-      <gui-markdown
+      <GuiMarkdownReact
         uid={uid}
         label={label}
         errors={errors}
@@ -73,7 +73,7 @@ export function Markdown(widgetInstance: WithWidget) {
         dependencies={templateData.deps}
         onInput={handleChange}
         onBlur={onBlur}
-      ></gui-markdown>
+      ></GuiMarkdownReact>
     </div>
   );
 }

--- a/libs/gui/react/src/lib/components/MarkdownText.tsx
+++ b/libs/gui/react/src/lib/components/MarkdownText.tsx
@@ -1,7 +1,8 @@
 import type { DisplayWidget, WithWidget } from '@golemui/core';
 import { useDisplayWdiget } from '@golemui/react';
 import { type MarkdownTextProps } from '@golemui/gui-shared';
-import '@golemui/gui-components/markdown-text';
+import { GuiMarkdownTextReact } from '../web-components';
+
 
 export function MarkdownText(widgetInstance: WithWidget) {
   const widget = widgetInstance.widget as DisplayWidget;
@@ -10,7 +11,7 @@ export function MarkdownText(widgetInstance: WithWidget) {
   return (
     <div className="gui-markdown-text gui-field" style={{ flex: templateData.size }}>
       <div className="gui-widget" id={uid}>
-        <gui-markdown-text md={templateData.md} dependencies={templateData.deps} />
+        <GuiMarkdownTextReact md={templateData.md} dependencies={templateData.deps} />
       </div>
     </div>
   );

--- a/libs/gui/react/src/lib/components/Number.tsx
+++ b/libs/gui/react/src/lib/components/Number.tsx
@@ -2,8 +2,9 @@ import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useInputWidget } from '@golemui/react';
 import { type NumberinputProps } from '@golemui/gui-shared';
 import { useCallback } from 'react';
-import '@golemui/gui-components/number';
+import { GuiNumberReact } from '../web-components';
 import '../styles.scss';
+
 
 export function NumberInput(widgetInstance: WithWidget) {
   const widget = widgetInstance.widget as InputWidget<number>;
@@ -13,8 +14,7 @@ export function NumberInput(widgetInstance: WithWidget) {
   >(widget);
 
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) =>
-      onValueChanged((e.nativeEvent as CustomEvent).detail.value),
+    (e: Event) => onValueChanged((e as CustomEvent).detail.value),
     [onValueChanged],
   );
 
@@ -32,7 +32,7 @@ export function NumberInput(widgetInstance: WithWidget) {
 
   return (
     <div className="gui-number gui-field" style={{ flex: templateData.size }}>
-      <gui-number
+      <GuiNumberReact
         uid={uid}
         label={label}
         hint={hint}
@@ -50,7 +50,7 @@ export function NumberInput(widgetInstance: WithWidget) {
         placeholder={placeholder ?? undefined}
         onInput={handleChange}
         onBlur={onBlur}
-      ></gui-number>
+      ></GuiNumberReact>
     </div>
   );
 }

--- a/libs/gui/react/src/lib/components/Password.tsx
+++ b/libs/gui/react/src/lib/components/Password.tsx
@@ -2,8 +2,9 @@ import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useInputWidget } from '@golemui/react';
 import { type PasswordProps } from '@golemui/gui-shared';
 import { useCallback } from 'react';
-import '@golemui/gui-components/password';
+import { GuiPasswordReact } from '../web-components';
 import '../styles.scss';
+
 
 export function Password(widgetInstance: WithWidget) {
   const widget = widgetInstance.widget as InputWidget<string>;
@@ -13,8 +14,7 @@ export function Password(widgetInstance: WithWidget) {
   >(widget);
 
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) =>
-      onValueChanged((e.nativeEvent as CustomEvent).detail.value),
+    (e: Event) => onValueChanged((e as CustomEvent).detail.value),
     [onValueChanged],
   );
 
@@ -33,7 +33,7 @@ export function Password(widgetInstance: WithWidget) {
 
   return (
     <div className="gui-password gui-field" style={{ flex: templateData.size }}>
-      <gui-password
+      <GuiPasswordReact
         uid={uid}
         label={label}
         hint={hint}
@@ -52,7 +52,7 @@ export function Password(widgetInstance: WithWidget) {
         hidePasswordLabel={hidePasswordLabel}
         onInput={handleChange}
         onBlur={onBlur}
-      ></gui-password>
+      ></GuiPasswordReact>
     </div>
   );
 }

--- a/libs/gui/react/src/lib/components/RadioGroup.tsx
+++ b/libs/gui/react/src/lib/components/RadioGroup.tsx
@@ -2,8 +2,9 @@ import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useInputWidget } from '@golemui/react';
 import { type OptionValue, type RadiogroupProps } from '@golemui/gui-shared';
 import { useCallback } from 'react';
-import '@golemui/gui-components/radiogroup';
+import { GuiRadiogroupReact } from '../web-components';
 import '../styles.scss';
+
 
 export function RadioGroup(widgetInstance: WithWidget) {
   const widget = widgetInstance.widget as InputWidget<string>;
@@ -13,8 +14,7 @@ export function RadioGroup(widgetInstance: WithWidget) {
   >(widget);
 
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) =>
-      onValueChanged((e.nativeEvent as CustomEvent).detail.value),
+    (e: Event) => onValueChanged((e as CustomEvent).detail.value),
     [onValueChanged],
   );
 
@@ -30,7 +30,7 @@ export function RadioGroup(widgetInstance: WithWidget) {
 
   return (
     <div className="gui-radiogroup gui-field" style={{ flex: templateData.size }}>
-      <gui-radiogroup
+      <GuiRadiogroupReact
         uid={uid}
         label={label}
         errors={errors}
@@ -46,7 +46,7 @@ export function RadioGroup(widgetInstance: WithWidget) {
         direction={direction}
         onChange={handleChange}
         onBlur={onBlur}
-      ></gui-radiogroup>
+      ></GuiRadiogroupReact>
     </div>
   );
 }

--- a/libs/gui/react/src/lib/components/RangeCalendar.tsx
+++ b/libs/gui/react/src/lib/components/RangeCalendar.tsx
@@ -2,7 +2,7 @@ import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useInputWidget } from '@golemui/react';
 import { type DateRange, type RangeCalendarProps } from '@golemui/gui-shared';
 import { useCallback } from 'react';
-import '@golemui/gui-components/range-calendar';
+import { GuiRangeCalendarReact } from '../web-components';
 import '../styles.scss';
 
 export function RangeCalendar(widgetInstance: WithWidget) {
@@ -53,7 +53,7 @@ export function RangeCalendar(widgetInstance: WithWidget) {
 
   return (
     <div className="gui-range-calendar gui-field" style={{ flex: templateData.size }}>
-      <gui-range-calendar
+      <GuiRangeCalendarReact
         ref={handleRef}
         uid={uid}
         label={label}

--- a/libs/gui/react/src/lib/components/RangeDateInput.tsx
+++ b/libs/gui/react/src/lib/components/RangeDateInput.tsx
@@ -2,7 +2,7 @@ import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useInputWidget } from '@golemui/react';
 import { type DateRange, type RangeDateInputProps } from '@golemui/gui-shared';
 import { useCallback } from 'react';
-import '@golemui/gui-components/range-date-input';
+import { GuiRangeDateReact } from '../web-components';
 import '../styles.scss';
 
 export function RangeDateInput(widgetInstance: WithWidget) {
@@ -61,7 +61,7 @@ export function RangeDateInput(widgetInstance: WithWidget) {
 
   return (
     <div className="gui-range-date-input gui-field" style={{ flex: templateData.size }}>
-      <gui-range-date
+      <GuiRangeDateReact
         ref={handleRef}
         uid={uid}
         label={label}

--- a/libs/gui/react/src/lib/components/RangeDatePicker.tsx
+++ b/libs/gui/react/src/lib/components/RangeDatePicker.tsx
@@ -2,10 +2,9 @@ import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useInputWidget } from '@golemui/react';
 import { type DateRange, type RangeDatePickerProps } from '@golemui/gui-shared';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import '@golemui/gui-components/range-date-input';
-import '@golemui/gui-components/range-calendar';
 import '../styles.scss';
 import { Errors } from './shared/Errors';
+import { GuiRangeCalendarReact, GuiRangeDateReact } from '../web-components';
 
 export function RangeDatePicker(widgetInstance: WithWidget) {
   const widget = widgetInstance.widget as InputWidget<DateRange[]>;
@@ -218,7 +217,7 @@ export function RangeDatePicker(widgetInstance: WithWidget) {
         }}
         aria-expanded={isCalendarOpen}
       >
-        <gui-range-date
+        <GuiRangeDateReact
           ref={handleDateRef}
           uid={uid}
           hint={hint}
@@ -243,7 +242,7 @@ export function RangeDatePicker(widgetInstance: WithWidget) {
         </span>
 
         {isCalendarOpen && (
-          <gui-range-calendar
+          <GuiRangeCalendarReact
             ref={handleCalendarRef}
             uid={uid}
             hint={hint}

--- a/libs/gui/react/src/lib/components/Repeater.tsx
+++ b/libs/gui/react/src/lib/components/Repeater.tsx
@@ -1,3 +1,4 @@
+import { GuiErrorsReact, GuiLabelReact } from '../web-components';
 import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { type RepeaterProps } from '@golemui/gui-shared';
 import { getItemKey } from '@golemui/gui-shared/internals';
@@ -8,8 +9,6 @@ import {
   WidgetRenderer,
 } from '@golemui/react';
 import React, { useCallback, useRef, useState } from 'react';
-import '@golemui/gui-components/label';
-import '@golemui/gui-components/errors';
 import '../styles.scss';
 
 /**
@@ -110,7 +109,7 @@ export function Repeater(widgetInstance: WithWidget) {
         onFocus={onFocusIn}
         onBlur={onFocusOut}
       >
-        <gui-label
+        <GuiLabelReact
           targetElement={repeaterRef.current || undefined}
           uid={uid}
           label={templateData.label as string}
@@ -118,7 +117,7 @@ export function Repeater(widgetInstance: WithWidget) {
           touched={isTouched}
           required={isRequired}
           native={false}
-        ></gui-label>
+        ></GuiLabelReact>
 
         {renderWidgets()}
         <button
@@ -138,7 +137,9 @@ export function Repeater(widgetInstance: WithWidget) {
         </button>
       </div>
 
-      {showErrors && <gui-errors uid={uid} errors={errors} touched={isTouched}></gui-errors>}
+      {showErrors && (
+        <GuiErrorsReact uid={uid} errors={errors} touched={isTouched}></GuiErrorsReact>
+      )}
     </div>
   );
 }

--- a/libs/gui/react/src/lib/components/Select.tsx
+++ b/libs/gui/react/src/lib/components/Select.tsx
@@ -2,8 +2,9 @@ import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useInputWidget } from '@golemui/react';
 import { type OptionValue, type SelectProps } from '@golemui/gui-shared';
 import { useCallback } from 'react';
-import '@golemui/gui-components/select';
+import { GuiSelectReact } from '../web-components';
 import '../styles.scss';
+
 
 export function Select(widgetInstance: WithWidget) {
   const widget = widgetInstance.widget as InputWidget<string>;
@@ -19,27 +20,12 @@ export function Select(widgetInstance: WithWidget) {
   } = useInputWidget<OptionValue, SelectProps>(widget);
 
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) =>
-      onValueChanged((e.nativeEvent as CustomEvent).detail.value),
+    (e: Event) => onValueChanged((e as CustomEvent).detail.value),
     [onValueChanged],
   );
 
-  const handleRef = useCallback(
-    (node: HTMLElement | null) => {
-      const target = node as any;
-
-      const errorHandler = (e: CustomEvent) => {
-        injectValidationIssues([e.detail.message]);
-      };
-
-      if (node) {
-        target.addEventListener('inputError', errorHandler);
-      }
-
-      return () => {
-        target.removeEventListener('inputError', errorHandler);
-      };
-    },
+  const handleInputError = useCallback(
+    (e: Event) => injectValidationIssues([(e as CustomEvent).detail.message]),
     [injectValidationIssues],
   );
 
@@ -57,8 +43,7 @@ export function Select(widgetInstance: WithWidget) {
 
   return (
     <div className="gui-select gui-field" style={{ flex: templateData.size }}>
-      <gui-select
-        ref={handleRef}
+      <GuiSelectReact
         uid={uid}
         label={label}
         errors={errors}
@@ -76,7 +61,8 @@ export function Select(widgetInstance: WithWidget) {
         valueField={valueField}
         onChange={handleChange}
         onBlur={onBlur}
-      ></gui-select>
+        onInputError={handleInputError}
+      ></GuiSelectReact>
     </div>
   );
 }

--- a/libs/gui/react/src/lib/components/Tags.tsx
+++ b/libs/gui/react/src/lib/components/Tags.tsx
@@ -2,8 +2,9 @@ import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useInputWidget } from '@golemui/react';
 import { type TagsProps } from '@golemui/gui-shared';
 import { useCallback } from 'react';
-import '@golemui/gui-components/tags';
+import { GuiTagsReact } from '../web-components';
 import '../styles.scss';
+
 
 export function Tags(widgetInstance: WithWidget) {
   const widget = widgetInstance.widget as InputWidget<string[]>;
@@ -13,8 +14,7 @@ export function Tags(widgetInstance: WithWidget) {
   >(widget);
 
   const handleChange = useCallback(
-    (e: React.SyntheticEvent<HTMLElement>) =>
-      onValueChanged((e.nativeEvent as CustomEvent).detail.value),
+    (e: Event) => onValueChanged((e as CustomEvent).detail.value),
     [onValueChanged],
   );
 
@@ -34,7 +34,7 @@ export function Tags(widgetInstance: WithWidget) {
 
   return (
     <div className="gui-tags gui-field" style={{ flex: templateData.size }}>
-      <gui-tags
+      <GuiTagsReact
         uid={uid}
         label={label}
         hint={hint}
@@ -54,7 +54,7 @@ export function Tags(widgetInstance: WithWidget) {
         removeIcon={removeIcon}
         onChange={handleChange}
         onBlur={onBlur}
-      ></gui-tags>
+      ></GuiTagsReact>
     </div>
   );
 }

--- a/libs/gui/react/src/lib/components/TextArea.tsx
+++ b/libs/gui/react/src/lib/components/TextArea.tsx
@@ -2,8 +2,9 @@ import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useInputWidget } from '@golemui/react';
 import { type TextareaProps } from '@golemui/gui-shared';
 import { useCallback } from 'react';
-import '@golemui/gui-components/textarea';
+import { GuiTextareaReact } from '../web-components';
 import '../styles.scss';
+
 
 export function TextArea(widgetInstance: WithWidget) {
   const widget = widgetInstance.widget as InputWidget<string>;
@@ -13,8 +14,7 @@ export function TextArea(widgetInstance: WithWidget) {
   >(widget);
 
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLTextAreaElement>) =>
-      onValueChanged((e.nativeEvent as CustomEvent).detail.value),
+    (e: Event) => onValueChanged((e as CustomEvent).detail.value),
     [onValueChanged],
   );
 
@@ -32,7 +32,7 @@ export function TextArea(widgetInstance: WithWidget) {
 
   return (
     <div className="gui-textarea gui-field" style={{ flex: templateData.size }}>
-      <gui-textarea
+      <GuiTextareaReact
         uid={uid}
         label={label}
         errors={errors}
@@ -50,7 +50,7 @@ export function TextArea(widgetInstance: WithWidget) {
         maxLength={maxLength}
         onInput={handleChange}
         onBlur={onBlur}
-      ></gui-textarea>
+      ></GuiTextareaReact>
     </div>
   );
 }

--- a/libs/gui/react/src/lib/components/TextInput.tsx
+++ b/libs/gui/react/src/lib/components/TextInput.tsx
@@ -2,8 +2,9 @@ import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useInputWidget } from '@golemui/react';
 import { type TextinputProps } from '@golemui/gui-shared';
 import { useCallback } from 'react';
-import '@golemui/gui-components/textinput';
+import { GuiTextinputReact } from '../web-components';
 import '../styles.scss';
+
 
 export function TextInput(widgetInstance: WithWidget) {
   const widget = widgetInstance.widget as InputWidget<string>;
@@ -13,8 +14,7 @@ export function TextInput(widgetInstance: WithWidget) {
   >(widget);
 
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) =>
-      onValueChanged((e.nativeEvent as CustomEvent).detail.value),
+    (e: Event) => onValueChanged((e as CustomEvent).detail.value),
     [onValueChanged],
   );
 
@@ -29,7 +29,7 @@ export function TextInput(widgetInstance: WithWidget) {
 
   return (
     <div className="gui-textinput gui-field" style={{ flex: templateData.size }}>
-      <gui-textinput
+      <GuiTextinputReact
         uid={uid}
         label={label}
         hint={hint}
@@ -44,7 +44,7 @@ export function TextInput(widgetInstance: WithWidget) {
         autocomplete={autocomplete ?? undefined}
         onInput={handleChange}
         onBlur={onBlur}
-      ></gui-textinput>
+      ></GuiTextinputReact>
     </div>
   );
 }

--- a/libs/gui/react/src/lib/components/Toggle.tsx
+++ b/libs/gui/react/src/lib/components/Toggle.tsx
@@ -2,8 +2,9 @@ import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useInputWidget } from '@golemui/react';
 import { type ToggleProps } from '@golemui/gui-shared';
 import { useCallback } from 'react';
-import '@golemui/gui-components/toggle';
+import { GuiToggleReact } from '../web-components';
 import '../styles.scss';
+
 
 export function Toggle(widgetInstance: WithWidget) {
   const widget = widgetInstance.widget as InputWidget<boolean>;
@@ -13,8 +14,7 @@ export function Toggle(widgetInstance: WithWidget) {
   >(widget);
 
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) =>
-      onValueChanged((e.nativeEvent as CustomEvent).detail.value),
+    (e: Event) => onValueChanged((e as CustomEvent).detail.value),
     [onValueChanged],
   );
 
@@ -27,7 +27,7 @@ export function Toggle(widgetInstance: WithWidget) {
 
   return (
     <div className={`gui-toggle gui-field`} style={{ flex: templateData.size }}>
-      <gui-toggle
+      <GuiToggleReact
         uid={uid}
         label={label}
         errors={errors}

--- a/libs/gui/react/src/lib/web-components.ts
+++ b/libs/gui/react/src/lib/web-components.ts
@@ -1,0 +1,56 @@
+import { createComponent, type EventName } from '@lit/react';
+import React from 'react';
+import { GuiButton } from '@golemui/gui-components/button';
+import { GuiCalendar } from '@golemui/gui-components/calendar';
+import { GuiCheckbox } from '@golemui/gui-components/checkbox';
+import { GuiCurrency } from '@golemui/gui-components/currency';
+import { GuiDate } from '@golemui/gui-components/date-input';
+import { GuiErrors } from '@golemui/gui-components/errors';
+import { GuiLabel } from '@golemui/gui-components/label';
+import { GuiList } from '@golemui/gui-components/list';
+import { GuiMarkdown } from '@golemui/gui-components/markdown';
+import { GuiMarkdownText } from '@golemui/gui-components/markdown-text';
+import { GuiNumber } from '@golemui/gui-components/number';
+import { GuiPassword } from '@golemui/gui-components/password';
+import { GuiRadiogroup } from '@golemui/gui-components/radiogroup';
+import { GuiRangeCalendar } from '@golemui/gui-components/range-calendar';
+import { GuiRangeDateInput } from '@golemui/gui-components/range-date-input';
+import { GuiSelect } from '@golemui/gui-components/select';
+import { GuiTags } from '@golemui/gui-components/tags';
+import { GuiTextarea } from '@golemui/gui-components/textarea';
+import { GuiTextinput } from '@golemui/gui-components/textinput';
+import { GuiToggle } from '@golemui/gui-components/toggle';
+
+const wrap = <I extends HTMLElement, E extends Record<string, EventName | string> = Record<never, never>>(
+  tagName: string,
+  elementClass: { new (): I },
+  events?: E,
+) => createComponent({ react: React, tagName, elementClass, events });
+
+export const GuiTextinputReact = wrap('gui-textinput', GuiTextinput, { onInput: 'input', onBlur: 'blur' });
+export const GuiTextareaReact = wrap('gui-textarea', GuiTextarea, { onInput: 'input', onBlur: 'blur' });
+export const GuiNumberReact = wrap('gui-number', GuiNumber, { onInput: 'input', onBlur: 'blur' });
+export const GuiCurrencyReact = wrap('gui-currency', GuiCurrency, { onInput: 'input', onBlur: 'blur' });
+export const GuiPasswordReact = wrap('gui-password', GuiPassword, { onInput: 'input', onBlur: 'blur' });
+export const GuiMarkdownReact = wrap('gui-markdown', GuiMarkdown, { onInput: 'input', onBlur: 'blur' });
+export const GuiRadiogroupReact = wrap('gui-radiogroup', GuiRadiogroup, { onChange: 'change', onBlur: 'blur' });
+export const GuiToggleReact = wrap('gui-toggle', GuiToggle, { onChange: 'change', onBlur: 'blur' });
+export const GuiCheckboxReact = wrap('gui-checkbox', GuiCheckbox, { onChange: 'change', onBlur: 'blur' });
+export const GuiTagsReact = wrap('gui-tags', GuiTags, { onChange: 'change', onBlur: 'blur' });
+export const GuiSelectReact = wrap('gui-select', GuiSelect, {
+  onChange: 'change',
+  onBlur: 'blur',
+  onInputError: 'inputError',
+});
+
+export const GuiCalendarReact = wrap('gui-calendar', GuiCalendar);
+export const GuiRangeCalendarReact = wrap('gui-range-calendar', GuiRangeCalendar);
+export const GuiDateReact = wrap('gui-date', GuiDate);
+export const GuiRangeDateReact = wrap('gui-range-date', GuiRangeDateInput);
+
+export const GuiListReact = wrap('gui-list', GuiList);
+export const GuiLabelReact = wrap('gui-label', GuiLabel);
+export const GuiErrorsReact = wrap('gui-errors', GuiErrors);
+export const GuiMarkdownTextReact = wrap('gui-markdown-text', GuiMarkdownText);
+
+export const GuiButtonReact = wrap('gui-button', GuiButton, { onClick: 'click' });

--- a/libs/gui/react/vite.config.ts
+++ b/libs/gui/react/vite.config.ts
@@ -6,8 +6,7 @@ import { join, resolve } from 'path';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
-// Opt-in React 18 pin (set REACT18=1) — lets the component-test bundler resolve the
-// adapter against React 18 (the advertised floor) instead of the repo's hoisted React 19.
+// React 18 pin (REACT18=1): resolve the adapter against the advertised floor, not React 19.
 const react18Alias = process.env.REACT18
   ? {
       resolve: {
@@ -50,6 +49,7 @@ export default defineConfig(() => ({
         'react',
         'react-dom',
         'react/jsx-runtime',
+        '@lit/react',
         '@golemui/core',
         '@golemui/react',
         '@golemui/gui-components',

--- a/libs/gui/react/vite.config.ts
+++ b/libs/gui/react/vite.config.ts
@@ -2,13 +2,30 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+
+// Opt-in React 18 pin (set REACT18=1) — lets the component-test bundler resolve the
+// adapter against React 18 (the advertised floor) instead of the repo's hoisted React 19.
+const react18Alias = process.env.REACT18
+  ? {
+      resolve: {
+        alias: {
+          'react-dom/client': resolve(__dirname, '../../../node_modules/react18-dom/client.js'),
+          'react-dom': resolve(__dirname, '../../../node_modules/react18-dom/index.js'),
+          'react/jsx-dev-runtime': resolve(__dirname, '../../../node_modules/react18/jsx-dev-runtime.js'),
+          'react/jsx-runtime': resolve(__dirname, '../../../node_modules/react18/jsx-runtime.js'),
+          react: resolve(__dirname, '../../../node_modules/react18/index.js'),
+        },
+      },
+    }
+  : {};
 
 export default defineConfig(() => ({
   root: __dirname,
   cacheDir: '../../../node_modules/.vite/libs/gui/react',
+  ...react18Alias,
   plugins: [
     react(),
     nxViteTsPaths(),

--- a/libs/react/src/lib/FormComponent.tsx
+++ b/libs/react/src/lib/FormComponent.tsx
@@ -11,7 +11,7 @@ import {
   type FormSubmitEvent,
 } from '@golemui/core';
 import { type FormInitConfig } from '@golemui/core';
-import { useEffect, useImperativeHandle, useRef, useState } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { ReactFormContextProvider } from './ReactFormContextProvider';
 import WidgetErrorBoundary from './WidgetErrorBoundary';
 import WidgetRenderer from './WidgetRenderer';
@@ -28,29 +28,24 @@ export interface FormComponentProps {
   formSubmit?: (event: FormSubmitEvent) => void;
   formHealth?: (error: FormHealth) => void;
   autocomplete?: string;
-  ref?: React.Ref<FormComponentHandle>;
 }
 
-export function FormComponent({
-  config,
-  validators,
-  formHealth,
-  formEvent,
-  formSubmit,
-  autocomplete,
-  ref,
-}: FormComponentProps) {
+export const FormComponent = forwardRef<FormComponentHandle, FormComponentProps>(
+  function FormComponent(
+    { config, validators, formHealth, formEvent, formSubmit, autocomplete },
+    ref,
+  ) {
   const formContextRef = useRef<FormContext<React.ComponentType<WithWidget>>>(new FormContext());
   const formNameRef = useRef<string>(config.formName ?? shortUUID());
   const [formLayoutField, setFormLayoutField] = useState<LayoutWidget<string> | null>(null);
   const [direction, setDirection] = useState<'ltr' | 'rtl'>('ltr');
-  const [storeVersion, setStoreVersion] = useState(0);
 
-  // INITIALIZE FORM CONTEXT
-  // Recreates the store when config reference changes (atomic reinit) or validators change.
-  // Bumps storeVersion so downstream effects re-subscribe to the new store.
+  const callbacksRef = useRef({ formHealth, formEvent, formSubmit });
+  callbacksRef.current = { formHealth, formEvent, formSubmit };
+
   useEffect(() => {
-    formContextRef.current.initialize(
+    const context = formContextRef.current;
+    context.initialize(
       config.widgetLoaders,
       config.middlewares ?? [],
       validators,
@@ -59,94 +54,42 @@ export function FormComponent({
       config.localization,
       config.dependencies ?? {},
     );
-    setStoreVersion((v) => v + 1);
+    context.store.dispatch({
+      type: 'INITIALIZE',
+      payload: { formName: formNameRef.current, formDef: config.formDef },
+    });
+    context.store.dispatch({ type: 'SET_DATA', payload: { data: config.data ?? {} } });
+    context.store.dispatch({ type: 'SET_META', payload: { meta: config.meta ?? {} } });
+    setDirection(getDirectionFromLanguage(context.localization.lang));
+
+    const stateSub = context.store.state$.subscribe((state) => {
+      setFormLayoutField(state.formDef.form);
+      setDirection(getDirectionFromLanguage(context.localization.lang));
+    });
+    const healthSub = watchFormHealth(context.store.state$).subscribe((health) =>
+      callbacksRef.current.formHealth?.(health),
+    );
+    const unsubscribeI18n = context.localization.subscribe((lang) => {
+      setDirection(getDirectionFromLanguage(lang));
+      context.store.dispatch({ type: 'SET_LANGUAGE', payload: { lang } });
+    });
+
+    return () => {
+      stateSub.unsubscribe();
+      healthSub.unsubscribe();
+      unsubscribeI18n();
+    };
   }, [config, validators]);
 
-  // INITIALIZE FORM DEFINITION
-  // Re-dispatches when storeVersion bumps (new store) so the definition is always loaded.
   useEffect(() => {
-    formContextRef.current.store.dispatch({
-      type: 'INITIALIZE',
-      payload: {
-        formName: formNameRef.current,
-        formDef: config.formDef,
-      },
-    });
-  }, [config.formDef, storeVersion]);
-
-  // FORM HEALTH
-  // Re-subscribes when store is recreated (storeVersion changes).
-  useEffect(() => {
-    const sub = watchFormHealth(formContextRef.current.store.state$).subscribe((health) =>
-      formHealth?.(health),
+    const context = formContextRef.current;
+    const eventSub = context.events$.subscribe((event) => callbacksRef.current.formEvent?.(event));
+    const submitSub = context.submit$.subscribe((event) =>
+      callbacksRef.current.formSubmit?.(event),
     );
     return () => {
-      sub.unsubscribe();
-    };
-  }, [formHealth, storeVersion]);
-
-  /**
-   * Stable events subscriptions
-   * ( Stable events are those that survive store replacements )
-   */
-  useEffect(() => {
-    const sub = formContextRef.current.events$.subscribe((event) => formEvent?.(event));
-    return () => {
-      sub.unsubscribe();
-    };
-  }, [formEvent]);
-  useEffect(() => {
-    const sub = formContextRef.current.submit$.subscribe((event) => {
-      formSubmit?.(event);
-    });
-    return () => {
-      sub.unsubscribe();
-    };
-  }, [formSubmit]);
-
-  // FORM ENTRY POINT
-  // Re-subscribes when store is recreated so the rendered form tree is always
-  // consistent with the new store's flatForm and calculatedWidgets.
-  useEffect(() => {
-    const sub = formContextRef.current.store.state$.subscribe((state) => {
-      setFormLayoutField(state.formDef.form);
-      setDirection(getDirectionFromLanguage(formContextRef.current.localization.lang));
-    });
-    return () => {
-      sub.unsubscribe();
-    };
-  }, [storeVersion]);
-
-  // SET FORM DATA
-  // Also re-dispatches when the store is recreated so fresh store starts with the right data.
-  useEffect(() => {
-    formContextRef.current.store.dispatch({
-      type: 'SET_DATA',
-      payload: { data: config.data || {} },
-    });
-  }, [config.data, storeVersion]);
-
-  // SET FORM META
-  useEffect(() => {
-    formContextRef.current.store.dispatch({
-      type: 'SET_META',
-      payload: { meta: config.meta || {} },
-    });
-  }, [config.meta, storeVersion]);
-
-  // I18n
-  useEffect(() => {
-    const sub = formContextRef.current.localization.subscribe((lang) => {
-      setDirection(getDirectionFromLanguage(lang));
-      formContextRef.current.store.dispatch({
-        type: 'SET_LANGUAGE',
-        payload: {
-          lang,
-        },
-      });
-    });
-    return () => {
-      sub();
+      eventSub.unsubscribe();
+      submitSub.unsubscribe();
     };
   }, []);
 
@@ -189,6 +132,6 @@ export function FormComponent({
       </div>
     </ReactFormContextProvider>
   );
-}
+});
 
 export default FormComponent;

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,8 @@
         "postcss-url": "~10.1.3",
         "prettier": "~3.6.2",
         "react-router": "^7.9.3",
+        "react18": "npm:react@18.3.1",
+        "react18-dom": "npm:react-dom@18.3.1",
         "sass": "^1.55.0",
         "snarkdown": "^2.0.0",
         "swc-loader": "0.1.15",
@@ -28388,6 +28390,45 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/react18": {
+      "name": "react",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react18-dom": {
+      "name": "react-dom",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react18-dom/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/read-cache": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@angular/platform-browser-dynamic": "20.3.9",
         "@angular/router": "20.3.9",
         "@lit/context": "^1.1.6",
+        "@lit/react": "^1.0.8",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@standard-schema/spec": "^1.0.0",
         "ajv-formats": "^3.0.1",
@@ -5371,7 +5372,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.8.tgz",
       "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "peerDependencies": {
         "@types/react": "17 || 18 || 19"

--- a/package.json
+++ b/package.json
@@ -119,6 +119,8 @@
     "postcss-url": "~10.1.3",
     "prettier": "~3.6.2",
     "react-router": "^7.9.3",
+    "react18": "npm:react@18.3.1",
+    "react18-dom": "npm:react-dom@18.3.1",
     "vue-router": "^4.5.0",
     "sass": "^1.55.0",
     "snarkdown": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@angular/platform-browser-dynamic": "20.3.9",
     "@angular/router": "20.3.9",
     "@lit/context": "^1.1.6",
+    "@lit/react": "^1.0.8",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@standard-schema/spec": "^1.0.0",
     "ajv-formats": "^3.0.1",


### PR DESCRIPTION
## What
  `@golemui/gui-react` crashes / misbehaves on **React 18** — the floor we
  advertise (`"react": ">=18.0.0"`). This makes the adapter work on React 18
  and 19 alike.

  ## Why
  React ≤18 sets object/array props on custom elements as **stringified
  attributes**; React 19 property-binds them. So on React 18:
  - widgets like `radiogroup`/`select` get `options` as a broken string →
    `this.options.find is not a function` → crash on render;
  - the imperative `setData` / `setMeta` handle never reaches the form.

  The monorepo runs React 19, so every internal test masked it — nothing
  exercised the advertised React-18 floor.

  ## What changed
  - **Property-bind every element via `@lit/react`** through a single registry
    (`web-components.ts`); each `<gui-*>` is wrapped so props are set as DOM
    properties on React 18 and 19 alike — consistent with the Vue/Angular/Lit
    adapters, which property-bind natively.
  - **`forwardRef`** in `GuiForm` / `FormComponent` so the imperative handle
    works on React 18 (the `ref`-as-prop shorthand is React 19 only).
  - **Mirror the Angular adapter's store wiring** in `FormComponent` (drop the
    `storeVersion` counter).
  - **`options` converter** `String→Array` on radiogroup/select (defense-in-depth).
  - **`@lit/react`** added as a dependency (external, ~1.4 KB, zero-dep).

  ## Testing
  - Full `gui-react` component suite: **194/194 on React 18 and 19**
    (React 18 via the `REACT18=1` alias).
  - typecheck + lint clean.

  ## Scope
  React-18 only. Two related cleanups land in their own PRs:
  - **peer-deps** — move third-party runtime libs (`rxjs`/`lit`/`zod`/…) from
    `peerDependencies` → `dependencies` so a fresh `npm i` resolves everything.
  - **kitchen-sink cleanup** — remove the dead `LanguagePicker` from the
    playgrounds + drop the raw-tag JSX augmentation; lands after this PR.
