### PR TITLE
chore(release): revert publish 1.0.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,3 @@
-## 1.0.0-rc.2 (2026-06-10)
-
-### 🩹 Fixes
-
-- reduce deps ([#180](https://github.com/golemui/golemui/pull/180))
-
-### ❤️ Thank You
-
-- Raúl Jiménez @Elecash
-
 ## 1.0.0-rc.1 (2026-06-10)
 
 ### 🩹 Fixes

--- a/libs/angular/CHANGELOG.md
+++ b/libs/angular/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.0.0-rc.2 (2026-06-10)
-
-This was a version bump only for angular to align it with other projects, there were no code changes.
-
 ## 1.0.0-rc.1 (2026-06-10)
 
 This was a version bump only for angular to align it with other projects, there were no code changes.

--- a/libs/core/CHANGELOG.md
+++ b/libs/core/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.0.0-rc.2 (2026-06-10)
-
-This was a version bump only for core to align it with other projects, there were no code changes.
-
 ## 1.0.0-rc.1 (2026-06-10)
 
 This was a version bump only for core to align it with other projects, there were no code changes.

--- a/libs/gui/angular/CHANGELOG.md
+++ b/libs/gui/angular/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.0.0-rc.2 (2026-06-10)
-
-This was a version bump only for gui-angular to align it with other projects, there were no code changes.
-
 ## 1.0.0-rc.1 (2026-06-10)
 
 This was a version bump only for gui-angular to align it with other projects, there were no code changes.

--- a/libs/gui/components/CHANGELOG.md
+++ b/libs/gui/components/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.0.0-rc.2 (2026-06-10)
-
-This was a version bump only for gui-components to align it with other projects, there were no code changes.
-
 ## 1.0.0-rc.1 (2026-06-10)
 
 ### 🩹 Fixes

--- a/libs/gui/lit/CHANGELOG.md
+++ b/libs/gui/lit/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.0.0-rc.2 (2026-06-10)
-
-This was a version bump only for gui-lit to align it with other projects, there were no code changes.
-
 ## 1.0.0-rc.1 (2026-06-10)
 
 This was a version bump only for gui-lit to align it with other projects, there were no code changes.

--- a/libs/gui/mcp/CHANGELOG.md
+++ b/libs/gui/mcp/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.0.0-rc.2 (2026-06-10)
-
-This was a version bump only for gui-mcp to align it with other projects, there were no code changes.
-
 ## 1.0.0-rc.1 (2026-06-10)
 
 This was a version bump only for gui-mcp to align it with other projects, there were no code changes.

--- a/libs/gui/react/CHANGELOG.md
+++ b/libs/gui/react/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.0.0-rc.2 (2026-06-10)
-
-This was a version bump only for gui-react to align it with other projects, there were no code changes.
-
 ## 1.0.0-rc.1 (2026-06-10)
 
 This was a version bump only for gui-react to align it with other projects, there were no code changes.

--- a/libs/gui/schemas/CHANGELOG.md
+++ b/libs/gui/schemas/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.0.0-rc.2 (2026-06-10)
-
-This was a version bump only for gui-schemas to align it with other projects, there were no code changes.
-
 ## 1.0.0-rc.1 (2026-06-10)
 
 This was a version bump only for gui-schemas to align it with other projects, there were no code changes.

--- a/libs/gui/shared/CHANGELOG.md
+++ b/libs/gui/shared/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.0.0-rc.2 (2026-06-10)
-
-This was a version bump only for gui-shared to align it with other projects, there were no code changes.
-
 ## 1.0.0-rc.1 (2026-06-10)
 
 This was a version bump only for gui-shared to align it with other projects, there were no code changes.

--- a/libs/gui/validators/CHANGELOG.md
+++ b/libs/gui/validators/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.0.0-rc.2 (2026-06-10)
-
-This was a version bump only for gui-validators to align it with other projects, there were no code changes.
-
 ## 1.0.0-rc.1 (2026-06-10)
 
 This was a version bump only for gui-validators to align it with other projects, there were no code changes.

--- a/libs/gui/vue/CHANGELOG.md
+++ b/libs/gui/vue/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.0.0-rc.2 (2026-06-10)
-
-This was a version bump only for gui-vue to align it with other projects, there were no code changes.
-
 ## 1.0.0-rc.1 (2026-06-10)
 
 This was a version bump only for gui-vue to align it with other projects, there were no code changes.

--- a/libs/lit/CHANGELOG.md
+++ b/libs/lit/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.0.0-rc.2 (2026-06-10)
-
-This was a version bump only for lit to align it with other projects, there were no code changes.
-
 ## 1.0.0-rc.1 (2026-06-10)
 
 This was a version bump only for lit to align it with other projects, there were no code changes.

--- a/libs/react/CHANGELOG.md
+++ b/libs/react/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.0.0-rc.2 (2026-06-10)
-
-This was a version bump only for react to align it with other projects, there were no code changes.
-
 ## 1.0.0-rc.1 (2026-06-10)
 
 This was a version bump only for react to align it with other projects, there were no code changes.

--- a/libs/vue/CHANGELOG.md
+++ b/libs/vue/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.0.0-rc.2 (2026-06-10)
-
-This was a version bump only for vue to align it with other projects, there were no code changes.
-
 ## 1.0.0-rc.1 (2026-06-10)
 
 This was a version bump only for vue to align it with other projects, there were no code changes.


### PR DESCRIPTION
Revert rc.2 that was not published because Github was down.