### PR TITLE
refactor(core): migrate decoders to v4.1.0

### DIFF
--- a/apps/apps-shared/src/lib/mocks/tabs/accordion.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/accordion.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabAccordion",
   "kind": "layout",
   "type": "accordion",

--- a/apps/apps-shared/src/lib/mocks/tabs/alert.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/alert.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabAlert",
   "kind": "layout",
   "type": "flex",

--- a/apps/apps-shared/src/lib/mocks/tabs/button.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/button.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabButton",
   "kind": "layout",
   "type": "flex",

--- a/apps/apps-shared/src/lib/mocks/tabs/calendar.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/calendar.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabDate",
   "kind": "layout",
   "type": "flex",

--- a/apps/apps-shared/src/lib/mocks/tabs/checkbox.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/checkbox.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabCheckbox",
   "kind": "layout",
   "type": "flex",
@@ -8,24 +8,21 @@
       "kind": "input",
       "type": "checkbox",
       "label": "Create new account?",
-      "path": "isNewUser",
-      "props": {}
+      "path": "isNewUser"
     },
     {
       "kind": "input",
       "type": "checkbox",
       "label": "Disabled checkbox",
       "path": "isDisabled",
-      "disabled": true,
-      "props": {}
+      "disabled": true
     },
     {
       "kind": "input",
       "type": "checkbox",
       "label": "Readonly checkbox",
       "path": "isReadonly",
-      "readonly": true,
-      "props": {}
+      "readonly": true
     },
     {
       "kind": "input",

--- a/apps/apps-shared/src/lib/mocks/tabs/currency.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/currency.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabCurrency",
   "kind": "layout",
   "type": "flex",

--- a/apps/apps-shared/src/lib/mocks/tabs/dropdown.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/dropdown.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabDropdown",
   "kind": "layout",
   "type": "flex",

--- a/apps/apps-shared/src/lib/mocks/tabs/flex.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/flex.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabFlex",
   "kind": "layout",
   "type": "flex",

--- a/apps/apps-shared/src/lib/mocks/tabs/grid.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/grid.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabGrid",
   "kind": "layout",
   "type": "grid",

--- a/apps/apps-shared/src/lib/mocks/tabs/list.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/list.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabList",
   "kind": "layout",
   "type": "flex",

--- a/apps/apps-shared/src/lib/mocks/tabs/markdown-text.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/markdown-text.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabMarkdownText",
   "kind": "layout",
   "type": "flex",

--- a/apps/apps-shared/src/lib/mocks/tabs/markdown.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/markdown.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabMarkdown",
   "kind": "layout",
   "type": "flex",

--- a/apps/apps-shared/src/lib/mocks/tabs/number.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/number.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabNumber",
   "kind": "layout",
   "type": "flex",

--- a/apps/apps-shared/src/lib/mocks/tabs/password.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/password.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabPassword",
   "kind": "layout",
   "type": "flex",

--- a/apps/apps-shared/src/lib/mocks/tabs/radiogroup.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/radiogroup.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabRadiogroup",
   "kind": "layout",
   "type": "flex",

--- a/apps/apps-shared/src/lib/mocks/tabs/repeater.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/repeater.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabRepeater",
   "kind": "layout",
   "type": "flex",

--- a/apps/apps-shared/src/lib/mocks/tabs/select.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/select.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabSelect",
   "kind": "layout",
   "type": "flex",

--- a/apps/apps-shared/src/lib/mocks/tabs/tags.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/tags.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabTags",
   "kind": "layout",
   "type": "flex",

--- a/apps/apps-shared/src/lib/mocks/tabs/textarea.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/textarea.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabTextarea",
   "kind": "layout",
   "type": "flex",

--- a/apps/apps-shared/src/lib/mocks/tabs/textinput.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/textinput.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabTextinput",
   "kind": "layout",
   "type": "flex",

--- a/apps/apps-shared/src/lib/mocks/tabs/toggle.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/toggle.form-chunk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../../../libs/gui/shared/src/lib/schemas/layout-widget.schema.json",
+  "$schema": "../../../../../../libs/gui/schemas/src/lib/layout-widget.schema.json",
   "uid": "tabToggle",
   "kind": "layout",
   "type": "flex",
@@ -8,8 +8,7 @@
       "kind": "input",
       "type": "toggle",
       "label": "Create new account?",
-      "path": "isNewUser",
-      "props": {}
+      "path": "isNewUser"
     },
     {
       "kind": "input",
@@ -17,8 +16,7 @@
       "label": "Disabled toggle",
       "path": "isDisabled",
       "disabled": true,
-      "readonly": true,
-      "props": {}
+      "readonly": true
     },
     {
       "kind": "input",

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -28,7 +28,7 @@
     "*.md"
   ],
   "dependencies": {
-    "ts.data.json": "^3.3.0"
+    "ts.data.json": "^4.1.0"
   },
   "peerDependencies": {
     "subscript": "^10.1.8",

--- a/libs/core/src/lib/form-widget.ts
+++ b/libs/core/src/lib/form-widget.ts
@@ -2,6 +2,7 @@ import {
   array,
   boolean,
   Decoder,
+  discriminatedUnion,
   err,
   lazy,
   literal,
@@ -256,23 +257,23 @@ export const isFunctionWidget = <
 //
 // --------------------------------
 
-const inDecoder = object({ in: array(string(), 'In[]') }, 'In');
+const inDecoder = object({ in: array(string()) });
 type In = FromDecoder<typeof inDecoder>;
 
-const whenDecoder = object({ when: string() }, 'When');
+const whenDecoder = object({ when: string() });
 type When = FromDecoder<typeof whenDecoder>;
 
 // include
-const includeDecoder = oneOf<In | When>([inDecoder, whenDecoder], 'In | When');
+const includeDecoder = oneOf<In | When>([inDecoder, whenDecoder]);
 
-const fromDecoder = object({ from: array(string(), 'From[]') }, 'From');
+const fromDecoder = object({ from: array(string()) });
 type From = FromDecoder<typeof fromDecoder>;
 
 // exclude
-const excludeDecoder = oneOf<From | When>([fromDecoder, whenDecoder], 'Exclude');
+const excludeDecoder = oneOf<From | When>([fromDecoder, whenDecoder]);
 
 // disable / readonly
-const boolWhenDecoder = oneOf<boolean | When>([boolean(), whenDecoder], 'Bool | When');
+const boolWhenDecoder = oneOf<boolean | When>([boolean(), whenDecoder]);
 
 // all widget properties that support states can potentially be a WidgetPropertyFunction
 const widgetPropFnDecoder: Decoder<WidgetPropertyFunction<any>> = new Decoder((json: unknown) => {
@@ -280,69 +281,57 @@ const widgetPropFnDecoder: Decoder<WidgetPropertyFunction<any>> = new Decoder((j
   if (jsonTypeof === 'function') {
     return ok(json as WidgetPropertyFunction<any>);
   } else {
-    return err(`Expected a function, got '${jsonTypeof}'`);
+    return err([{ message: `Expected a function, got '${jsonTypeof}'`, path: [] }]);
   }
 });
 const decodeWidgetPropOrWidgetPropFn = <T>(decoder: Decoder<T>) =>
-  oneOf<T | WidgetPropertyFunction<any>>([decoder, widgetPropFnDecoder], '');
+  oneOf<T | WidgetPropertyFunction<any>>([decoder, widgetPropFnDecoder]);
 
-const onDecoder = objectWithSuffix(
-  {
-    load: { suffixed: true, decoder: decodeWidgetPropOrWidgetPropFn(optional(string())) },
-    click: { suffixed: true, decoder: decodeWidgetPropOrWidgetPropFn(optional(string())) },
-    change: { suffixed: true, decoder: decodeWidgetPropOrWidgetPropFn(optional(string())) },
-    filter: { suffixed: true, decoder: decodeWidgetPropOrWidgetPropFn(optional(string())) },
-    blur: { suffixed: true, decoder: decodeWidgetPropOrWidgetPropFn(optional(string())) },
-  },
-  'On',
-);
+const onDecoder = objectWithSuffix({
+  load: { suffixed: true, decoder: decodeWidgetPropOrWidgetPropFn(optional(string())) },
+  click: { suffixed: true, decoder: decodeWidgetPropOrWidgetPropFn(optional(string())) },
+  change: { suffixed: true, decoder: decodeWidgetPropOrWidgetPropFn(optional(string())) },
+  filter: { suffixed: true, decoder: decodeWidgetPropOrWidgetPropFn(optional(string())) },
+  blur: { suffixed: true, decoder: decodeWidgetPropOrWidgetPropFn(optional(string())) },
+});
 
-const translationConfigDecoder = object<TranslationConfig>(
-  {
-    key: string(),
-    default: optional(string()),
-    params: optional(succeed()),
-  },
-  'TranslationConfig',
-);
-const localizableDecoder = oneOf<Localizable>([string(), translationConfigDecoder], 'Localizable');
+const translationConfigDecoder = object<TranslationConfig>({
+  key: string(),
+  default: optional(string()),
+  params: optional(succeed()),
+});
+const localizableDecoder = oneOf<Localizable>([string(), translationConfigDecoder]);
 
 const uidDecoder = optional(string()).map((s) => s || shortUUID());
 
-const displayWidgetDecoder = objectWithSuffix<DisplayWidget<string>>(
-  {
-    kind: { decoder: literal('display') },
-    uid: { decoder: uidDecoder },
-    type: { decoder: string() },
-    size: { suffixed: true, decoder: optional(number()) },
-    include: { decoder: optional(includeDecoder) },
-    exclude: { decoder: optional(excludeDecoder) },
-    props: { decoder: optional(succeed()) },
-  },
-  'DisplayWidget',
-);
+const displayWidgetDecoder = objectWithSuffix<DisplayWidget<string>>({
+  kind: { decoder: literal('display') },
+  uid: { decoder: uidDecoder },
+  type: { decoder: string() },
+  size: { suffixed: true, decoder: optional(number()) },
+  include: { decoder: optional(includeDecoder) },
+  exclude: { decoder: optional(excludeDecoder) },
+  props: { decoder: optional(succeed()) },
+});
 
-const actionWidgetDecoder = objectWithSuffix<ActionWidget<string>>(
-  {
-    kind: { decoder: literal('action') },
-    uid: { decoder: uidDecoder },
-    type: { decoder: string() },
-    actionType: {
-      decoder: optional(oneOf([literal('button'), literal('submit')], 'button | submit ')),
-    },
-    size: { suffixed: true, decoder: optional(number()) },
-    include: { decoder: optional(includeDecoder) },
-    exclude: { decoder: optional(excludeDecoder) },
-    label: {
-      suffixed: true,
-      decoder: decodeWidgetPropOrWidgetPropFn(optional(localizableDecoder)),
-    },
-    disabled: { suffixed: true, decoder: optional(boolWhenDecoder) },
-    on: { decoder: optional(onDecoder) },
-    props: { decoder: optional(succeed()) },
+const actionWidgetDecoder = objectWithSuffix<ActionWidget<string>>({
+  kind: { decoder: literal('action') },
+  uid: { decoder: uidDecoder },
+  type: { decoder: string() },
+  actionType: {
+    decoder: optional(oneOf([literal('button'), literal('submit')])),
   },
-  'ActionWidget',
-);
+  size: { suffixed: true, decoder: optional(number()) },
+  include: { decoder: optional(includeDecoder) },
+  exclude: { decoder: optional(excludeDecoder) },
+  label: {
+    suffixed: true,
+    decoder: decodeWidgetPropOrWidgetPropFn(optional(localizableDecoder)),
+  },
+  disabled: { suffixed: true, decoder: optional(boolWhenDecoder) },
+  on: { decoder: optional(onDecoder) },
+  props: { decoder: optional(succeed()) },
+});
 
 const functionWidgetDecoder: Decoder<FunctionWidget<string>> = new Decoder((json: unknown) => {
   const jsonTypeof = typeof json;
@@ -354,35 +343,32 @@ const functionWidgetDecoder: Decoder<FunctionWidget<string>> = new Decoder((json
     fnWidget.path = (widget as InputWidget<unknown>).path; // this could be undefined, and it's ok.
     return ok(fnWidget);
   } else {
-    return err(`Expected a function, got '${jsonTypeof}'`);
+    return err([{ message: `Expected a function, got '${jsonTypeof}'`, path: [] }]);
   }
 });
 
-const inputWidgetDecoder = objectWithSuffix<InputWidget<any, string>>(
-  {
-    kind: { decoder: literal('input') },
-    uid: { decoder: optional(string()) },
-    type: { decoder: string() },
-    size: { suffixed: true, decoder: optional(number()) },
-    include: { decoder: optional(includeDecoder) },
-    exclude: { decoder: optional(excludeDecoder) },
-    disabled: { suffixed: true, decoder: optional(boolWhenDecoder) },
-    readonly: { suffixed: true, decoder: optional(boolWhenDecoder) },
-    on: { decoder: optional(onDecoder) },
-    props: { decoder: optional(succeed()) },
-    label: {
-      suffixed: true,
-      decoder: decodeWidgetPropOrWidgetPropFn(optional(localizableDecoder)),
-    },
-    path: { decoder: string() },
-    defaultValue: { decoder: optional(succeed()) },
-    validator: {
-      suffixed: true,
-      decoder: decodeWidgetPropOrWidgetPropFn(optional(succeed())),
-    },
+const inputWidgetDecoder = objectWithSuffix<InputWidget<any, string>>({
+  kind: { decoder: literal('input') },
+  uid: { decoder: optional(string()) },
+  type: { decoder: string() },
+  size: { suffixed: true, decoder: optional(number()) },
+  include: { decoder: optional(includeDecoder) },
+  exclude: { decoder: optional(excludeDecoder) },
+  disabled: { suffixed: true, decoder: optional(boolWhenDecoder) },
+  readonly: { suffixed: true, decoder: optional(boolWhenDecoder) },
+  on: { decoder: optional(onDecoder) },
+  props: { decoder: optional(succeed()) },
+  label: {
+    suffixed: true,
+    decoder: decodeWidgetPropOrWidgetPropFn(optional(localizableDecoder)),
   },
-  'InputWidget',
-).map((ctrl) => {
+  path: { decoder: string() },
+  defaultValue: { decoder: optional(succeed()) },
+  validator: {
+    suffixed: true,
+    decoder: decodeWidgetPropOrWidgetPropFn(optional(succeed())),
+  },
+}).map((ctrl) => {
   const transformed = { ...ctrl };
   if (!ctrl.uid) {
     transformed.uid = `${ctrl.path}-${ctrl.type}`;
@@ -402,37 +388,28 @@ type FormWidgetDecoder = Decoder<
   | LayoutWidget<string>
   | FunctionWidget<string>
 >;
-const formWidgetDecoder = lazy(
-  (): FormWidgetDecoder =>
-    oneOf<
-      | DisplayWidget<string>
-      | ActionWidget<string>
-      | InputWidget<any, string>
-      | LayoutWidget<string>
-      | FunctionWidget<string>
-    >(
-      [
-        functionWidgetDecoder,
-        inputWidgetDecoder,
-        layoutWidgetDecoder,
-        displayWidgetDecoder,
-        actionWidgetDecoder,
-      ],
-      'FormWidget',
-    ),
-);
+const formWidgetDecoder = lazy((): FormWidgetDecoder => {
+  const objectWidgetDecoder = discriminatedUnion('kind', {
+    input: inputWidgetDecoder,
+    layout: layoutWidgetDecoder,
+    display: displayWidgetDecoder,
+    action: actionWidgetDecoder,
+  });
+  return new Decoder<FormWidget<string>>((json: unknown) =>
+    typeof json === 'function'
+      ? functionWidgetDecoder.decode(json)
+      : objectWidgetDecoder.decode(json),
+  );
+});
 
-export const layoutWidgetDecoder = objectWithSuffix<LayoutWidget<string>>(
-  {
-    kind: { decoder: literal('layout') },
-    uid: { decoder: uidDecoder },
-    type: { decoder: string() },
-    size: { suffixed: true, decoder: optional(number()) },
-    include: { decoder: optional(includeDecoder) },
-    exclude: { decoder: optional(excludeDecoder) },
-    props: { decoder: optional(succeed()) },
-    on: { decoder: optional(onDecoder) },
-    children: { decoder: array(formWidgetDecoder, 'FormWidget[]') },
-  },
-  'LayoutWidget',
-);
+export const layoutWidgetDecoder = objectWithSuffix<LayoutWidget<string>>({
+  kind: { decoder: literal('layout') },
+  uid: { decoder: uidDecoder },
+  type: { decoder: string() },
+  size: { suffixed: true, decoder: optional(number()) },
+  include: { decoder: optional(includeDecoder) },
+  exclude: { decoder: optional(excludeDecoder) },
+  props: { decoder: optional(succeed()) },
+  on: { decoder: optional(onDecoder) },
+  children: { decoder: array(formWidgetDecoder) },
+});

--- a/libs/core/src/lib/form.ts
+++ b/libs/core/src/lib/form.ts
@@ -60,10 +60,7 @@ export interface FormInitConfig<ComponentType = unknown> {
   meta?: Record<string, any>;
 }
 
-export const formDefDecoder = object(
-  {
-    states: optional(record(string(), 'states')),
-    form: lazy(() => layoutWidgetDecoder),
-  },
-  'FormDef',
-);
+export const formDefDecoder = object({
+  states: optional(record(string())),
+  form: lazy(() => layoutWidgetDecoder),
+});

--- a/libs/core/src/lib/store/reducers/initialize.ts
+++ b/libs/core/src/lib/store/reducers/initialize.ts
@@ -1,3 +1,4 @@
+import { formatIssuePath } from 'ts.data.json';
 import { errorCodes } from '../../errors';
 import { type Form, formDefDecoder } from '../../form';
 import { type FormWidget, isInputWidget } from '../../form-widget';
@@ -81,11 +82,17 @@ export const initialize = ({ lang }: State, action: INITIALIZE): State => {
   }
 
   const code = errorCodes.initializeUnknownError;
+  const message = result.issues
+    .map((issue) => {
+      const location = issue.path.length > 0 ? formatIssuePath(issue.path) : 'root';
+      return `${location}: ${issue.message}`;
+    })
+    .join('; ');
   return {
     ...initialState,
     formHealth: {
       status: 'errored',
-      message: `[${code}] ${result.error}`,
+      message: `[${code}] ${message}`,
       code,
     },
   };

--- a/libs/core/src/lib/utils/decoder.spec.ts
+++ b/libs/core/src/lib/utils/decoder.spec.ts
@@ -3,15 +3,12 @@ import { objectWithSuffix } from './decoder';
 
 describe('objectWithSuffix (KeySpec)', () => {
   it('decodes a non-suffixed key (exact match)', () => {
-    const decoder = objectWithSuffix<{ label: string }>(
-      {
-        label: {
-          suffixed: false,
-          decoder: string(),
-        },
+    const decoder = objectWithSuffix<{ label: string }>({
+      label: {
+        suffixed: false,
+        decoder: string(),
       },
-      'MyObj',
-    );
+    });
 
     const res = decoder.decode({ label: 'Submit' });
 
@@ -22,15 +19,12 @@ describe('objectWithSuffix (KeySpec)', () => {
   });
 
   it('accepts base and suffixed keys together when suffixed is true', () => {
-    const decoder = objectWithSuffix<Record<string, string>>(
-      {
-        label: {
-          suffixed: true,
-          decoder: string(),
-        },
+    const decoder = objectWithSuffix<Record<string, string>>({
+      label: {
+        suffixed: true,
+        decoder: string(),
       },
-      'MyObj',
-    );
+    });
 
     const res = decoder.decode({
       label: 'Submit',
@@ -47,15 +41,12 @@ describe('objectWithSuffix (KeySpec)', () => {
   });
 
   it('rejects suffixed keys when suffixed is false', () => {
-    const decoder = objectWithSuffix<Record<string, string>>(
-      {
-        label: {
-          suffixed: false,
-          decoder: string(),
-        },
+    const decoder = objectWithSuffix<Record<string, string>>({
+      label: {
+        suffixed: false,
+        decoder: string(),
       },
-      'MyObj',
-    );
+    });
 
     const res = decoder.decode({
       'label.register': 'Register',
@@ -63,20 +54,22 @@ describe('objectWithSuffix (KeySpec)', () => {
 
     expect(res.isOk()).toBe(false);
     if (!res.isOk()) {
-      expect(res.error).toContain('<MyObj> failed at "label" with undefined is not a valid string');
+      expect(res.issues).toContainEqual(
+        expect.objectContaining({
+          message: expect.stringContaining('is not a valid string'),
+          path: ['label'],
+        }),
+      );
     }
   });
 
   it('fails when a required spec key is not provided', () => {
-    const decoder = objectWithSuffix<{ label: string }>(
-      {
-        label: {
-          suffixed: false,
-          decoder: string(),
-        },
+    const decoder = objectWithSuffix<{ label: string }>({
+      label: {
+        suffixed: false,
+        decoder: string(),
       },
-      'MyObj',
-    );
+    });
 
     const res = decoder.decode({
       somethingelse: 'Hello',
@@ -84,20 +77,22 @@ describe('objectWithSuffix (KeySpec)', () => {
 
     expect(res.isOk()).toBe(false);
     if (!res.isOk()) {
-      expect(res.error).toContain('<MyObj> failed at "label" with undefined is not a valid string');
+      expect(res.issues).toContainEqual(
+        expect.objectContaining({
+          message: expect.stringContaining('is not a valid string'),
+          path: ['label'],
+        }),
+      );
     }
   });
 
   it('fails when a value does not match the decoder', () => {
-    const decoder = objectWithSuffix<Record<string, string>>(
-      {
-        label: {
-          suffixed: true,
-          decoder: string(),
-        },
+    const decoder = objectWithSuffix<Record<string, string>>({
+      label: {
+        suffixed: true,
+        decoder: string(),
       },
-      'MyObj',
-    );
+    });
 
     const res = decoder.decode({
       'label.register': 123,
@@ -107,21 +102,22 @@ describe('objectWithSuffix (KeySpec)', () => {
   });
 
   it('fails when input is not an object literal', () => {
-    const decoder = objectWithSuffix<Record<string, string>>(
-      {
-        label: {
-          suffixed: true,
-          decoder: string(),
-        },
+    const decoder = objectWithSuffix<Record<string, string>>({
+      label: {
+        suffixed: true,
+        decoder: string(),
       },
-      'MyObj',
-    );
+    });
 
     const res = decoder.decode(null);
 
     expect(res.isOk()).toBe(false);
     if (!res.isOk()) {
-      expect(res.error).toContain('Expected object literal');
+      expect(res.issues).toContainEqual(
+        expect.objectContaining({
+          message: expect.stringContaining('Expected object literal'),
+        }),
+      );
     }
   });
 
@@ -129,12 +125,9 @@ describe('objectWithSuffix (KeySpec)', () => {
     const generateId = vi.fn(() => 'generated-id-123');
     const uidDecoder = optional(string()).map((s) => s || generateId());
 
-    const decoder = objectWithSuffix<{ uid: string }>(
-      {
-        uid: { suffixed: false, decoder: uidDecoder },
-      },
-      'MyObj',
-    );
+    const decoder = objectWithSuffix<{ uid: string }>({
+      uid: { suffixed: false, decoder: uidDecoder },
+    });
 
     const res = decoder.decode({ uid: '' });
     expect(res.isOk()).toBe(true);
@@ -147,12 +140,9 @@ describe('objectWithSuffix (KeySpec)', () => {
     const generateId = vi.fn(() => 'generated-id-123');
     const uidDecoder = optional(string()).map((s) => s || generateId());
 
-    const decoder = objectWithSuffix<{ uid: string }>(
-      {
-        uid: { suffixed: false, decoder: uidDecoder },
-      },
-      'MyObj',
-    );
+    const decoder = objectWithSuffix<{ uid: string }>({
+      uid: { suffixed: false, decoder: uidDecoder },
+    });
 
     const res = decoder.decode({});
     expect(res.isOk()).toBe(true);
@@ -165,12 +155,9 @@ describe('objectWithSuffix (KeySpec)', () => {
     const generateId = vi.fn(() => 'generated-id-123');
     const uidDecoder = optional(string()).map((s) => s || generateId());
 
-    const decoder = objectWithSuffix<{ uid: string }>(
-      {
-        uid: { suffixed: false, decoder: uidDecoder },
-      },
-      'MyObj',
-    );
+    const decoder = objectWithSuffix<{ uid: string }>({
+      uid: { suffixed: false, decoder: uidDecoder },
+    });
 
     const res = decoder.decode({ uid: 'my-custom-id' });
     expect(res.isOk()).toBe(true);

--- a/libs/core/src/lib/utils/decoder.ts
+++ b/libs/core/src/lib/utils/decoder.ts
@@ -31,20 +31,16 @@ export type KeySpec<A> = Record<
  * @typeParam T - The resulting object shape after successful decoding.
  *
  * @param specs - A map of base keys to their decoding specification.
- * @param decoderName - Human-readable name used in error messages.
  *
  * @returns A `jd.Decoder` that validates and decodes objects according to the
  *          provided key specifications.
  *
  * @example
  * ```ts
- * const decoder = objectWithSuffix<Record<string, string>>(
- *   {
- *     label: { suffixed: true, decoder: jd.string() },
- *     title: { suffixed: false, decoder: jd.string() },
- *   },
- *   'MyObj',
- * );
+ * const decoder = objectWithSuffix<Record<string, string>>({
+ *   label: { suffixed: true, decoder: jd.string() },
+ *   title: { suffixed: false, decoder: jd.string() },
+ * });
  *
  * decoder.decode({
  *   label: 'Submit',
@@ -54,13 +50,10 @@ export type KeySpec<A> = Record<
  * ```
  */
 
-export function objectWithSuffix<T extends Record<string, any>>(
-  specs: KeySpec<any>,
-  decoderName: string,
-): Decoder<T> {
+export function objectWithSuffix<T extends Record<string, any>>(specs: KeySpec<any>): Decoder<T> {
   return new Decoder<T>((json: any) => {
     if (typeof json !== 'object' || json === null) {
-      return err<T>(`<${decoderName}> failed. Expected object literal, got "${typeof json}"`);
+      return err<T>([{ message: `Expected object literal, got "${typeof json}"`, path: [] }]);
     }
 
     const out: Record<string, any> = {};
@@ -69,7 +62,12 @@ export function objectWithSuffix<T extends Record<string, any>>(
       // decode normal properties (without state)
       const res = spec.decoder.decode(json[specKey]);
       if (!res.isOk()) {
-        return err<T>(`<${decoderName}> failed at "${specKey}" with ${res.error}`);
+        return err<T>(
+          res.issues.map((issue) => ({
+            message: issue.message,
+            path: [specKey, ...issue.path],
+          })),
+        );
       }
       out[specKey] = res.value;
 
@@ -79,7 +77,12 @@ export function objectWithSuffix<T extends Record<string, any>>(
           if (jsonKey.startsWith(specKey + '.')) {
             const res = spec.decoder.decode(jsonValue);
             if (!res.isOk()) {
-              return err<T>(`<${decoderName}> failed at "${jsonKey}" with ${res.error}`);
+              return err<T>(
+                res.issues.map((issue) => ({
+                  message: issue.message,
+                  path: [jsonKey, ...issue.path],
+                })),
+              );
             }
             out[jsonKey] = res.value;
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "react-dom": "19.0.0",
         "rxjs": "~7.8.0",
         "subscript": "^10.1.8",
-        "ts.data.json": "^3.3.0",
+        "ts.data.json": "^4.1.0",
         "vue": "^3.5.0",
         "zod": "^4.0.0",
         "zone.js": "~0.15.0"
@@ -32483,9 +32483,9 @@
       "license": "MIT"
     },
     "node_modules/ts.data.json": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ts.data.json/-/ts.data.json-3.3.0.tgz",
-      "integrity": "sha512-GkuFwuK1pgKb66nQ2RTuONe0sI9g4iVdtA0UmbOIphjkL3jE4Esk6SsaHvRN59zpVw1CncTyqUjWwYeLK7Wbcg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ts.data.json/-/ts.data.json-4.1.0.tgz",
+      "integrity": "sha512-HQAJkw5DwHRG9mH2u8m6qdQftX1uGvsfRo3iC+NLC7q2pbnscOzhYNgccjia1uBxxd0b8HaeMeIk2MrwjLLhlg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/tsconfig-paths": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-dom": "19.0.0",
     "rxjs": "~7.8.0",
     "subscript": "^10.1.8",
-    "ts.data.json": "^3.3.0",
+    "ts.data.json": "^4.1.0",
     "vue": "^3.5.0",
     "zod": "^4.0.0",
     "zone.js": "~0.15.0"


### PR DESCRIPTION
## Description

Upgrades `ts.data.json` from `^3.3.0` to `^4.1.0` and migrates the form
decoders to the v4 API, then takes advantage of v4 to produce cleaner
validation errors.


## Behavior change

Decode errors are more precise. For example, a deeply nested input widget
missing its `path` now reports a single issue:

```
form.children[1].children[13].children[0].path: undefined is not a valid string
```

instead of the previous five-segment message padded with intermediate
"no alternative matched" / "Expected a function" lines.
