### PR TITLE
feat(core): validation-aware submit buttons

### DIFF
--- a/docs/src/content/docs/widgets-reference/interactive-fields/button.mdx
+++ b/docs/src/content/docs/widgets-reference/interactive-fields/button.mdx
@@ -37,13 +37,14 @@ Button widgets are [Interactive Fields](/widgets-reference/interactive-fields/ov
 
 Use these `props` to customize your Button widget.
 
-| prop           | type                               | description                                                                |
-| -------------- | ---------------------------------- | -------------------------------------------------------------------------- |
-| `label`        | string                             | The text displayed inside the button (Optional if icon is present)         |
-| `disabled`     | boolean                            | Whether the button is interactive or not                                   |
-| `variant`      | `'filled' \| 'outlined' \| 'link'` | **Optional**. Button style variant (Default: `filled`)                     |
-| `icon`         | string                             | Optional CSS class for an icon (Implementation may vary by framework)      |
-| `iconPosition` | `'left' \| 'right'`                | **Optional**. Position of the icon relative to the label (Default: `left`) |
+| prop           | type                               | description                                                                                                      |
+| -------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `label`        | string                             | The text displayed inside the button (Optional if icon is present)                                               |
+| `actionType`   | `'button' \| 'submit'`             | **Optional**. Sets the HTML button type. `'submit'` triggers form-wide validation on click (Default: `'button'`) |
+| `disabled`     | boolean                            | Whether the button is interactive or not                                                                         |
+| `variant`      | `'filled' \| 'outlined' \| 'link'` | **Optional**. Button style variant (Default: `filled`)                                                           |
+| `icon`         | string                             | Optional CSS class for an icon (Implementation may vary by framework)                                            |
+| `iconPosition` | `'left' \| 'right'`                | **Optional**. Position of the icon relative to the label (Default: `left`)                                       |
 
 ### Variants
 
@@ -97,6 +98,43 @@ You can disable the button by setting the `disabled` property to `true`.
   src="/template/index.html?form=template/widgets/button/button-disabled.json"
 />
 
+## Submit behavior
+
+Setting `actionType: 'submit'` turns the button into a form submission trigger. Clicking it runs form-wide validation before emitting the `formSubmit` event. If any field fails validation, submission is blocked.
+
+### Validation feedback
+
+When a submit attempt fails due to validation errors, the button automatically displays an error border. This gives users a visual cue even when the invalid fields are not visible — for example in a long form or in a tab that is not currently selected.
+
+The error border clears automatically once all validation errors are resolved.
+
+This behavior is on by default and requires no additional configuration:
+
+```json
+{
+  "uid": "submit-button",
+  "kind": "action",
+  "type": "button",
+  "label": "Submit",
+  "actionType": "submit"
+}
+```
+
+If you prefer to block submission entirely rather than just flagging the button, you can combine `actionType: 'submit'` with the `$formIsInvalid` expression variable:
+
+```json
+{
+  "uid": "submit-button",
+  "kind": "action",
+  "type": "button",
+  "label": "Submit",
+  "actionType": "submit",
+  "disabled": { "when": "$formIsInvalid" }
+}
+```
+
+See [Validators](/features/validators/) for how to configure field-level validation rules.
+
 ## Styling
 
 Buttons can be styled as explained in the [Styling Guide](/styling/overview/).
@@ -105,13 +143,15 @@ Buttons can be styled as explained in the [Styling Guide](/styling/overview/).
 
 Following you will find a list with the CSS Variables and a quick description of what you will style.
 
-| CSS Variable                  | Description                         |
-| ----------------------------- | ----------------------------------- |
-| `--gui-intent-primary`        | Background color of the button      |
-| `--gui-intent-primary-text`   | Color of the text inside the button |
-| `--gui-intent-primary-hover`  | Background color on hover           |
-| `--gui-intent-primary-active` | Background color when clicked       |
-| `--gui-radius-md`             | Border radius of the button         |
+| CSS Variable                  | Description                                                        |
+| ----------------------------- | ------------------------------------------------------------------ |
+| `--gui-intent-primary`        | Background color of the button                                     |
+| `--gui-intent-primary-text`   | Color of the text inside the button                                |
+| `--gui-intent-primary-hover`  | Background color on hover                                          |
+| `--gui-intent-primary-active` | Background color when clicked                                      |
+| `--gui-radius-md`             | Border radius of the button                                        |
+| `--gui-intent-error`          | Border color when a submit button has unresolved validation errors |
+| `--gui-shadow-focus-error`    | Focus ring color when a submit button is in the invalid state      |
 
 ### Anatomy
 

--- a/libs/angular/src/lib/adapters/action-widget-adapter.service.ts
+++ b/libs/angular/src/lib/adapters/action-widget-adapter.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, signal } from '@angular/core';
 import type { ActionWidget, ActionWidgetTemplateData } from '@golemui/core';
+import { distinctUntilChanged, map, takeUntil } from 'rxjs';
 import { BaseWidgetAdapter } from './base-widget.adapter';
 
 @Injectable()
@@ -19,6 +20,16 @@ export class ActionWidgetAdapter<
 
     this.addWidgetToTheStore(widget);
     this.templateDataUpdater(this.templateData);
+
+    this.context.store.state$
+      .pipe(
+        takeUntil(this.destroy$),
+        map((state) => state.touched && !state.isFormValid),
+        distinctUntilChanged(),
+      )
+      .subscribe((invalid) => {
+        this.templateData.update((current) => ({ ...current, invalid }));
+      });
 
     this.context.emitEvent('load', this.widget);
   }

--- a/libs/core/src/lib/shared.ts
+++ b/libs/core/src/lib/shared.ts
@@ -177,6 +177,11 @@ export type ActionWidgetTemplateData = {
   label?: string;
   disabled?: boolean;
   /**
+   * True when the form has been touched and is currently invalid.
+   * Used by submit buttons to show an error visual state.
+   */
+  invalid?: boolean;
+  /**
    * A size relative to the container and sibling components
    * @example
    * // This component will measure twice than sibling components with size: 1

--- a/libs/gui/angular/cypress/test/core-features/actions.cy.ts
+++ b/libs/gui/angular/cypress/test/core-features/actions.cy.ts
@@ -1,0 +1,4 @@
+import { runActionsComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runActionsComponentTests(mountFramework);

--- a/libs/gui/angular/src/lib/components/button/button.component.html
+++ b/libs/gui/angular/src/lib/components/button/button.component.html
@@ -5,6 +5,7 @@
   [actionType]="templateData.actionType ?? 'button'"
   [label]="templateData.label"
   [disabled]="templateData.disabled"
+  [invalid]="templateData.invalid"
   [variant]="templateData.variant"
   [icon]="templateData.icon"
   [iconPosition]="templateData.iconPosition"

--- a/libs/gui/components/src/lib/components/button.ts
+++ b/libs/gui/components/src/lib/components/button.ts
@@ -11,6 +11,7 @@ export class GuiButton extends LitElement {
   @property({ type: String }) variant: 'filled' | 'outlined' | 'link' | undefined = 'filled';
   @property({ type: String }) iconPosition: 'left' | 'right' | undefined = 'left';
   @property({ type: String }) actionType: 'submit' | 'button' | undefined = 'button';
+  @property({ type: Boolean }) invalid = false;
 
   override createRenderRoot() {
     return this;
@@ -30,6 +31,7 @@ export class GuiButton extends LitElement {
       [`gui-button-icon-${iconPosition}`]: true,
       'gui-button--outlined': this.variant === 'outlined',
       'gui-button--link': this.variant === 'link',
+      'gui-button--invalid': this.invalid && this.actionType === 'submit',
     };
 
     const iconTemplate = icon

--- a/libs/gui/components/src/styles/button.scss
+++ b/libs/gui/components/src/styles/button.scss
@@ -86,5 +86,23 @@
         color: var(--gui-intent-primary-active);
       }
     }
+
+    &.gui-button--invalid {
+      background: var(--gui-intent-error);
+      color: var(--gui-intent-error-text);
+
+      &:hover {
+        background: var(--gui-intent-error-hover);
+      }
+
+      &:active {
+        background: var(--gui-intent-error-hover);
+      }
+
+      &:focus {
+        outline: 0;
+        box-shadow: var(--gui-shadow-focus-error);
+      }
+    }
   }
 }

--- a/libs/gui/components/src/styles/button.scss
+++ b/libs/gui/components/src/styles/button.scss
@@ -88,16 +88,7 @@
     }
 
     &.gui-button--invalid {
-      background: var(--gui-intent-error);
-      color: var(--gui-intent-error-text);
-
-      &:hover {
-        background: var(--gui-intent-error-hover);
-      }
-
-      &:active {
-        background: var(--gui-intent-error-hover);
-      }
+      border: 2px solid var(--gui-intent-error);
 
       &:focus {
         outline: 0;

--- a/libs/gui/lit/cypress/test/core-features/actions.cy.ts
+++ b/libs/gui/lit/cypress/test/core-features/actions.cy.ts
@@ -1,0 +1,4 @@
+import { runActionsComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runActionsComponentTests(mountFramework);

--- a/libs/gui/lit/src/lib/components/button.element.ts
+++ b/libs/gui/lit/src/lib/components/button.element.ts
@@ -54,6 +54,7 @@ export class ButtonElement extends LitElement implements WithWidget {
         .actionType=${this.adapter.templateData.actionType ?? 'button'}
         .label=${this.adapter.templateData.label}
         ?disabled=${this.adapter.templateData.disabled === true}
+        ?invalid=${this.adapter.templateData.invalid === true}
         .variant=${this.adapter.templateData.variant}
         .icon=${this.adapter.templateData.icon}
         .iconPosition=${this.adapter.templateData.iconPosition}

--- a/libs/gui/react/cypress/test/core-features/actions.cy.ts
+++ b/libs/gui/react/cypress/test/core-features/actions.cy.ts
@@ -1,0 +1,4 @@
+import { runActionsComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runActionsComponentTests(mountFramework);

--- a/libs/gui/react/src/lib/components/Button.tsx
+++ b/libs/gui/react/src/lib/components/Button.tsx
@@ -15,6 +15,7 @@ export function Button(widgetInstance: WithWidget) {
         actionType={templateData.actionType ?? 'button'}
         label={templateData.label as string}
         disabled={templateData.disabled as boolean}
+        invalid={templateData.invalid as boolean}
         variant={templateData.variant}
         icon={templateData.icon}
         iconPosition={templateData.iconPosition}

--- a/libs/gui/vue/cypress/test/core-features/actions.cy.ts
+++ b/libs/gui/vue/cypress/test/core-features/actions.cy.ts
@@ -1,0 +1,4 @@
+import { runActionsComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runActionsComponentTests(mountFramework);

--- a/libs/gui/vue/src/lib/components/Button.vue
+++ b/libs/gui/vue/src/lib/components/Button.vue
@@ -7,7 +7,7 @@ import '@golemui/gui-components/button';
 
 const props = defineProps<WithWidget>();
 const widget = props.widget as ActionWidget;
-const { uid, templateData, onClick } = useActionWidget<ButtonProps>(widget);
+const { uid, templateData, invalid, onClick } = useActionWidget<ButtonProps>(widget);
 
 // Mirror the Lit element's class-field defaults so Vue never sends '' or undefined
 // to an enum prop (which Lit's String converter would coerce to '', overriding the default).
@@ -22,6 +22,7 @@ const iconPosition = computed(() => templateData.value.iconPosition || 'left');
       :actionType="templateData.actionType ?? 'button'"
       :label="templateData.label"
       :disabled="templateData.disabled"
+      :invalid.prop="invalid"
       :variant.prop="variant"
       :icon="templateData.icon"
       :iconPosition.prop="iconPosition"

--- a/libs/lit/src/lib/adapters/action-widget.adapter.ts
+++ b/libs/lit/src/lib/adapters/action-widget.adapter.ts
@@ -1,5 +1,6 @@
 import type { ActionWidget, ActionWidgetTemplateData } from '@golemui/core';
 import { createContext } from '@lit/context';
+import { distinctUntilChanged, map, takeUntil } from 'rxjs';
 import { BaseWidgetAdapter } from './base-widget.adapter';
 
 export const actionContext = createContext<ActionWidgetAdapter<any>>('guiActionWidgetAdapter');
@@ -19,6 +20,16 @@ export class ActionWidgetAdapter<
 
     this.addWidgetToTheStore(widget);
     this.templateDataUpdater();
+
+    this.context.store.state$
+      .pipe(
+        takeUntil(this.destroy$),
+        map((state) => state.touched && !state.isFormValid),
+        distinctUntilChanged(),
+      )
+      .subscribe((invalid) => {
+        this.setTemplateData({ invalid });
+      });
 
     this.context.emitEvent('load', this.widget);
   }

--- a/libs/react/src/lib/hooks/useActionWidget.ts
+++ b/libs/react/src/lib/hooks/useActionWidget.ts
@@ -1,5 +1,6 @@
 import type { ActionWidget } from '@golemui/core';
 import { useCallback, useEffect, useState } from 'react';
+import { distinctUntilChanged, map } from 'rxjs';
 import { useReactFormContext } from '../ReactFormContext';
 import { useTemplateData } from './internal/useExtraProps';
 
@@ -9,6 +10,7 @@ export function useActionWidget<ExtraProps extends Record<string, any>>(
   const { formContext } = useReactFormContext();
   const [uid, setUid] = useState('');
   const templateData = useTemplateData<ActionWidget<string>, ExtraProps>(widget);
+  const [invalid, setInvalid] = useState(false);
 
   useEffect(() => {
     setUid(widget.uid);
@@ -34,13 +36,25 @@ export function useActionWidget<ExtraProps extends Record<string, any>>(
     };
   }, [formContext, widget]);
 
+  useEffect(() => {
+    const subscription = formContext.store.state$
+      .pipe(
+        map((state) => state.touched && !state.isFormValid),
+        distinctUntilChanged(),
+      )
+      .subscribe((isInvalid) => {
+        setInvalid(isInvalid);
+      });
+    return () => subscription.unsubscribe();
+  }, [formContext.store.state$]);
+
   const onClick = useCallback(() => {
     formContext.emitEvent('click', widget);
   }, [widget, formContext]);
 
   return {
     uid,
-    templateData,
+    templateData: { ...templateData, invalid },
     onClick,
   };
 }

--- a/libs/ui-testing/src/index.ts
+++ b/libs/ui-testing/src/index.ts
@@ -1,4 +1,5 @@
 // Core features
+export * from './lib/core-features/actions.cy';
 export * from './lib/core-features/data.cy';
 export * from './lib/core-features/dependencies.cy';
 export * from './lib/core-features/disabled.cy';

--- a/libs/ui-testing/src/lib/core-features/actions.cy.ts
+++ b/libs/ui-testing/src/lib/core-features/actions.cy.ts
@@ -1,0 +1,122 @@
+import { type MountComponentFn } from '../utils';
+import { golemForm } from '@golemui/gui-shared';
+
+export const runActionsComponentTests = (mountFn: MountComponentFn) => {
+  describe('Actions', () => {
+    context('Submit button invalid state', () => {
+      it('should not have the invalid class before any submit attempt', () => {
+        mountFn({
+          formDef: golemForm().create({
+            form: [
+              {
+                uid: 'name',
+                kind: 'input',
+                type: 'textinput',
+                path: 'name',
+                validator: { type: 'string', required: true },
+              },
+              {
+                uid: 'submitBtn',
+                kind: 'action',
+                type: 'button',
+                label: 'Submit',
+                actionType: 'submit',
+              },
+            ],
+          }),
+        });
+
+        cy.get('[data-cy="submitBtn_button"]').should('not.have.class', 'gui-button--invalid');
+      });
+
+      it('should apply the invalid class when submitted with validation errors', () => {
+        mountFn({
+          formDef: golemForm().create({
+            form: [
+              {
+                uid: 'name',
+                kind: 'input',
+                type: 'textinput',
+                path: 'name',
+                validator: { type: 'string', required: true },
+              },
+              {
+                uid: 'submitBtn',
+                kind: 'action',
+                type: 'button',
+                label: 'Submit',
+                actionType: 'submit',
+              },
+            ],
+          }),
+        });
+
+        cy.get('[data-cy="submitBtn_button"]').click();
+        cy.get('[data-cy="submitBtn_button"]').should('have.class', 'gui-button--invalid');
+      });
+
+      it('should remove the invalid class once all errors are resolved', () => {
+        mountFn({
+          formDef: golemForm().create({
+            form: [
+              {
+                uid: 'name',
+                kind: 'input',
+                type: 'textinput',
+                path: 'name',
+                validator: { type: 'string', required: true },
+              },
+              {
+                uid: 'submitBtn',
+                kind: 'action',
+                type: 'button',
+                label: 'Submit',
+                actionType: 'submit',
+              },
+            ],
+          }),
+        });
+
+        cy.get('[data-cy="submitBtn_button"]').click();
+        cy.get('[data-cy="submitBtn_button"]').should('have.class', 'gui-button--invalid');
+
+        cy.get('[data-cy="name_textinput"]').type('Joan');
+        cy.get('[data-cy="submitBtn_button"]').should('not.have.class', 'gui-button--invalid');
+      });
+
+      it('should not apply the invalid class to a non-submit button', () => {
+        mountFn({
+          formDef: golemForm().create({
+            form: [
+              {
+                uid: 'name',
+                kind: 'input',
+                type: 'textinput',
+                path: 'name',
+                validator: { type: 'string', required: true },
+              },
+              {
+                uid: 'plainBtn',
+                kind: 'action',
+                type: 'button',
+                label: 'Action',
+                actionType: 'button',
+              },
+              {
+                uid: 'submitBtn',
+                kind: 'action',
+                type: 'button',
+                label: 'Submit',
+                actionType: 'submit',
+              },
+            ],
+          }),
+        });
+
+        cy.get('[data-cy="submitBtn_button"]').click();
+        cy.get('[data-cy="submitBtn_button"]').should('have.class', 'gui-button--invalid');
+        cy.get('[data-cy="plainBtn_button"]').should('not.have.class', 'gui-button--invalid');
+      });
+    });
+  });
+};

--- a/libs/vue/src/lib/composables/useActionWidget.ts
+++ b/libs/vue/src/lib/composables/useActionWidget.ts
@@ -1,11 +1,13 @@
 import type { ActionWidget } from '@golemui/core';
 import { onScopeDispose, ref, type Ref } from 'vue';
+import { distinctUntilChanged, map, Subject, takeUntil } from 'rxjs';
 import { useVueFormContext } from '../provideFormContext';
 import { useTemplateData, type WithFlattenedProps } from './useTemplateData';
 
 export interface UseActionWidgetReturn<ExtraProps extends Record<string, any>> {
   uid: Ref<string>;
   templateData: Ref<WithFlattenedProps<ActionWidget<string>, ExtraProps>>;
+  invalid: Ref<boolean>;
   onClick: () => void;
 }
 
@@ -15,23 +17,40 @@ export function useActionWidget<ExtraProps extends Record<string, any> = Record<
   const formContext = useVueFormContext();
   const uid = ref('');
   const templateData = useTemplateData<ActionWidget<string>, ExtraProps>(widget);
+  const invalid = ref(false);
 
   uid.value = widget.uid;
   formContext.store.dispatch({ type: 'ADD_WIDGET', payload: { widget } });
   formContext.emitEvent('load', widget);
+
+  const destroy$ = new Subject<void>();
+
+  formContext.store.state$
+    .pipe(
+      takeUntil(destroy$),
+      map((state) => state.touched && !state.isFormValid),
+      distinctUntilChanged(),
+    )
+    .subscribe((isInvalid) => {
+      invalid.value = isInvalid;
+    });
 
   // See `useInputWidget` for the rationale — same teardown race applies here.
   let disposed = false;
 
   onScopeDispose(() => {
     disposed = true;
+    destroy$.next();
+    destroy$.complete();
     formContext.store.dispatch({ type: 'REMOVE_WIDGET', payload: { uid: widget.uid } });
   });
 
   const onClick = () => {
-    if (disposed) return;
+    if (disposed) {
+      return;
+    }
     formContext.emitEvent('click', widget);
   };
 
-  return { uid, templateData, onClick };
+  return { uid, templateData, invalid, onClick };
 }


### PR DESCRIPTION
### Problem

Currently, when there are validation errors, the only way to notice them is if the invalid widget is visible, which isn't always possible. For instance, this can occur in a long form or a tabbed layout where the invalid fields are in an unselected tab.

### Solution

To notify the user of invalid fields when they are about to submit the form, we should apply a special 'invalid' style to the button with `actionType=submit`.

This wouldn't require any additional properties; it should be a default characteristic of the `actionType=submit` button. The button shouldn't be disabled by default, as this is a behavior the user can choose to implement using the conditional `disabled="$formIsInvalid"`.