### PR TITLE
fix(core): sync touched on widgets added after VALIDATE_ALL

### DIFF
--- a/libs/core/src/lib/store/reducers/add-widget.ts
+++ b/libs/core/src/lib/store/reducers/add-widget.ts
@@ -1,4 +1,4 @@
-import { type NonFunctionWidget } from '../../form-widget';
+import { isInputWidget, type NonFunctionWidget } from '../../form-widget';
 import { type ADD_WIDGET } from '../actions';
 import { type State } from '../model';
 
@@ -7,12 +7,23 @@ export function addWidget(state: State, action: ADD_WIDGET): State {
   if (!uid) {
     throw new Error('addWidget: widget must have a uid');
   }
+
+  const widget = action.payload.widget;
+
+  // If the form has already been globally touched (e.g. submitted), immediately
+  // mark the incoming widget as touched so its validation errors are visible.
+  const touchedControls =
+    state.touched && isInputWidget(widget)
+      ? { ...state.touchedControls, [(widget as any).path]: true }
+      : state.touchedControls;
+
   return {
     ...state,
+    touchedControls,
     calculatedWidgets: {
       ...state.calculatedWidgets,
       [uid]: {
-        source: action.payload.widget,
+        source: widget,
         current: {} as NonFunctionWidget,
       },
     },

--- a/libs/ui-testing/src/lib/golem-features/select.cy.ts
+++ b/libs/ui-testing/src/lib/golem-features/select.cy.ts
@@ -28,6 +28,7 @@ export const runSelectComponentTests = (mountFn: MountComponentFn) => {
         }),
       });
 
+      cy.get('[data-cy="testSubject_select"]').should('exist');
       cy.get('[data-cy="testButton_button"]').click();
       cy.get('[data-cy="testSubject_validator-errors"]').should('exist');
       cy.get('[data-cy="testSubject_validator-error"]').should('be.visible');


### PR DESCRIPTION
### Description 

When a widget is added to a form already in globally-touched state (state.touched === true), its path is immediately added to touchedControls, otherwise a widget added after VALIDATE_ALL has no way to get touched=true and its errors were permanently hidden.