### PR TITLE
fix(core): clear `data` after an input widget is removed

### DIFF
--- a/apps/apps-shared/src/lib/mocks/tiny.ts
+++ b/apps/apps-shared/src/lib/mocks/tiny.ts
@@ -12,7 +12,7 @@ const resources = {};
 export const tiny: Example = {
   data,
   form: async () => {
-    const baseUrl = new URL('assets/mocks/tiny.form.json', window.location.href).href;
+    const baseUrl = new URL('/assets/mocks/tiny.form.json', window.location.href).href;
     const json = await fetch(baseUrl).then((r) => r.json());
     return json as unknown as Form<string>;
   },

--- a/libs/core/src/lib/context/form.context.ts
+++ b/libs/core/src/lib/context/form.context.ts
@@ -13,6 +13,7 @@ import {
 } from '../shared';
 import { type Action } from '../store/actions';
 import { type Middleware, type State } from '../store/model';
+import { pruneHiddenData } from '../utils/form';
 import { type WidgetLoaders, WidgetRegistry } from './widget-registry';
 
 export class FormContext<ComponentType> {
@@ -63,7 +64,7 @@ export class FormContext<ComponentType> {
         if (eventName) {
           this.events$.next({
             name: eventName,
-            data: this.store.getState().data,
+            data: pruneHiddenData(this.store.getState()),
             detail: detail ?? undefined,
             callback: (action: EventHandlerCallback) => {
               this.store.dispatch(action);
@@ -77,7 +78,7 @@ export class FormContext<ComponentType> {
       if (eventName) {
         this.events$.next({
           name: eventName,
-          data: this.store.getState().data,
+          data: pruneHiddenData(this.store.getState()),
           detail: detail,
           callback: (action: EventHandlerCallback) => {
             this.store.dispatch(action);
@@ -94,7 +95,7 @@ export class FormContext<ComponentType> {
 
     if (this.store.getState().isFormValid) {
       this.submit$.next({
-        data: this.store.getState().data,
+        data: pruneHiddenData(this.store.getState()),
         callback: (action: EventHandlerCallback) => {
           this.store.dispatch(action);
         },

--- a/libs/core/src/lib/store/reducers/calculate-widget-props.spec.ts
+++ b/libs/core/src/lib/store/reducers/calculate-widget-props.spec.ts
@@ -726,7 +726,8 @@ describe('calculateWidgetProps', () => {
   // ---------------------------------------------------------------------------
 
   describe('hidden widgets', () => {
-    it('hidden widget is absent from output', () => {
+    // This basically means that when a hidden widget is hit, the logic skips calculations with a `continue`.
+    it('hidden widget is unchanged', () => {
       const source = {
         kind: 'display',
         uid: 'd',
@@ -737,7 +738,8 @@ describe('calculateWidgetProps', () => {
 
       const next = run(state);
 
-      expect('d' in next.calculatedWidgets).toBe(false);
+      expect(next.calculatedWidgets['d'].source).toBe(source);
+      expect(next.calculatedWidgets['d'].current).toEqual({});
     });
   });
 

--- a/libs/core/src/lib/store/reducers/calculate-widget-props.spec.ts
+++ b/libs/core/src/lib/store/reducers/calculate-widget-props.spec.ts
@@ -738,8 +738,7 @@ describe('calculateWidgetProps', () => {
 
       const next = run(state);
 
-      expect(next.calculatedWidgets['d'].source).toBe(source);
-      expect(next.calculatedWidgets['d'].current).toEqual({});
+      expect('d' in next.calculatedWidgets).toBe(false);
     });
   });
 

--- a/libs/core/src/lib/store/reducers/calculate-widget-props.ts
+++ b/libs/core/src/lib/store/reducers/calculate-widget-props.ts
@@ -59,6 +59,8 @@ function calculateAll(state: State, localization: I18nTranslator): State['calcul
 
   for (const uid of Object.keys(state.calculatedWidgets)) {
     if (state.widgetFlags[uid]?.hidden) {
+      // we keep it because 'REMOVE_WIDGET' takes care of the removal when the destroy life-cycle hits
+      result[uid] = state.calculatedWidgets[uid];
       continue;
     }
 

--- a/libs/core/src/lib/store/reducers/calculate-widget-props.ts
+++ b/libs/core/src/lib/store/reducers/calculate-widget-props.ts
@@ -59,8 +59,6 @@ function calculateAll(state: State, localization: I18nTranslator): State['calcul
 
   for (const uid of Object.keys(state.calculatedWidgets)) {
     if (state.widgetFlags[uid]?.hidden) {
-      // we keep it because 'REMOVE_WIDGET' takes care of the removal when the destroy life-cycle hits
-      result[uid] = state.calculatedWidgets[uid];
       continue;
     }
 

--- a/libs/core/src/lib/store/reducers/remove-widget.ts
+++ b/libs/core/src/lib/store/reducers/remove-widget.ts
@@ -1,13 +1,12 @@
 import { isInputWidget } from '../../form-widget';
 import { pipe } from '../../utils/function';
-import { deleteKey, unset } from '../../utils/object';
+import { deleteKey } from '../../utils/object';
 import { type REMOVE_WIDGET } from '../actions';
 import { type State } from '../model';
 
 export function removeWidget(state: State, action: REMOVE_WIDGET): State {
   return pipe(
     state,
-    data(action),
     widgetFlags(action),
     calculatedWidgets(action),
     widgetPropOverrides(action),
@@ -15,19 +14,6 @@ export function removeWidget(state: State, action: REMOVE_WIDGET): State {
   );
   // TODO: clear widget from injectedValidations
 }
-
-const data =
-  (action: REMOVE_WIDGET) =>
-  (state: State): State => ({
-    ...state,
-    data: pipe(state.calculatedWidgets, (calculatedWidgets) => {
-      const widget = calculatedWidgets[action.payload.uid].current;
-      if (widget && isInputWidget(widget)) {
-        return unset(state.data, widget.path);
-      }
-      return state.data;
-    }),
-  });
 
 const widgetFlags =
   (action: REMOVE_WIDGET) =>

--- a/libs/core/src/lib/store/reducers/remove-widget.ts
+++ b/libs/core/src/lib/store/reducers/remove-widget.ts
@@ -1,33 +1,71 @@
 import { isInputWidget } from '../../form-widget';
 import { pipe } from '../../utils/function';
-import { deleteKey } from '../../utils/object';
+import { deleteKey, unset } from '../../utils/object';
 import { type REMOVE_WIDGET } from '../actions';
 import { type State } from '../model';
 
-// TODO: should we remove data as well?
 export function removeWidget(state: State, action: REMOVE_WIDGET): State {
-  return {
+  return pipe(
+    state,
+    data(action),
+    widgetFlags(action),
+    calculatedWidgets(action),
+    widgetPropOverrides(action),
+    touchedControls(action),
+  );
+  // TODO: clear widget from injectedValidations
+}
+
+const data =
+  (action: REMOVE_WIDGET) =>
+  (state: State): State => ({
+    ...state,
+    data: pipe(state.calculatedWidgets, (calculatedWidgets) => {
+      const widget = calculatedWidgets[action.payload.uid].current;
+      if (widget && isInputWidget(widget)) {
+        return unset(state.data, widget.path);
+      }
+      return state.data;
+    }),
+  });
+
+const widgetFlags =
+  (action: REMOVE_WIDGET) =>
+  (state: State): State => ({
     ...state,
     widgetFlags: {
       ...deleteKey(state.widgetFlags, action.payload.uid),
     },
+  });
+
+const calculatedWidgets =
+  (action: REMOVE_WIDGET) =>
+  (state: State): State => ({
+    ...state,
     // TODO: has this already been removed in calculate-widget-props??? Do we need this at all?
     calculatedWidgets: {
       ...deleteKey(state.calculatedWidgets, action.payload.uid),
     },
+  });
+
+const widgetPropOverrides =
+  (action: REMOVE_WIDGET) =>
+  (state: State): State => ({
+    ...state,
     widgetPropOverrides: {
       ...deleteKey(state.widgetPropOverrides, action.payload.uid),
     },
-    touchedControls: {
-      ...pipe(state.touchedControls, (touchedControls) => {
-        // TODO: this doesn't account for repeater items
-        const widget = state.flatForm[action.payload.uid];
-        if (widget && isInputWidget(widget)) {
-          return deleteKey(touchedControls, widget.path);
-        }
-        return touchedControls;
-      }),
-    },
-    // TODO: clear widget from injectedValidations
-  };
-}
+  });
+
+const touchedControls =
+  (action: REMOVE_WIDGET) =>
+  (state: State): State => ({
+    ...state,
+    touchedControls: pipe(state.touchedControls, (touchedControls) => {
+      const widget = state.flatForm[action.payload.uid];
+      if (widget && isInputWidget(widget)) {
+        return deleteKey(touchedControls, widget.path);
+      }
+      return touchedControls;
+    }),
+  });

--- a/libs/core/src/lib/utils/form.spec.ts
+++ b/libs/core/src/lib/utils/form.spec.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from 'vitest';
+import { type InputWidget, type LayoutWidget } from '../form-widget';
 import { type State } from '../store/model';
-import { calculateValidationVariables, flattenForm } from './form';
+import { calculateValidationVariables, flattenForm, pruneHiddenData } from './form';
 
 describe('utils.form', () => {
   describe('flattenForm', () => {
-    const textWidget = (name: string) => ({ type: 'text', kind: 'input', name }) as any;
-    const layoutWidget = (name: string, children: any[]) =>
-      ({ type: 'layout', kind: 'layout', name, children }) as any;
+    const textWidget = (uid: string) =>
+      ({ uid, kind: 'input', type: 'textinput', path: uid }) satisfies InputWidget<unknown>;
+
+    const layoutWidget = (uid: string, children: LayoutWidget['children']) =>
+      ({ uid, kind: 'layout', type: 'flex', children }) satisfies LayoutWidget;
 
     it('returns an empty array for an empty form', () => {
       expect(flattenForm([])).toEqual([]);
@@ -41,7 +44,8 @@ describe('utils.form', () => {
   });
 
   describe('calculateValidationVariables', () => {
-    const makeState = (validations: State['validations']) => ({ validations }) as any;
+    const makeState = (validations: State['validations']) =>
+      ({ validations }) satisfies Pick<State, 'validations'> as unknown as State;
 
     it('returns $formIsInvalid: false and empty $errors when validations is empty', () => {
       const result = calculateValidationVariables(makeState({}));
@@ -72,6 +76,107 @@ describe('utils.form', () => {
       const result = calculateValidationVariables(makeState({ age: ['Too young'], name: null }));
       expect(result.$errors).not.toHaveProperty('name');
       expect(result.$errors).toMatchObject({ age: ['Too young'] });
+    });
+  });
+
+  describe('pruneHiddenData', () => {
+    const inputWidget = (path: string) =>
+      ({ uid: '', kind: 'input', type: 'textinput', path }) satisfies InputWidget<unknown, string>;
+
+    const layoutWidget = () =>
+      ({ uid: '', kind: 'layout', type: 'flex', children: [] }) satisfies LayoutWidget<string>;
+
+    const makeState = (
+      data: State['data'],
+      widgetFlags: State['widgetFlags'],
+      flatForm: State['flatForm'],
+    ) =>
+      ({ data, widgetFlags, flatForm }) satisfies Pick<
+        State,
+        'data' | 'widgetFlags' | 'flatForm'
+      > as unknown as State;
+
+    it('returns data unchanged when no widgets are hidden', () => {
+      const state = makeState(
+        { name: 'Alice' },
+        { nameField: {} },
+        { nameField: inputWidget('name') },
+      );
+      expect(pruneHiddenData(state)).toEqual({ name: 'Alice' });
+    });
+
+    it('removes the path of a hidden input widget', () => {
+      const state = makeState(
+        { name: 'Alice', extra: 'hidden value' },
+        { extraField: { hidden: true } },
+        { extraField: inputWidget('extra') },
+      );
+      expect(pruneHiddenData(state)).toEqual({ name: 'Alice' });
+    });
+
+    it('does not mutate state.data', () => {
+      const data = { name: 'Alice', extra: 'hidden value' };
+      const state = makeState(
+        data,
+        { extraField: { hidden: true } },
+        { extraField: inputWidget('extra') },
+      );
+      pruneHiddenData(state);
+      expect(data).toEqual({ name: 'Alice', extra: 'hidden value' });
+    });
+
+    it('removes a nested dot-path for a hidden widget', () => {
+      const state = makeState(
+        { user: { name: 'Alice', age: 30 } },
+        { ageField: { hidden: true } },
+        { ageField: inputWidget('user.age') },
+      );
+      expect(pruneHiddenData(state)).toEqual({ user: { name: 'Alice' } });
+    });
+
+    it('prunes empty ancestor objects after removing the only nested value', () => {
+      const state = makeState(
+        { user: { age: 30 } },
+        { ageField: { hidden: true } },
+        { ageField: inputWidget('user.age') },
+      );
+      expect(pruneHiddenData(state)).toEqual({});
+    });
+
+    it('removes paths for all hidden widgets', () => {
+      const state = makeState(
+        { name: 'Alice', city: 'BCN', country: 'ES' },
+        { cityField: { hidden: true }, countryField: { hidden: true } },
+        { cityField: inputWidget('city'), countryField: inputWidget('country') },
+      );
+      expect(pruneHiddenData(state)).toEqual({ name: 'Alice' });
+    });
+
+    it('skips entries with hidden not strictly true', () => {
+      const state = makeState(
+        { name: 'Alice' },
+        { nameField: { hidden: undefined } },
+        { nameField: inputWidget('name') },
+      );
+      expect(pruneHiddenData(state)).toEqual({ name: 'Alice' });
+    });
+
+    it('skips hidden layout widgets (no path to prune)', () => {
+      const state = makeState(
+        { name: 'Alice' },
+        { section: { hidden: true } },
+        { section: layoutWidget() },
+      );
+      expect(pruneHiddenData(state)).toEqual({ name: 'Alice' });
+    });
+
+    it('skips uid entries absent from flatForm (e.g. indexed repeater items)', () => {
+      const state = makeState(
+        { items: [{ name: 'Alice' }] },
+        { 'itemName[0]': { hidden: true } },
+        {},
+      );
+      expect(pruneHiddenData(state)).toEqual({ items: [{ name: 'Alice' }] });
     });
   });
 });

--- a/libs/core/src/lib/utils/form.ts
+++ b/libs/core/src/lib/utils/form.ts
@@ -1,7 +1,7 @@
-import { type FormWidget, isLayoutWidget } from '../form-widget';
+import { type FormWidget, isInputWidget, isLayoutWidget } from '../form-widget';
 import { type $Errors } from '../shared';
 import { type State } from '../store/model';
-import { set } from './object';
+import { cloneObject, set, unset } from './object';
 
 /**
  * Flattens the hierarchical form structure into a single-level array of form widgets.
@@ -49,4 +49,24 @@ export function calculateValidationVariables(state: State): {
     { $formIsInvalid: false, $errors: {} },
   );
   return result;
+}
+
+/**
+ * Returns a copy of the form data with values for currently-hidden input widgets removed.
+ * Paths are derived from the flat form widget map so this works even though hidden widgets
+ * are absent from calculatedWidgets.
+ */
+export function pruneHiddenData(state: State): Record<string, any> {
+  const pruned = cloneObject(state.data);
+
+  for (const [uid, flags] of Object.entries(state.widgetFlags)) {
+    if (flags.hidden === true) {
+      const widget = state.flatForm[uid];
+      if (widget && isInputWidget(widget)) {
+        unset(pruned, widget.path);
+      }
+    }
+  }
+
+  return pruned;
 }

--- a/libs/core/src/lib/utils/object.spec.ts
+++ b/libs/core/src/lib/utils/object.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { cloneObject, get, set } from './object';
+import { cloneObject, get, set, unset } from './object';
 
 describe('object.set', () => {
   it('sets dot notation paths', () => {
@@ -255,6 +255,62 @@ describe('object.get', () => {
       expect(get(numericPropObj, '1.nested')).toBe('value');
       expect(get(numericPropObj, 'normal')).toBe('property');
     });
+  });
+});
+
+describe('object.unset', () => {
+  it('removes a leaf key while preserving siblings', () => {
+    const obj = { a: { b: { c: 1, d: 2 } } };
+    unset(obj, 'a.b.c');
+    expect(obj).toEqual({ a: { b: { d: 2 } } });
+  });
+
+  it('prunes empty plain object ancestors recursively', () => {
+    const obj = { a: { b: { c: 1 } } };
+    unset(obj, 'a.b.c');
+    expect(obj).toEqual({});
+  });
+
+  it('prunes only the empty branch, leaving non-empty siblings intact', () => {
+    const obj = { a: { b: { c: 1 }, keep: true } };
+    unset(obj, 'a.b.c');
+    expect(obj).toEqual({ a: { keep: true } });
+  });
+
+  it('removes a root-level key', () => {
+    const obj = { username: 'john' };
+    unset(obj, 'username');
+    expect(obj).toEqual({});
+  });
+
+  it('keeps the empty object in the array when its only property is removed', () => {
+    const obj = { items: [{ name: 'Alice' }] };
+    unset(obj, 'items.0.name');
+    expect(obj).toEqual({ items: [{}] });
+  });
+
+  it('keeps the empty object in the array at its original index when siblings remain', () => {
+    const obj = { items: [{ name: 'Alice' }, { name: 'Bob' }] };
+    unset(obj, 'items.0.name');
+    expect(obj).toEqual({ items: [{}, { name: 'Bob' }] });
+  });
+
+  it('is a no-op when the path does not exist', () => {
+    const obj = { a: 1 };
+    unset(obj, 'a.b.c');
+    expect(obj).toEqual({ a: 1 });
+  });
+
+  it('returns the object unchanged when path is empty', () => {
+    const obj = { a: 1 };
+    unset(obj, '');
+    expect(obj).toEqual({ a: 1 });
+  });
+
+  it('mutates and returns the original object reference', () => {
+    const obj = { a: { b: 1 } };
+    const result = unset(obj, 'a.b');
+    expect(result).toBe(obj);
   });
 });
 

--- a/libs/core/src/lib/utils/object.ts
+++ b/libs/core/src/lib/utils/object.ts
@@ -174,9 +174,105 @@ export const set = (object: Record<string, any>, path: DotPath, value: any) => {
   return object;
 };
 
+/**
+ * Removes the property at the given dot-path from object by mutation.
+ * After deletion, any ancestor plain objects that become empty are also removed.
+ * Ancestor arrays that become empty are left in place — upward pruning stops as
+ * soon as an array boundary is encountered.
+ *
+ * @param object - The object to modify
+ * @param path - The dot-separated path of the property to remove (e.g. "user.profile.name").
+ *   Pass an empty string to return the object unchanged.
+ * @returns The modified object (mutates the original object). Returns unchanged if path is
+ *   empty or does not exist.
+ *
+ * @example
+ * Basic property removal with sibling preserved:
+ * ```typescript
+ * const obj = { user: { name: 'John', age: 30 } };
+ * unset(obj, 'user.name');
+ * // Result: { user: { age: 30 } }
+ * ```
+ *
+ * @example
+ * Recursive pruning of empty ancestors:
+ * ```typescript
+ * const obj = { a: { b: { c: 1 } } };
+ * unset(obj, 'a.b.c');
+ * // Result: {} — 'b' and 'a' are pruned because they became empty objects
+ * ```
+ *
+ * @example
+ * Pruning stops at array boundaries:
+ * ```typescript
+ * const obj = { items: [{ name: 'Alice' }] };
+ * unset(obj, 'items.0.name');
+ * // Result: { items: [{}] } — the empty object is kept inside the array
+ * ```
+ */
+export const unset = <T extends Record<string, any>>(object: T, path: DotPath): T => {
+  if (path === '') {
+    return object;
+  }
+
+  const segments = path.split('.');
+  const containers: Array<any> = [object];
+
+  // Collect each intermediate container along the path
+  for (let i = 0; i < segments.length - 1; i++) {
+    const current = containers[i];
+    if (current === null || current === undefined || typeof current !== 'object') {
+      return object;
+    }
+    const segment = segments[i];
+    const next = Array.isArray(current) ? current[parseInt(segment, 10)] : current[segment];
+    if (next === null || next === undefined || typeof next !== 'object') {
+      return object;
+    }
+    containers.push(next);
+  }
+
+  // Delete the target property from its direct container
+  const targetContainer = containers[containers.length - 1];
+  const targetSegment = segments[segments.length - 1];
+  if (Array.isArray(targetContainer)) {
+    targetContainer.splice(parseInt(targetSegment, 10), 1);
+  } else {
+    delete targetContainer[targetSegment];
+  }
+
+  // Walk up, pruning ancestor plain objects that became empty.
+  // Stop when hitting a non-empty container or an array.
+  for (let i = containers.length - 1; i >= 1; i--) {
+    const child = containers[i];
+    if (Array.isArray(child) || !isEmptyPlainObject(child)) {
+      break;
+    }
+    const parent = containers[i - 1];
+    const segment = segments[i - 1];
+    if (Array.isArray(parent)) {
+      break;
+    } else {
+      delete parent[segment];
+    }
+  }
+
+  return object;
+};
+
 function isIndex(value: string) {
   const num = Number(value);
   return Number.isInteger(num) && num >= 0 && num.toString() === value;
+}
+
+function isEmptyPlainObject(value: any): boolean {
+  return (
+    value !== null &&
+    value !== undefined &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === 0
+  );
 }
 
 /**

--- a/libs/gui/angular/cypress/support/mount.ts
+++ b/libs/gui/angular/cypress/support/mount.ts
@@ -1,7 +1,13 @@
 import { CommonModule } from '@angular/common';
 import { EventEmitter, type Type } from '@angular/core';
 import { FormCoreComponent } from '@golemui/angular';
-import type { FormEvent, FormHealth, WidgetLoaders, WithWidget } from '@golemui/core';
+import type {
+  FormEvent,
+  FormHealth,
+  FormSubmitEvent,
+  WidgetLoaders,
+  WithWidget,
+} from '@golemui/core';
 import { type GuiFormInitConfig } from '@golemui/gui-shared';
 import { type MountOptions } from '@golemui/ui-testing';
 import { createOutputSpy, mount } from 'cypress/angular';
@@ -35,6 +41,15 @@ export const mountFramework = (options: MountOptions) => {
     formHealthOutput = createOutputSpy('formHealth');
   }
 
+  let formSubmitOutput;
+  if (options.formSubmit) {
+    const emitter = new EventEmitter<FormSubmitEvent>();
+    emitter.subscribe((e) => options.formSubmit!(e));
+    formSubmitOutput = emitter;
+  } else {
+    formSubmitOutput = createOutputSpy('formSubmit');
+  }
+
   const config: GuiFormInitConfig = {
     formDef: options.formDef,
     data: options.data,
@@ -53,6 +68,7 @@ export const mountFramework = (options: MountOptions) => {
       config,
       formHealth: formHealthOutput,
       formEvent: formEventOutput,
+      formSubmit: formSubmitOutput,
     },
   }).then(({ fixture }) => {
     // toObservable()'s internal effect is scheduled, not run, during the first detectChanges() call

--- a/libs/gui/lit/cypress/support/mount.ts
+++ b/libs/gui/lit/cypress/support/mount.ts
@@ -1,4 +1,10 @@
-import type { FormEvent, FormHealth, WidgetLoaders, WithWidget } from '@golemui/core';
+import type {
+  FormEvent,
+  FormHealth,
+  FormSubmitEvent,
+  WidgetLoaders,
+  WithWidget,
+} from '@golemui/core';
 import { type GuiFormInitConfig } from '@golemui/gui-shared';
 import { type Type } from '@golemui/lit';
 import { type FormHandle, type MountOptions } from '@golemui/ui-testing';
@@ -30,6 +36,14 @@ export const mountFramework = (options: MountOptions) => {
     }
   };
 
+  const handleFormSubmit = (e: CustomEvent<FormSubmitEvent>) => {
+    if (options.formSubmit) {
+      options.formSubmit(e.detail);
+    } else {
+      cy.spy().as('formSubmit')(e.detail);
+    }
+  };
+
   const config: GuiFormInitConfig = {
     formDef: options.formDef,
     data: options.data,
@@ -47,6 +61,7 @@ export const mountFramework = (options: MountOptions) => {
       .config=${config}
       @formEvent=${handleFormEvent}
       @formHealth=${handleFormHealth}
+      @formSubmit=${handleFormSubmit}
     ></gui-form>`,
   ).then(() => {
     const el = document.querySelector('gui-form') as HTMLElement & FormHandle;

--- a/libs/gui/react/cypress/support/mount.tsx
+++ b/libs/gui/react/cypress/support/mount.tsx
@@ -19,6 +19,8 @@ export const mountFramework = (options: MountOptions) => {
 
   const handleFormHealth = options.formHealth ? options.formHealth : cy.spy().as('formHealth');
 
+  const handleFormSubmit = options.formSubmit ? options.formSubmit : cy.spy().as('formSubmit');
+
   const config: GuiFormInitConfig = {
     formDef: options.formDef,
     data: options.data,
@@ -39,6 +41,7 @@ export const mountFramework = (options: MountOptions) => {
       config={config}
       formEvent={handleFormEvent}
       formHealth={handleFormHealth}
+      formSubmit={handleFormSubmit}
     />,
   );
 

--- a/libs/gui/vue/cypress/support/mount.ts
+++ b/libs/gui/vue/cypress/support/mount.ts
@@ -1,4 +1,4 @@
-import type { WidgetLoaders, WithWidget } from '@golemui/core';
+import type { FormSubmitEvent, WidgetLoaders, WithWidget } from '@golemui/core';
 import type { GuiFormInitConfig } from '@golemui/gui-shared';
 import type { MountOptions } from '@golemui/ui-testing';
 import { h, ref, type Component } from 'vue';
@@ -15,6 +15,9 @@ export const mountFramework = (options: MountOptions) => {
 
   const handleFormEvent = options.formEvent ? options.formEvent : cy.spy().as('formEvent');
   const handleFormHealth = options.formHealth ? options.formHealth : cy.spy().as('formHealth');
+  const handleFormSubmit = options.formSubmit
+    ? options.formSubmit
+    : (cy.spy().as('formSubmit') as unknown as (event: FormSubmitEvent) => void);
 
   const config: GuiFormInitConfig = {
     formDef: options.formDef,
@@ -38,6 +41,7 @@ export const mountFramework = (options: MountOptions) => {
       config,
       'onForm-event': handleFormEvent,
       'onForm-health': handleFormHealth,
+      'onForm-submit': handleFormSubmit,
     }),
   );
 

--- a/libs/ui-testing/src/lib/core-features/data.cy.ts
+++ b/libs/ui-testing/src/lib/core-features/data.cy.ts
@@ -59,5 +59,57 @@ export const runDataComponentTests = (mountFn: MountComponentFn) => {
       cy.get('[data-cy="selectData_select"]').should('have.value', 'option2');
       cy.get('[data-cy="radioData_radiogroup_1"]').should('be.checked');
     });
+
+    it('should not include hidden field data in submitted form data', () => {
+      const formSubmitHandler = cy.stub().as('formSubmitHandler');
+
+      mountFn({
+        formDef: defineForm({
+          form: [
+            {
+              uid: 'showExtra',
+              kind: 'input',
+              type: 'checkbox',
+              path: 'showExtra',
+              label: 'Show extra field',
+            },
+            {
+              uid: 'extraField',
+              kind: 'input',
+              type: 'textinput',
+              path: 'extra',
+              label: 'Extra field',
+              include: { when: '$form.showExtra === true' },
+            },
+            {
+              uid: 'submitBtn',
+              kind: 'action',
+              type: 'button',
+              label: 'Submit',
+              actionType: 'submit',
+            },
+          ],
+        }),
+        formSubmit: formSubmitHandler,
+      });
+
+      // Make the field visible and enter a value
+      cy.get('[data-cy="showExtra_checkbox"]').click();
+      cy.get('[data-cy="extraField_textinput"]').should('exist').type('hidden value');
+
+      // Hide the field by unchecking the checkbox
+      cy.get('[data-cy="showExtra_checkbox"]').click();
+      cy.get('[data-cy="extraField_textinput"]').should('not.exist');
+
+      // Submit the form
+      cy.get('[data-cy="submitBtn_button"]').click();
+
+      // The submitted data must not carry the value of the hidden field
+      cy.get('@formSubmitHandler').should('have.been.calledOnce');
+      cy.get('@formSubmitHandler').then((stub: any) => {
+        const submittedData = stub.getCall(0).args[0].data;
+        expect(submittedData).to.deep.equal({ showExtra: false });
+      });
+    });
   });
 };

--- a/libs/ui-testing/src/lib/utils.ts
+++ b/libs/ui-testing/src/lib/utils.ts
@@ -1,4 +1,11 @@
-import type { Form, FormEvent, FormHealth, I18nTranslator, UiState } from '@golemui/core';
+import type {
+  Form,
+  FormEvent,
+  FormHealth,
+  FormSubmitEvent,
+  I18nTranslator,
+  UiState,
+} from '@golemui/core';
 import { type Action, type Middleware, type State, type ValidateOn } from '@golemui/core';
 import { type Dependencies } from '@golemui/gui-shared';
 import { type CustomValidatorSchemas } from '@golemui/gui-validators';
@@ -16,6 +23,7 @@ export interface MountOptions<StateKeys extends UiState = string> {
   validators?: CustomValidatorSchemas;
   formEvent?: (event: FormEvent) => void | Promise<void>;
   formHealth?: (error: FormHealth) => void | Promise<void>;
+  formSubmit?: (event: FormSubmitEvent) => void;
   validateOn?: ValidateOn;
   withCustomComponent?: boolean;
   localization?: I18nTranslator;


### PR DESCRIPTION
## Description

When conditional rendering hides a node in the widget tree, its associated data must also be removed from the form.