### PR TITLE
fix(gui-shared): make dx event handlers function-only

### DIFF
--- a/apps/apps-shared/src/lib/mocks/appetizer.ts
+++ b/apps/apps-shared/src/lib/mocks/appetizer.ts
@@ -58,7 +58,7 @@ const formDef: DxDefinitions = [
         },
       },
     },
-    onChange: 'onSelectLanguage',
+    onChange: () => 'onSelectLanguage',
   }),
 
   gui.layouts.grid(
@@ -110,7 +110,7 @@ const formDef: DxDefinitions = [
             },
           },
         },
-        onChange: 'fieldChange',
+        onChange: () => 'fieldChange',
       }),
       gui.inputs.currency('budget', {
         label: {
@@ -136,7 +136,7 @@ const formDef: DxDefinitions = [
             },
           },
         },
-        onChange: 'fieldChange',
+        onChange: () => 'fieldChange',
       }),
     ],
     { direction: 'row', autoFit: true, align: 'stretch' },
@@ -215,7 +215,7 @@ const formDef: DxDefinitions = [
           key: 'travelPlanner.field.includePets',
           default: 'Include Pets',
         },
-        onChange: 'fieldChange',
+        onChange: () => 'fieldChange',
       }),
     ],
     { direction: 'column', align: 'end', justify: 'end' },
@@ -261,7 +261,7 @@ const formDef: DxDefinitions = [
         },
       },
     },
-    onChange: 'fieldChange',
+    onChange: () => 'fieldChange',
   }),
 
   gui.actions.button({

--- a/apps/apps-shared/src/lib/mocks/kitchen-sink.dx.ts
+++ b/apps/apps-shared/src/lib/mocks/kitchen-sink.dx.ts
@@ -162,7 +162,7 @@ export const buildKitchenSinkDx = (options: KitchenSinkDxOptions = {}): KitchenS
             ]
           : []),
       ],
-      { defaultOpen: 'tabAlert', onChange: 'onTabEvent' },
+      { defaultOpen: 'tabAlert', onChange: () => 'onTabEvent' },
     ),
     gui.actions.button({
       uid: 'submit-button',

--- a/apps/apps-shared/src/lib/mocks/kitchen-sink.equivalence.spec.ts
+++ b/apps/apps-shared/src/lib/mocks/kitchen-sink.equivalence.spec.ts
@@ -130,13 +130,13 @@ const collapseLayoutWrappers = (node: any): any => {
       out[k] = collapseLayoutWrappers(v);
     }
     if (
-      out.kind === 'layout' &&
-      out.type === 'flex' &&
-      Array.isArray(out.children) &&
-      out.children.length === 1 &&
-      out.children[0]?.kind === 'layout'
+      out['kind'] === 'layout' &&
+      out['type'] === 'flex' &&
+      Array.isArray(out['children']) &&
+      out['children'].length === 1 &&
+      out['children'][0]?.kind === 'layout'
     ) {
-      return out.children[0];
+      return out['children'][0];
     }
     return out;
   }

--- a/apps/apps-shared/src/lib/mocks/tabs/accordion.dx.ts
+++ b/apps/apps-shared/src/lib/mocks/tabs/accordion.dx.ts
@@ -39,6 +39,6 @@ export const accordionTab = gui.layouts.accordion(
   {
     singleOpen: false,
     defaultOpen: { section1: true },
-    onChange: 'onAccordionEvent',
+    onChange: () => 'onAccordionEvent',
   },
 );

--- a/apps/apps-shared/src/lib/mocks/tabs/dropdown.dx.ts
+++ b/apps/apps-shared/src/lib/mocks/tabs/dropdown.dx.ts
@@ -17,8 +17,8 @@ export const dropdownTab = gui.layouts.flex([
     items: [],
     hint: 'Search as you type with server side filtering',
     autocomplete: 'off',
-    onLoad: 'searchProductForDropdown',
-    onFilter: 'searchProductForDropdown',
+    onLoad: () => 'searchProductForDropdown',
+    onFilter: () => 'searchProductForDropdown',
   }),
   gui.inputs.dropdown('dropdowns.defaultListRendererObjectItems', {
     label: 'Default list renderer with object values',

--- a/apps/apps-shared/src/lib/mocks/tabs/radiogroup.dx.ts
+++ b/apps/apps-shared/src/lib/mocks/tabs/radiogroup.dx.ts
@@ -28,8 +28,8 @@ export const radiogroupTab = gui.layouts.flex([
   gui.inputs.radiogroup('radiogroups.subregion', {
     label: 'Country subregion',
     hint: 'No option should be selected',
-    onLoad: 'getSubregionsForRadio',
-    onChange: 'getCountriesForRadio',
+    onLoad: () => 'getSubregionsForRadio',
+    onChange: () => 'getCountriesForRadio',
   }),
   gui.inputs.radiogroup('radiogroups.country', {
     include: { in: ['hasSubregionRadiogroup'] },

--- a/apps/apps-shared/src/lib/mocks/tabs/select.dx.ts
+++ b/apps/apps-shared/src/lib/mocks/tabs/select.dx.ts
@@ -31,8 +31,8 @@ export const selectTab = gui.layouts.flex([
   gui.inputs.select('selects.subregion', {
     label: 'Country subregion',
     hint: 'The disabled  "Select an Option" option should be selected',
-    onLoad: 'getSubregionsForSelect',
-    onChange: 'getCountriesForSelect',
+    onLoad: () => 'getSubregionsForSelect',
+    onChange: () => 'getCountriesForSelect',
   }),
   gui.inputs.select('selects.country', {
     include: { in: ['hasSubregionSelect'] },

--- a/libs/gui/mcp/src/dx/check-dx-code.spec.ts
+++ b/libs/gui/mcp/src/dx/check-dx-code.spec.ts
@@ -65,6 +65,21 @@ describe('dx_check_code', () => {
     expect(r.diagnostics.some((d) => /actionType: 'submit'/.test(d.hint ?? ''))).toBe(true);
   });
 
+  it('rejects a bare-string event handler (dx events must be functions, like actions)', async () => {
+    const r = await checkDxCode({
+      code: `[ gui.inputs.textInput('name', { label: 'Name', onChange: 'doSomething' }) ]`,
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  it('accepts a function event handler that returns a host-managed event name', async () => {
+    const r = await checkDxCode({
+      code: `[ gui.inputs.textInput('name', { label: 'Name', onChange: () => 'doSomething' }) ]`,
+    });
+    if (!r.ok) console.error(JSON.stringify(r.diagnostics, null, 2));
+    expect(r.ok).toBe(true);
+  });
+
   it('catches the cold hallucination (invented chained builder)', async () => {
     const r = await checkDxCode({
       code: `gui.form('signup').text('name', (f) => f.label('Name')).build();`,

--- a/libs/gui/mcp/src/dx/dx-specs.spec.ts
+++ b/libs/gui/mcp/src/dx/dx-specs.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { DX_SPECS, dxPatterns, listDxFactories } from './dx-specs';
+import { DX_SPECS, dxCommonNote, dxPatterns, listDxFactories } from './dx-specs';
 import { typeCheckDx } from './typecheck';
 
 /**
@@ -19,6 +19,14 @@ describe('dx-specs registry', () => {
     ]) {
       expect(listDxFactories()).toContain(f);
     }
+  });
+
+  it('teaches the function-only event-handler rule in the common note', () => {
+    const note = dxCommonNote();
+    expect(note).toMatch(/EVENT HANDLERS/);
+    // Both forms a model needs: declarative host name and imperative event.update.
+    expect(note).toMatch(/onChange: \(\) =>/);
+    expect(note).toMatch(/event\.update\(/);
   });
 
   it.each(listDxFactories())(

--- a/libs/gui/mcp/src/dx/dx-specs.ts
+++ b/libs/gui/mcp/src/dx/dx-specs.ts
@@ -110,7 +110,11 @@ function commonNote(fw: DxFramework = 'react'): string {
     "(`dropdown`, `radiogroup`, `select`) REQUIRE an explicit `type`: `validator: { type: 'string', required: true }`. " +
     "(2) `repeater` (array) validators auto-supply `type: 'array'` — supply only the rules, e.g. " +
     '`validator: { required: true, minItems: 1 }`, never `type`. (3) everything else (text, number, date) takes the ' +
-    'loose validator with NO `type`: `validator: { required: true }`.'
+    'loose validator with NO `type`: `validator: { required: true }`. ' +
+    'EVENT HANDLERS — `onChange`/`onLoad`/`onFilter`/`onBlur` (inputs/layouts) and `onClick` (actions) are ' +
+    'FUNCTIONS, never bare strings: return a string to dispatch a host event by that name ' +
+    "(`onChange: () => 'languageChanged'`), or take the event to push live changes " +
+    "(`onChange: (event) => event.update({ path: 'city', options: [...] })`)."
   );
 }
 

--- a/libs/gui/mcp/src/dx/type-graph.ts
+++ b/libs/gui/mcp/src/dx/type-graph.ts
@@ -140,13 +140,30 @@ export function diagnose(
 let guardChecked = false;
 export function assertTypesAreLive(ts: typeof TS, options: TS.CompilerOptions): void {
   if (guardChecked) return;
+
+  // Negative control: an invented member must fail. Catches a TOTAL collapse to `any`
+  // (the whole `gui.*` graph degraded, so every member access type-checks clean).
   const bogus = `import { gui } from '@golemui/gui-shared';\n[gui.inputs.__definitely_not_a_real_member__('x', {})];\n`;
-  const diags = diagnose(ts, bogus, options);
-  if (diags.length === 0) {
+  if (diagnose(ts, bogus, options).length === 0) {
     throw new Error(
       'dx_check_code: internal type-resolution guard failed — a known-invalid snippet type-checked ' +
         'clean, which means the @golemui types resolved to `any`. Refusing to return misleading results.',
     );
   }
+
+  // Positive control: a bare-string event handler must fail. Catches a PARTIAL degradation
+  // the negative control would miss — e.g. a stale `dist` `.d.ts` that predates the
+  // function-only `DxEventHandler`, where `onChange` resolves to `any` while `gui.inputs`
+  // is otherwise live. Without this, the exact protection `dx_check_code` advertises could
+  // silently regress and let `onChange: 'string'` through.
+  const looseEvent = `import { gui } from '@golemui/gui-shared';\n[gui.inputs.textInput('x', { onChange: 'not-a-function' })];\n`;
+  if (diagnose(ts, looseEvent, options).length === 0) {
+    throw new Error(
+      'dx_check_code: internal type-resolution guard failed — a bare-string event handler type-checked ' +
+        'clean, so the DxEventHandler type resolved to `any` (likely a stale @golemui build). Refusing ' +
+        'to return misleading results.',
+    );
+  }
+
   guardChecked = true;
 }

--- a/libs/gui/shared/src/lib/dx/__tests__/eventWiring.pipeline.spec.ts
+++ b/libs/gui/shared/src/lib/dx/__tests__/eventWiring.pipeline.spec.ts
@@ -17,7 +17,7 @@ function getRootFromFacadeResult(
 describe('DX Pipeline — Event Wiring', () => {
   describe('Input events — onLoad', () => {
     it('wires onLoad callback on a select to on.load with generated event name', () => {
-      const loadFn = vi.fn();
+      const loadFn = vi.fn((_event: FormEvent) => undefined);
       const root = processDx([_guiSelect('country', { options: [], onLoad: loadFn })]);
 
       const select = getStaticChild(root, 0) as any;
@@ -27,15 +27,15 @@ describe('DX Pipeline — Event Wiring', () => {
       expect(select.on.load).toMatch(/^event_\d+$/);
     });
 
-    it('wires onLoad string passthrough to on.load', () => {
-      const root = processDx([_guiSelect('country', { options: [], onLoad: 'myLoadEvent' })]);
+    it('wires a zero-arg handler returning a string to on.load (host-managed dispatch)', () => {
+      const root = processDx([_guiSelect('country', { options: [], onLoad: () => 'myLoadEvent' })]);
 
       const select = getStaticChild(root, 0) as any;
       expect(select.on?.load).toBe('myLoadEvent');
     });
 
     it('registers onLoad callback in event registry and dispatches FormEvent with update', () => {
-      const loadFn = vi.fn();
+      const loadFn = vi.fn((_event: FormEvent) => undefined);
       const result = formDefs.processDxFacade(
         [_guiSelect('country', { options: [], onLoad: loadFn })],
         [],
@@ -66,7 +66,7 @@ describe('DX Pipeline — Event Wiring', () => {
 
   describe('Input events — onChange', () => {
     it('wires onChange callback on a select to on.change', () => {
-      const changeFn = vi.fn();
+      const changeFn = vi.fn((_event: FormEvent) => undefined);
       const root = processDx([_guiSelect('country', { options: [], onChange: changeFn })]);
 
       const select = getStaticChild(root, 0) as any;
@@ -74,15 +74,17 @@ describe('DX Pipeline — Event Wiring', () => {
       expect(select.on.change).toMatch(/^event_\d+$/);
     });
 
-    it('wires onChange string passthrough to on.change', () => {
-      const root = processDx([_guiSelect('country', { options: [], onChange: 'myChangeEvent' })]);
+    it('wires a zero-arg handler returning a string to on.change (host-managed dispatch)', () => {
+      const root = processDx([
+        _guiSelect('country', { options: [], onChange: () => 'myChangeEvent' }),
+      ]);
 
       const select = getStaticChild(root, 0) as any;
       expect(select.on?.change).toBe('myChangeEvent');
     });
 
     it('registers onChange callback and dispatches FormEvent with update', () => {
-      const changeFn = vi.fn();
+      const changeFn = vi.fn((_event: FormEvent) => undefined);
       const result = formDefs.processDxFacade(
         [_guiSelect('country', { options: [], onChange: changeFn })],
         [],
@@ -113,7 +115,7 @@ describe('DX Pipeline — Event Wiring', () => {
 
   describe('Input events — onFilter', () => {
     it('wires onFilter callback on a dropdown to on.filter', () => {
-      const filterFn = vi.fn();
+      const filterFn = vi.fn((_event: FormEvent) => undefined);
       const root = processDx([_guiDropdown('product', { items: [], onFilter: filterFn })]);
 
       const dropdown = getStaticChild(root, 0) as any;
@@ -121,8 +123,10 @@ describe('DX Pipeline — Event Wiring', () => {
       expect(dropdown.on.filter).toMatch(/^event_\d+$/);
     });
 
-    it('wires onFilter string passthrough to on.filter', () => {
-      const root = processDx([_guiDropdown('product', { items: [], onFilter: 'searchProduct' })]);
+    it('wires a zero-arg handler returning a string to on.filter (host-managed dispatch)', () => {
+      const root = processDx([
+        _guiDropdown('product', { items: [], onFilter: () => 'searchProduct' }),
+      ]);
 
       const dropdown = getStaticChild(root, 0) as any;
       expect(dropdown.on?.filter).toBe('searchProduct');
@@ -131,8 +135,8 @@ describe('DX Pipeline — Event Wiring', () => {
 
   describe('Multiple events on a single widget', () => {
     it('wires onLoad and onChange on the same select with unique event names', () => {
-      const loadFn = vi.fn();
-      const changeFn = vi.fn();
+      const loadFn = vi.fn((_event: FormEvent) => undefined);
+      const changeFn = vi.fn((_event: FormEvent) => undefined);
       const root = processDx([
         _guiSelect('country', { options: [], onLoad: loadFn, onChange: changeFn }),
       ]);
@@ -144,9 +148,9 @@ describe('DX Pipeline — Event Wiring', () => {
     });
 
     it('wires onLoad, onChange, and onFilter on a dropdown', () => {
-      const loadFn = vi.fn();
-      const changeFn = vi.fn();
-      const filterFn = vi.fn();
+      const loadFn = vi.fn((_event: FormEvent) => undefined);
+      const changeFn = vi.fn((_event: FormEvent) => undefined);
+      const filterFn = vi.fn((_event: FormEvent) => undefined);
       const root = processDx([
         _guiDropdown('product', {
           items: [],
@@ -168,7 +172,7 @@ describe('DX Pipeline — Event Wiring', () => {
 
   describe('Layout events — onChange', () => {
     it('wires onChange callback on tabs to on.change', () => {
-      const changeFn = vi.fn();
+      const changeFn = vi.fn((_event: FormEvent) => undefined);
       const root = processDx([
         _guiTabs(
           [
@@ -187,7 +191,7 @@ describe('DX Pipeline — Event Wiring', () => {
     });
 
     it('registers tabs onChange callback and dispatches FormEvent with update', () => {
-      const changeFn = vi.fn();
+      const changeFn = vi.fn((_event: FormEvent) => undefined);
       const result = formDefs.processDxFacade(
         [
           _guiTabs(
@@ -315,7 +319,7 @@ describe('DX Pipeline — Event Wiring', () => {
 
   describe('Input events — onBlur', () => {
     it('wires onBlur callback to on.blur with generated event name', () => {
-      const blurFn = vi.fn();
+      const blurFn = vi.fn((_event: FormEvent) => undefined);
       const root = processDx([_guiTextInput('email', { onBlur: blurFn })]);
 
       const input = getStaticChild(root, 0) as any;
@@ -324,17 +328,27 @@ describe('DX Pipeline — Event Wiring', () => {
       expect(input.on.blur).toMatch(/^event_\d+$/);
     });
 
-    it('wires onBlur string passthrough to on.blur', () => {
-      const root = processDx([_guiTextInput('email', { onBlur: 'myBlurEvent' })]);
+    it('wires a zero-arg handler returning a string to on.blur (host-managed dispatch)', () => {
+      const root = processDx([_guiTextInput('email', { onBlur: () => 'myBlurEvent' })]);
 
       const input = getStaticChild(root, 0) as any;
       expect(input.on?.blur).toBe('myBlurEvent');
+    });
+
+    it('registers an imperative handler that reads the event without invoking it at build time', () => {
+      const blurFn = vi.fn((event: any) => event.update({ path: 'email' }));
+      const root = processDx([_guiTextInput('email', { onBlur: blurFn })]);
+
+      const input = getStaticChild(root, 0) as any;
+      // Handler declares the `event` param, so it is registered (generated name), not probed.
+      expect(input.on?.blur).toMatch(/^event_\d+$/);
+      expect(blurFn).not.toHaveBeenCalled();
     });
   });
 
   describe('DX update wrapper — event.update({ path, prop: value })', () => {
     it('translates DX-friendly update shape to OVERRIDE_WIDGET_PROP dispatch', () => {
-      const changeFn = vi.fn();
+      const changeFn = vi.fn((_event: FormEvent) => undefined);
       const result = formDefs.processDxFacade(
         [
           _guiSelect('country', { options: [], onChange: changeFn }),
@@ -372,7 +386,7 @@ describe('DX Pipeline — Event Wiring', () => {
     });
 
     it('translates multiple props in a single update call', () => {
-      const loadFn = vi.fn();
+      const loadFn = vi.fn((_event: FormEvent) => undefined);
       const result = formDefs.processDxFacade(
         [_guiSelect('tz', { options: [], onLoad: loadFn })],
         [],
@@ -402,7 +416,7 @@ describe('DX Pipeline — Event Wiring', () => {
     });
 
     it('passes through raw OVERRIDE_WIDGET_PROP actions unchanged via callback (backward compat)', () => {
-      const changeFn = vi.fn();
+      const changeFn = vi.fn((_event: FormEvent) => undefined);
       const result = formDefs.processDxFacade(
         [_guiSelect('country', { options: [], onChange: changeFn })],
         [],
@@ -430,7 +444,7 @@ describe('DX Pipeline — Event Wiring', () => {
 
   describe('Dynamic (callback) widgets with events', () => {
     it('wires onLoad on a dynamic select at runtime', () => {
-      const loadFn = vi.fn();
+      const loadFn = vi.fn((_event: FormEvent) => undefined);
       const root = processDx([
         _guiSelect('country', (p: any) => ({
           options: p?.$form?.ready ? ['US'] : [],

--- a/libs/gui/shared/src/lib/dx/core/dxBase.types.ts
+++ b/libs/gui/shared/src/lib/dx/core/dxBase.types.ts
@@ -17,10 +17,24 @@ export type DxFormEvent = FormEvent & {
 
 /**
  * Event handler type for DX event properties.
- * - Function: handler invoked with a DxFormEvent (use event.update to push widget changes).
- * - String: pass-through event name for host-managed dispatch.
+ *
+ * Function-only, mirroring action `onClick`. Bare strings are NOT accepted — a stray
+ * `onChange: 'something'` is a footgun (it looks like a value, not a handler), so the
+ * type rejects it.
+ *
+ * - Return a string to wire a host-managed event name (e.g. `onChange: () => 'fieldChange'`
+ *   dispatches `fieldChange` to the host event bus). Only zero-arg handlers are probed for
+ *   this, so the `event` parameter is never touched at build time.
+ * - Otherwise the handler runs on dispatch; use `event.update(...)` to push widget changes.
+ *
+ * @example
+ * // Host-managed dispatch by name:
+ * onChange: () => 'fieldChange'
+ * @example
+ * // Imperative handler:
+ * onChange: (event) => event.update({ path: 'country', options: [] })
  */
-export type DxEventHandler = string | ((event: DxFormEvent) => void);
+export type DxEventHandler = (event: DxFormEvent) => void | string;
 
 /**
  * INTERNAL decorator fields — used by the pipeline, NOT by form authors.

--- a/libs/gui/shared/src/lib/dx/core/dxBase.types.ts
+++ b/libs/gui/shared/src/lib/dx/core/dxBase.types.ts
@@ -71,7 +71,13 @@ export interface DxCommonFields {
   uid?: string;
   tags?: string[];
   size?: number;
-  /** Per-state property overrides. Keys are state names (use `:` for hierarchy). */
+  /**
+   * Per-state property overrides. Keys are state names (use `:` for hierarchy).
+   *
+   * NOTE: the override values are an untyped escape hatch (`Record<string, any>`), so they
+   * are NOT type-checked — e.g. `states: { editing: { onChange: 'foo' } }` compiles even
+   * though a top-level `onChange: 'foo'` does not (events are function-only).
+   */
   states?: Record<string, Record<string, any>>;
   /** Conditionally include the widget — by active state list or reactive expression. */
   include?: DxIncludeCondition;

--- a/libs/gui/shared/src/lib/dx/core/eventWiring.service.ts
+++ b/libs/gui/shared/src/lib/dx/core/eventWiring.service.ts
@@ -142,7 +142,8 @@ export class EventWiringService {
         }
         hasNewEvents = true;
       } else if (typeof value === 'string') {
-        // Internal/legacy path — the public DX type no longer accepts bare strings.
+        // Strings are still honored at runtime for internal/core wiring (and untyped
+        // `states` overrides); the public DX type rejects them, so authors use functions.
         on[coreKey] = value;
         hasNewEvents = true;
       }

--- a/libs/gui/shared/src/lib/dx/core/eventWiring.service.ts
+++ b/libs/gui/shared/src/lib/dx/core/eventWiring.service.ts
@@ -19,6 +19,31 @@ const INPUT_LAYOUT_EVENT_PROPS: Record<string, string> = {
 const INPUT_LAYOUT_EVENT_KEYS = Object.keys(INPUT_LAYOUT_EVENT_PROPS);
 
 /**
+ * Probe a DX event handler for a host-managed event name.
+ *
+ * Mirrors the action `onClick` pattern: a handler that simply returns a string
+ * (`() => 'fieldChange'`) declares a host-managed dispatch by name. Only **zero-arg**
+ * handlers are probed — a handler that declares the `event` parameter
+ * (`(event) => event.update(...)`) is an imperative handler and is never invoked here,
+ * so its method-bearing `DxFormEvent` is never touched with `undefined`.
+ *
+ * @returns the returned event name, or `null` when the handler is not a declarative
+ *   zero-arg string-returning handler (i.e. it should be registered and run on dispatch).
+ */
+export function probeForHostEventName(handler: (...args: any[]) => any): string | null {
+  if (handler.length > 0) {
+    return null;
+  }
+  try {
+    const result = handler();
+    return typeof result === 'string' ? result : null;
+  } catch {
+    // A zero-arg handler that throws is treated as an imperative handler.
+    return null;
+  }
+}
+
+/**
  * Generalisation of ActionOnClickService.
  *
  * Two entry points:
@@ -106,11 +131,18 @@ export class EventWiringService {
       const coreKey = INPUT_LAYOUT_EVENT_PROPS[prop];
 
       if (typeof value === 'function') {
-        const eventName = eventIdGenerator.next();
-        eventRegistry.set(eventName, value);
-        on[coreKey] = eventName;
+        const hostEventName = probeForHostEventName(value);
+        if (hostEventName != null) {
+          // Declarative form `() => 'evName'`: wire the host-managed event name directly.
+          on[coreKey] = hostEventName;
+        } else {
+          const eventName = eventIdGenerator.next();
+          eventRegistry.set(eventName, value);
+          on[coreKey] = eventName;
+        }
         hasNewEvents = true;
       } else if (typeof value === 'string') {
+        // Internal/legacy path — the public DX type no longer accepts bare strings.
         on[coreKey] = value;
         hasNewEvents = true;
       }

--- a/libs/gui/shared/src/lib/dx/core/stateExpansion.service.ts
+++ b/libs/gui/shared/src/lib/dx/core/stateExpansion.service.ts
@@ -1,6 +1,7 @@
 import { type FunctionWidgetParams, type NonFunctionWidget } from '@golemui/core';
 import { type GslLeafSelector, type MergeResult, type RuntimeFunction } from './dx.domain';
 import { type EventIdGenerator, type EventRegistry } from './itemTypeRegistry';
+import { probeForHostEventName } from './eventWiring.service';
 
 // ═══════════════════════════════════════════════════
 // State Expansion Service
@@ -180,9 +181,15 @@ export class StateExpansionService {
     if (!widget['on']) widget['on'] = {};
 
     if (typeof value === 'function') {
-      const eventName = eventIdGenerator.next();
-      eventRegistry.set(eventName, value);
-      widget['on'][`${coreKey}.${coreStateName}`] = eventName;
+      const hostEventName = probeForHostEventName(value);
+      if (hostEventName != null) {
+        // Declarative form `() => 'evName'`: wire the host-managed event name directly.
+        widget['on'][`${coreKey}.${coreStateName}`] = hostEventName;
+      } else {
+        const eventName = eventIdGenerator.next();
+        eventRegistry.set(eventName, value);
+        widget['on'][`${coreKey}.${coreStateName}`] = eventName;
+      }
     } else if (typeof value === 'string') {
       widget['on'][`${coreKey}.${coreStateName}`] = value;
     }

--- a/libs/gui/shared/src/lib/dx/shortcuts/custom-action/customAction.domain.ts
+++ b/libs/gui/shared/src/lib/dx/shortcuts/custom-action/customAction.domain.ts
@@ -8,7 +8,7 @@ import type { DefOrCallback, GslConfigBase, GuiShortcutOf } from '../../core/dxU
 export interface CustomActionDecorator extends DxActionBase, DxCommonFields {
   customType: string;
   props?: Record<string, unknown>;
-  onClick?: ((data: any) => void) | string;
+  onClick?: (data: any) => void | string;
   data?: any | null;
   on?: { click: string };
 }


### PR DESCRIPTION
## Description

`gui.*` (dx) API event handlers are function-only, matching action `onClick`.

- `onChange: 'something'` is now a type error. 
- Use `onChange: () => 'fieldChange'` or `onChange: (event) => event.update(...)`.