### PR TITLE
fix(gui): repeater + display render correctness

### DIFF
--- a/libs/gui/shared/src/lib/dx/__tests__/displays.pipeline.spec.ts
+++ b/libs/gui/shared/src/lib/dx/__tests__/displays.pipeline.spec.ts
@@ -54,6 +54,31 @@ describe('DX Pipeline — Displays', () => {
     });
   });
 
+  describe('render params always carry $form', () => {
+    // Guards the arena crash: a render read `params.$form.serviceLines` when the walk passed no `$form`.
+    it('resolves a display that reads params.$form.<field> without form data, never throwing', () => {
+      const root = processDx(
+        _guiDisplay((params) => {
+          const lines = Array.isArray(params.$form.serviceLines) ? params.$form.serviceLines : [];
+          return `count:${lines.length}`;
+        }),
+      );
+      const rawChild = getRawChild(root, 0);
+      expect(() => resolveDynamic(rawChild)).not.toThrow();
+      const resolved = resolveDynamic(rawChild) as { props?: { render?: unknown } };
+      expect(resolved.props?.render).toBe('count:0');
+    });
+
+    it('still passes real $form data through when provided', () => {
+      const root = processDx(_guiDisplay((params) => `n:${params.$form.serviceLines?.length ?? 0}`));
+      const rawChild = getRawChild(root, 0);
+      const resolved = resolveDynamic(rawChild, { $form: { serviceLines: [1, 2, 3] } }) as {
+        props?: { render?: unknown };
+      };
+      expect(resolved.props?.render).toBe('n:3');
+    });
+  });
+
   describe('GSL tag matching — Phase 2 safety baseline', () => {
     it('processes tagged display with matching _gslTag + _gslDisplays selector', () => {
       const defs = [_guiDisplay(() => 'tagged', ['highlight']), _guiTextInput('a')];

--- a/libs/gui/shared/src/lib/dx/__tests__/repeater.pipeline.spec.ts
+++ b/libs/gui/shared/src/lib/dx/__tests__/repeater.pipeline.spec.ts
@@ -43,6 +43,20 @@ describe('DX Pipeline — Repeater', () => {
     expect(child1.type).toBe('textinput');
   });
 
+  // Full `<path>.items.<field>` child paths (what docs/grounding write) must not be double-prefixed.
+  it('accepts a full <path>.items.<field> child path without double-prefixing', () => {
+    const result = processDx(
+      _guiRepeater('guests', {
+        template: [_guiTextInput('guests.items.guest_name')],
+      }),
+    );
+    const w = getStaticChild(result, 0) as NonFunctionWidget & {
+      props?: { template?: LayoutWidget };
+    };
+    const leaf = w.props?.template?.children?.[0] as NonFunctionWidget & { path?: string };
+    expect(leaf.path).toBe('guests.items.guest_name');
+  });
+
   it('works with template-only props (no other config)', () => {
     const result = processDx(
       _guiRepeater('items', {

--- a/libs/gui/shared/src/lib/dx/shortcuts/display/register.ts
+++ b/libs/gui/shared/src/lib/dx/shortcuts/display/register.ts
@@ -11,6 +11,19 @@ import { type BuildWidgetContext } from '../../core/itemTypeRegistry';
 import { defineShortcutType } from '../../core/defineShortcutType';
 import { type DisplayDecorator, type DisplayEntry, type GslDisplaysConfig } from './display.domain';
 
+// Render runs during the build walk before form data exists; the FunctionWidgetParams contract
+// guarantees `$form` is an object, so normalize it to at least `{}` — a render reading
+// `params.$form.field` must get `undefined`, not crash.
+function withForm(params?: FunctionWidgetParams<any>): FunctionWidgetParams<any> {
+  return {
+    errors: undefined,
+    touched: undefined,
+    translate: undefined,
+    ...(params ?? {}),
+    $form: params?.$form ?? {},
+  };
+}
+
 function mapToWidget<StateKeys extends UiState = never, FormData extends Record<string, any> = any>(
   def: DisplayDecorator,
 ): NonFunctionWidget<StateKeys, FormData> {
@@ -31,7 +44,7 @@ function buildCustomWidget(mergeResult: MergeResult, _context: BuildWidgetContex
       type: 'renderer',
       ...(displayDef.include != null ? { include: displayDef.include } : {}),
       ...(displayDef.exclude != null ? { exclude: displayDef.exclude } : {}),
-      props: { render: displayDef.render(params ?? ({} as FunctionWidgetParams<any>)) },
+      props: { render: displayDef.render(withForm(params)) },
     })) as FormWidget;
   }
 
@@ -44,7 +57,7 @@ function buildCustomWidget(mergeResult: MergeResult, _context: BuildWidgetContex
       type: 'renderer',
       ...(displayDef.include != null ? { include: displayDef.include } : {}),
       ...(displayDef.exclude != null ? { exclude: displayDef.exclude } : {}),
-      props: { render: displayDef.render(params ?? ({} as FunctionWidgetParams<any>)) },
+      props: { render: displayDef.render(withForm(params)) },
     };
   }) as FormWidget;
 }

--- a/libs/gui/shared/src/lib/dx/shortcuts/repeater/register.ts
+++ b/libs/gui/shared/src/lib/dx/shortcuts/repeater/register.ts
@@ -49,7 +49,10 @@ function prefixTemplatePaths(widgets: FormWidget[], prefix: string): void {
   for (const widget of widgets) {
     if (typeof widget === 'function') continue;
     const w = widget as NonFunctionWidget & { path?: string };
-    if (typeof w.path === 'string' && w.path) {
+    // Idempotent: a child path may be relative (`guest_name`) or full (`guests.items.guest_name`);
+    // only prepend when not already prefixed, so a full path isn't double-prefixed (which throws in
+    // `toRepeaterItemPath`).
+    if (typeof w.path === 'string' && w.path && !w.path.startsWith(prefix)) {
       w.path = prefix + w.path;
     }
     // Recurse into layout children (e.g. horizontal/vertical stacks)


### PR DESCRIPTION
Two render bugs in the gui-shared DX builder, both surfaced by the arena:

- **Display `$form` crash** — a display render reading `params.$form.<field>` threw, because the
  structure-building walk invokes the render *before* form data exists and passed params without `$form`.
  Fixed by normalizing params so `$form` is always at least `{}` (the `FunctionWidgetParams` contract).
- **Repeater double-prefix** — a child written with the full `<path>.items.<field>` path (what the docs
  and generated code emit) got prefixed *again* → `guests.items.guests.items.…` → threw at render → blank
  row. Fixed by making the prefix idempotent (skip when already prefixed).

**Where to look:** the two `register.ts` changes. **Proof:** 3 new pipeline specs (red before / green
after), `vite:test` 285 green, affected build green. **No** behavioural change to relative child paths or
to displays that don't read `$form`.