### PR TITLE
fix(gui-mcp): defer DX createRequire and add portable /json export

### DIFF
--- a/libs/gui/mcp/package.json
+++ b/libs/gui/mcp/package.json
@@ -11,6 +11,10 @@
     ".": {
       "types": "./lib.d.ts",
       "import": "./lib.js"
+    },
+    "./json": {
+      "types": "./json.d.ts",
+      "import": "./json.js"
     }
   },
   "bin": {

--- a/libs/gui/mcp/src/dx/type-graph.ts
+++ b/libs/gui/mcp/src/dx/type-graph.ts
@@ -21,7 +21,19 @@ import type * as TS from 'typescript';
  * to return results in that state.
  */
 
-const requireFrom = createRequire(import.meta.url);
+let cachedRequire: ReturnType<typeof createRequire> | undefined;
+
+/**
+ * Lazily construct a `require` bound to this module.
+ *
+ * Deferred (not evaluated at module load) so consumers that import only the JSON
+ * tools can be bundled for non-Node runtimes (e.g. Cloudflare Workers) without
+ * `createRequire(import.meta.url)` throwing at import time, where `import.meta.url`
+ * is undefined. Only ever called on the DX type-check path, which is Node-only.
+ */
+function getRequire(): ReturnType<typeof createRequire> {
+  return (cachedRequire ??= createRequire(import.meta.url));
+}
 
 /** The `@golemui` packages the `gui.*` type graph transitively references. */
 const GOLEMUI_TYPE_PACKAGES = [
@@ -53,7 +65,7 @@ interface ResolveStrategy {
  */
 function resolveStrategy(): ResolveStrategy {
   try {
-    const pj = requireFrom.resolve('@golemui/gui-shared/package.json');
+    const pj = getRequire().resolve('@golemui/gui-shared/package.json');
     const [root] = pj.split(/[\\/]node_modules[\\/]/);
     if (root && root !== pj) return { baseUrl: root };
   } catch {

--- a/libs/gui/mcp/src/json.ts
+++ b/libs/gui/mcp/src/json.ts
@@ -1,0 +1,29 @@
+// Runtime-portable surface: the JSON form-definition tools plus the shared concept
+// reference.
+//
+// This entry deliberately excludes the `gui.*` DX type-check path (`./dx/*`), which
+// depends on the Node `typescript` compiler and `node:module`/`node:fs`/`node:url` and
+// is therefore Node-only. Importing from `@golemui/gui-mcp/json` (rather than the
+// package root) lets non-Node consumers — e.g. a Cloudflare Worker — bundle the JSON
+// tools without dragging in the DX machinery. The package root (`./lib`) re-exports
+// everything for Node consumers.
+
+// --- JSON form-definition path ---
+export {
+  validateFormDefinition,
+  JSON_VALIDATE_FORM_DEFINITION_TOOL,
+} from './json/validate-form-definition';
+export type { ValidateInput, ValidateResult } from './json/validate-form-definition';
+export {
+  generateFromJsonSchema,
+  JSON_GENERATE_FROM_SCHEMA_TOOL,
+} from './json/generate-from-json-schema';
+export type {
+  GenerateFromJsonSchemaInput,
+  GenerateFromJsonSchemaResult,
+} from './json/generate-from-json-schema';
+export { generateFromOpenapi, JSON_GENERATE_FROM_OPENAPI_TOOL } from './json/generate-from-openapi';
+export { getWidgetSpec, JSON_GET_WIDGET_SPEC_TOOL } from './json/get-widget-spec';
+
+// --- shared (cross-cutting reference) ---
+export { getConcept, GET_CONCEPT_TOOL } from './shared/get-concept';

--- a/libs/gui/mcp/src/lib.ts
+++ b/libs/gui/mcp/src/lib.ts
@@ -1,21 +1,12 @@
-// --- JSON form-definition path ---
-export {
-  validateFormDefinition,
-  JSON_VALIDATE_FORM_DEFINITION_TOOL,
-} from './json/validate-form-definition';
-export type { ValidateInput, ValidateResult } from './json/validate-form-definition';
-export {
-  generateFromJsonSchema,
-  JSON_GENERATE_FROM_SCHEMA_TOOL,
-} from './json/generate-from-json-schema';
-export type {
-  GenerateFromJsonSchemaInput,
-  GenerateFromJsonSchemaResult,
-} from './json/generate-from-json-schema';
-export { generateFromOpenapi, JSON_GENERATE_FROM_OPENAPI_TOOL } from './json/generate-from-openapi';
-export { getWidgetSpec, JSON_GET_WIDGET_SPEC_TOOL } from './json/get-widget-spec';
+// Full package surface (Node). Re-exports the runtime-portable JSON + shared tools
+// plus the Node-only `gui.*` DX type-check path. Non-Node consumers (e.g. a Cloudflare
+// Worker) should import from `@golemui/gui-mcp/json` instead, to avoid bundling the DX
+// machinery (the `typescript` compiler and `node:*` builtins).
 
-// --- gui.* DX path ---
+// --- runtime-portable: JSON form-definition path + shared reference ---
+export * from './json';
+
+// --- gui.* DX path (Node-only) ---
 export { checkDxCode, DX_CHECK_CODE_TOOL } from './dx/check-dx-code';
 export type { CheckDxCodeInput, CheckDxCodeResult } from './dx/check-dx-code';
 export { getDxSpec, DX_GET_SPEC_TOOL } from './dx/get-dx-spec';
@@ -26,6 +17,3 @@ export { typeCheckDx } from './dx/typecheck';
 export type { DxDiagnostic, DxCheckResult } from './dx/typecheck';
 export { DX_SPECS, listDxFactories, dxCatalog } from './dx/dx-specs';
 export type { DxSpec, DxNamespace, DxCatalog, DxCatalogEntry } from './dx/dx-specs';
-
-// --- shared (cross-cutting reference) ---
-export { getConcept, GET_CONCEPT_TOOL } from './shared/get-concept';

--- a/libs/gui/mcp/vite.config.ts
+++ b/libs/gui/mcp/vite.config.ts
@@ -24,7 +24,8 @@ export default defineConfig(() => ({
     ssr: true,
     lib: {
       entry: {
-        lib: 'src/lib.ts', // library - no server, importable anywhere
+        lib: 'src/lib.ts', // full surface (JSON + DX) - Node consumers
+        json: 'src/json.ts', // JSON + shared only, no Node-only DX - bundles anywhere (e.g. Workers)
         cli: 'src/cli.ts', // MCP stdio server - Node.js only
       },
       formats: ['es'],


### PR DESCRIPTION
## Description

Top-level createRequire(import.meta.url) crashed non-Node bundles (e.g. cloudflare Workers) on import. Make it lazy, and add a @golemui/gui-mcp/json subpath exporting only the JSON tools + getConcept, free of DX/node:* code.
