### PR TITLE
fix: added license field and copied license to all publishable packages

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -21,17 +21,11 @@ const config = {
     '**/eslint.config.{js,mjs,cjs}',
     'vitest.workspace.ts',
   ],
-  project: [
-    'apps/**/*.{ts,tsx,js,vue,html}',
-    'libs/**/*.{ts,tsx,js,vue,html}',
-    'tools/**/*.ts',
-  ],
+  project: ['apps/**/*.{ts,tsx,js,vue,html}', 'libs/**/*.{ts,tsx,js,vue,html}', 'tools/**/*.ts'],
   // Knip does not parse .vue files by default: extract the <script> blocks
   compilers: {
     vue: (text: string) =>
-      [...text.matchAll(/<script[^>]*>([\s\S]*?)<\/script>/g)]
-        .map((m) => m[1])
-        .join('\n'),
+      [...text.matchAll(/<script[^>]*>([\s\S]*?)<\/script>/g)].map((m) => m[1]).join('\n'),
   },
   // Used by Nx executors / Angular CLI / tooling, never imported in source code:
   ignoreDependencies: [

--- a/libs/angular/package.json
+++ b/libs/angular/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@golemui/angular",
   "version": "0.0.0",
+  "license": "MIT",
   "peerDependencies": {
     "@angular/common": ">=18.0.0",
     "@angular/core": ">=18.0.0",

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@golemui/core",
   "version": "0.0.0",
+  "license": "MIT",
   "type": "module",
   "main": "./index.umd.cjs",
   "module": "./index.js",

--- a/libs/gui/angular/package.json
+++ b/libs/gui/angular/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@golemui/gui-angular",
   "version": "0.0.0",
+  "license": "MIT",
   "peerDependencies": {
     "@angular/common": ">=18.0.0",
     "@angular/core": ">=18.0.0",

--- a/libs/gui/components/package.json
+++ b/libs/gui/components/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@golemui/gui-components",
   "version": "0.0.0",
+  "license": "MIT",
   "type": "module",
   "main": "./index.umd.cjs",
   "module": "./index.js",

--- a/libs/gui/lit/package.json
+++ b/libs/gui/lit/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@golemui/gui-lit",
   "version": "0.0.0",
+  "license": "MIT",
   "type": "module",
   "main": "./index.umd.cjs",
   "module": "./index.js",

--- a/libs/gui/mcp/package.json
+++ b/libs/gui/mcp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@golemui/gui-mcp",
   "version": "0.0.0",
+  "license": "MIT",
   "description": "Model Context Protocol server for GolemUI — gives AI coding assistants deterministic schema validation and form generation for GolemUI form definitions.",
   "type": "module",
   "main": "./lib.js",

--- a/libs/gui/react/package.json
+++ b/libs/gui/react/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@golemui/gui-react",
   "version": "0.0.0",
+  "license": "MIT",
   "type": "module",
   "main": "./index.umd.cjs",
   "module": "./index.js",

--- a/libs/gui/schemas/package.json
+++ b/libs/gui/schemas/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@golemui/gui-schemas",
   "version": "0.0.0",
+  "license": "MIT",
   "type": "module",
   "main": "./index.umd.cjs",
   "module": "./index.js",

--- a/libs/gui/shared/package.json
+++ b/libs/gui/shared/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@golemui/gui-shared",
   "version": "0.0.0",
+  "license": "MIT",
   "type": "module",
   "main": "./index.umd.cjs",
   "module": "./index.js",

--- a/libs/gui/shared/src/lib/dx/__tests__/displays.pipeline.spec.ts
+++ b/libs/gui/shared/src/lib/dx/__tests__/displays.pipeline.spec.ts
@@ -70,7 +70,9 @@ describe('DX Pipeline — Displays', () => {
     });
 
     it('still passes real $form data through when provided', () => {
-      const root = processDx(_guiDisplay((params) => `n:${params.$form.serviceLines?.length ?? 0}`));
+      const root = processDx(
+        _guiDisplay((params) => `n:${params.$form.serviceLines?.length ?? 0}`),
+      );
       const rawChild = getRawChild(root, 0);
       const resolved = resolveDynamic(rawChild, { $form: { serviceLines: [1, 2, 3] } }) as {
         props?: { render?: unknown };

--- a/libs/gui/validators/package.json
+++ b/libs/gui/validators/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@golemui/gui-validators",
   "version": "0.0.0",
+  "license": "MIT",
   "type": "module",
   "main": "./index.umd.cjs",
   "module": "./index.js",

--- a/libs/gui/vue/package.json
+++ b/libs/gui/vue/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@golemui/gui-vue",
   "version": "0.0.0",
+  "license": "MIT",
   "type": "module",
   "main": "./index.umd.cjs",
   "module": "./index.js",

--- a/libs/lit/package.json
+++ b/libs/lit/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@golemui/lit",
   "version": "0.0.0",
+  "license": "MIT",
   "type": "module",
   "main": "./index.umd.cjs",
   "module": "./index.js",

--- a/libs/react/package.json
+++ b/libs/react/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@golemui/react",
   "version": "0.0.0",
+  "license": "MIT",
   "type": "module",
   "main": "./index.umd.cjs",
   "module": "./index.js",

--- a/libs/ui-testing/package.json
+++ b/libs/ui-testing/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@golemui/ui-testing",
   "version": "0.0.1",
+  "license": "MIT",
   "private": true,
   "type": "commonjs",
   "main": "./src/index.js",

--- a/libs/vue/package.json
+++ b/libs/vue/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@golemui/vue",
   "version": "0.0.0",
+  "license": "MIT",
   "type": "module",
   "main": "./index.umd.cjs",
   "module": "./index.js",

--- a/tools/release.ts
+++ b/tools/release.ts
@@ -1,4 +1,6 @@
 import { execSync } from 'node:child_process';
+import { copyFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { releaseChangelog, releasePublish, releaseVersion } from 'nx/release';
 import { type VersionData } from 'nx/src/command-line/release/utils/shared';
 import { updateTemplateVersions } from './update-template-versions';
@@ -21,6 +23,47 @@ const PUBLISHABLE_PACKAGES = [
   '@golemui/gui-shared',
   '@golemui/gui-mcp',
 ];
+
+/**
+ * Derives the built `dist` directory for a publishable package from its npm name.
+ * `@golemui/core` lives at `dist/libs/core`, while `gui-` scoped packages live one
+ * level deeper, e.g. `@golemui/gui-mcp` => `dist/libs/gui/mcp`.
+ */
+function distDirForPackage(packageName: string): string {
+  const shortName = packageName.replace('@golemui/', '');
+  const relativePath = shortName.startsWith('gui-')
+    ? join('gui', shortName.slice('gui-'.length))
+    : shortName;
+  return join('dist', 'libs', relativePath);
+}
+
+/**
+ * Copies the root LICENSE file into every publishable package's `dist` directory
+ */
+function copyLicenseToPackages(dryRun: boolean) {
+  const licenseFile = join(process.cwd(), 'LICENSE');
+  if (!existsSync(licenseFile)) {
+    console.warn(`LICENSE not found at ${licenseFile}; skipping license copy.`);
+    return;
+  }
+
+  PUBLISHABLE_PACKAGES.forEach((packageName) => {
+    const destDir = join(process.cwd(), distDirForPackage(packageName));
+    if (!existsSync(destDir)) {
+      console.warn(`Build output missing for ${packageName} (${destDir}); skipping license copy.`);
+      return;
+    }
+
+    const destination = join(destDir, 'LICENSE');
+    if (dryRun) {
+      console.log(`[dry-run] Would copy LICENSE => ${destination}`);
+      return;
+    }
+
+    copyFileSync(licenseFile, destination);
+    console.log(`Copied LICENSE => ${destination}`);
+  });
+}
 
 function updateLatestDistTag(projectsVersionData: VersionData) {
   const version = projectsVersionData.newVersion;
@@ -58,6 +101,9 @@ function updateLatestDistTag(projectsVersionData: VersionData) {
     version: workspaceVersion,
     dryRun,
   });
+
+  // Ensure the MIT license text ships inside every package tarball.
+  copyLicenseToPackages(dryRun);
 
   const publishResult = await releasePublish({
     registry: 'https://registry.npmjs.org/',


### PR DESCRIPTION
## Description
- Added `"license": "MIT"` in every publishable package ( plus the private @golemui/ui-testing for consistency).
- Copy LICENSE text in tarballs ( via `tools/release.ts` )