### PR TITLE
fix(schemas): add custom widget fallback to the JSON form schema

### DIFF
--- a/libs/gui/mcp/src/json/errors.ts
+++ b/libs/gui/mcp/src/json/errors.ts
@@ -153,11 +153,15 @@ export function formatAjvErrors(
   errors: ErrorObject[] | null | undefined,
   dataRoot?: unknown,
 ): FormattedResult {
-  if (!errors?.length) return { errors: [], warnings: [] };
+  // With a `dataRoot` we always run the per-widget pass, even when ajv reports no errors. The
+  // custom-widget fallback in the form schema makes ajv accept any unknown `type` (including typos
+  // of built-ins), so the targeted per-widget diagnostics (typo suggestions, custom-widget
+  // warnings) are now the only place those are surfaced.
+  if (!errors?.length && dataRoot === undefined) return { errors: [], warnings: [] };
   const collapsed =
     dataRoot !== undefined
-      ? collapseOneOfErrors(errors, dataRoot)
-      : { errors, warnings: [] as FormattedError[] };
+      ? collapseOneOfErrors(errors ?? [], dataRoot)
+      : { errors: errors as ErrorObject[], warnings: [] as FormattedError[] };
   const filtered = collapsed.errors;
   const out: FormattedError[] = [];
   for (const err of filtered) {

--- a/libs/gui/mcp/src/json/schemas/index.ts
+++ b/libs/gui/mcp/src/json/schemas/index.ts
@@ -9,6 +9,7 @@ import {
   calendarSchema as calendar,
   checkboxSchema as checkbox,
   currencySchema as currency,
+  customSchema as custom,
   dateinputSchema as dateinput,
   datepickerSchema as datepicker,
   dropdownSchema as dropdown,
@@ -43,6 +44,13 @@ export const COMMON_SCHEMA = commonSchema as WidgetSchema;
 export const FORM_SCHEMA = formSchema as WidgetSchema;
 export const LAYOUT_WIDGET_SCHEMA = layoutWidgetSchema as WidgetSchema;
 export const VALIDATORS_SCHEMA = validatorsSchema as WidgetSchema;
+
+/**
+ * Fallback schema for user-registered custom components (any `type` not in COMPONENT_SCHEMAS).
+ * Referenced by `form.schema.json`'s `formWidget` oneOf, so it must be registered for the form
+ * validator to compile. Kept out of COMPONENT_SCHEMAS because it has no single `type` const.
+ */
+export const CUSTOM_SCHEMA = custom as WidgetSchema;
 
 /**
  * Component schemas, keyed by their widget `type` constant (the value of `properties.type.const`
@@ -83,5 +91,6 @@ export const ALL_SCHEMAS: WidgetSchema[] = [
   VALIDATORS_SCHEMA,
   LAYOUT_WIDGET_SCHEMA,
   ...Object.values(COMPONENT_SCHEMAS),
+  CUSTOM_SCHEMA,
   FORM_SCHEMA,
 ];

--- a/libs/gui/schemas/src/index.ts
+++ b/libs/gui/schemas/src/index.ts
@@ -8,6 +8,7 @@ export { default as buttonSchema } from './lib/components/button.schema.json';
 export { default as calendarSchema } from './lib/components/calendar.schema.json';
 export { default as checkboxSchema } from './lib/components/checkbox.schema.json';
 export { default as currencySchema } from './lib/components/currency.schema.json';
+export { default as customSchema } from './lib/components/custom.schema.json';
 export { default as dateinputSchema } from './lib/components/dateinput.schema.json';
 export { default as datepickerSchema } from './lib/components/datepicker.schema.json';
 export { default as dropdownSchema } from './lib/components/dropdown.schema.json';

--- a/libs/gui/schemas/src/lib/common.schema.json
+++ b/libs/gui/schemas/src/lib/common.schema.json
@@ -31,6 +31,38 @@
       "type": "string",
       "description": "Unique identifier for the widget"
     },
+    "knownWidgetTypes": {
+      "description": "Built-in widget `type` identifiers. Used to exclude built-ins from the custom-widget fallback so every widget matches exactly one schema.",
+      "enum": [
+        "accordion",
+        "alert",
+        "button",
+        "calendar",
+        "checkbox",
+        "currency",
+        "dateInput",
+        "datePicker",
+        "dropdown",
+        "flex",
+        "grid",
+        "list",
+        "markdown",
+        "markdownText",
+        "number",
+        "password",
+        "radiogroup",
+        "rangeCalendar",
+        "rangeDateInput",
+        "rangeDatePicker",
+        "repeater",
+        "select",
+        "tabs",
+        "tags",
+        "textarea",
+        "textinput",
+        "toggle"
+      ]
+    },
     "localizable": {
       "description": "A value that can be a plain string or an i18n key object. Use a plain string for static text, or `{key, default, params}` to reference a translation key.",
       "oneOf": [

--- a/libs/gui/schemas/src/lib/components/custom.schema.json
+++ b/libs/gui/schemas/src/lib/components/custom.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://golemui.com/schemas/components/custom.schema.json",
+  "title": "Custom Widget",
+  "description": "Fallback for user-registered custom components. Matches any widget whose `type` is NOT a built-in. Structural fields required by the widget's `kind` are validated (input -> path, layout -> children); `props` is an open object validated at runtime by the custom component itself.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "../common.schema.json#/$defs/baseWidget"
+    },
+    {
+      "properties": {
+        "type": {
+          "not": { "$ref": "../common.schema.json#/$defs/knownWidgetTypes" }
+        }
+      }
+    }
+  ],
+  "oneOf": [
+    { "$ref": "#/$defs/customInput" },
+    { "$ref": "#/$defs/customDisplay" },
+    { "$ref": "#/$defs/customAction" },
+    { "$ref": "#/$defs/customLayout" }
+  ],
+  "unevaluatedProperties": false,
+  "$defs": {
+    "customInput": {
+      "type": "object",
+      "description": "Custom input widget. Binds to form data via `path`; `props` is open.",
+      "properties": {
+        "kind": { "const": "input" },
+        "type": { "type": "string" },
+        "path": { "$ref": "../common.schema.json#/$defs/dotPath" },
+        "label": { "$ref": "../common.schema.json#/$defs/localizable" },
+        "disabled": { "$ref": "../common.schema.json#/$defs/boolOrWhen" },
+        "readonly": { "$ref": "../common.schema.json#/$defs/boolOrWhen" },
+        "on": { "$ref": "../common.schema.json#/$defs/on" },
+        "validator": { "$ref": "../validators.schema.json#/$defs/validator" },
+        "defaultValue": true,
+        "props": { "type": "object" }
+      },
+      "required": ["kind", "type", "path"]
+    },
+    "customDisplay": {
+      "type": "object",
+      "description": "Custom display widget. No data binding; `props` is open.",
+      "properties": {
+        "kind": { "const": "display" },
+        "type": { "type": "string" },
+        "props": { "type": "object" }
+      },
+      "required": ["kind", "type"]
+    },
+    "customAction": {
+      "type": "object",
+      "description": "Custom action widget; `props` is open.",
+      "properties": {
+        "kind": { "const": "action" },
+        "type": { "type": "string" },
+        "label": { "$ref": "../common.schema.json#/$defs/localizable" },
+        "disabled": { "$ref": "../common.schema.json#/$defs/boolOrWhen" },
+        "on": { "$ref": "../common.schema.json#/$defs/on" },
+        "props": { "type": "object" }
+      },
+      "required": ["kind", "type"]
+    },
+    "customLayout": {
+      "type": "object",
+      "description": "Custom layout widget. Contains `children`; `props` is open.",
+      "properties": {
+        "kind": { "const": "layout" },
+        "type": { "type": "string" },
+        "children": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "../form.schema.json#/$defs/formWidget" }
+        },
+        "props": { "type": "object" }
+      },
+      "required": ["kind", "type", "children"]
+    }
+  }
+}

--- a/libs/gui/schemas/src/lib/components/custom.schema.json
+++ b/libs/gui/schemas/src/lib/components/custom.schema.json
@@ -39,6 +39,12 @@
         "defaultValue": true,
         "props": { "type": "object" }
       },
+      "patternProperties": {
+        "^label\\.[^.]+$": { "$ref": "../common.schema.json#/$defs/localizable" },
+        "^disabled\\.[^.]+$": { "$ref": "../common.schema.json#/$defs/boolOrWhen" },
+        "^readonly\\.[^.]+$": { "$ref": "../common.schema.json#/$defs/boolOrWhen" },
+        "^validator\\.[^.]+$": { "$ref": "../validators.schema.json#/$defs/validator" }
+      },
       "required": ["kind", "type", "path"]
     },
     "customDisplay": {
@@ -61,6 +67,10 @@
         "disabled": { "$ref": "../common.schema.json#/$defs/boolOrWhen" },
         "on": { "$ref": "../common.schema.json#/$defs/on" },
         "props": { "type": "object" }
+      },
+      "patternProperties": {
+        "^label\\.[^.]+$": { "$ref": "../common.schema.json#/$defs/localizable" },
+        "^disabled\\.[^.]+$": { "$ref": "../common.schema.json#/$defs/boolOrWhen" }
       },
       "required": ["kind", "type"]
     },

--- a/libs/gui/schemas/src/lib/components/custom.schema.spec.ts
+++ b/libs/gui/schemas/src/lib/components/custom.schema.spec.ts
@@ -84,11 +84,70 @@ describe('Custom widget schema validation', () => {
       expect(isValid).toBe(true);
     });
 
-    it('should accept arbitrary props keys and shapes (loose props)', () => {
+    it('should accept arbitrary props keys and shapes (loose props), including suffixed prop keys', () => {
       const widget = {
         kind: 'display',
         type: 'fancyChart',
-        props: { series: [1, 2, 3], options: { legend: true }, 'data-id': 'x' },
+        props: {
+          series: [1, 2, 3],
+          options: { legend: true },
+          'data-id': 'x',
+          'text.myState': 'Hi',
+        },
+      };
+
+      const isValid = validate(widget);
+      if (!isValid) {
+        specValidationErrorsLogger(validate, widget);
+      }
+      expect(isValid).toBe(true);
+    });
+  });
+
+  describe('State-suffixed root properties', () => {
+    it('should validate a custom input with suffixed label/disabled/readonly/validator', () => {
+      const widget = {
+        kind: 'input',
+        type: 'matTextInput',
+        path: 'user.email',
+        label: 'Email',
+        'label.myState': 'Email (active)',
+        'disabled.myState': { when: '$form.locked === true' },
+        'readonly.myState': true,
+        'validator.myState': { type: 'string', required: true },
+        props: {},
+      };
+
+      const isValid = validate(widget);
+      if (!isValid) {
+        specValidationErrorsLogger(validate, widget);
+      }
+      expect(isValid).toBe(true);
+    });
+
+    it('should validate a custom action with suffixed label/disabled', () => {
+      const widget = {
+        kind: 'action',
+        type: 'matButton',
+        label: 'Send',
+        'label.myState': 'Sending...',
+        'disabled.myState': true,
+        props: {},
+      };
+
+      const isValid = validate(widget);
+      if (!isValid) {
+        specValidationErrorsLogger(validate, widget);
+      }
+      expect(isValid).toBe(true);
+    });
+
+    it('should validate suffixed event handlers via the shared `on` definition', () => {
+      const widget = {
+        kind: 'action',
+        type: 'matButton',
+        on: { click: 'submitForm', 'click.myState': 'cancel' },
+        props: {},
       };
 
       const isValid = validate(widget);
@@ -103,6 +162,12 @@ describe('Custom widget schema validation', () => {
     it('should reject unknown root-level keys (strict root)', () => {
       // `level` belongs inside `props`, not at the root.
       const widget = { kind: 'display', type: 'heading', level: 1, props: { text: 'Hi' } };
+      expect(validate(widget)).toBe(false);
+    });
+
+    it('should reject a suffixed root key on a kind that does not support it', () => {
+      // `display` widgets have no root-level `disabled`, so `disabled.myState` is unevaluated.
+      const widget = { kind: 'display', type: 'heading', 'disabled.myState': true, props: {} };
       expect(validate(widget)).toBe(false);
     });
 

--- a/libs/gui/schemas/src/lib/components/custom.schema.spec.ts
+++ b/libs/gui/schemas/src/lib/components/custom.schema.spec.ts
@@ -1,0 +1,179 @@
+import Ajv2020 from 'ajv/dist/2020';
+import { beforeEach, describe, expect, it } from 'vitest';
+import commonSchema from '../common.schema.json';
+import {
+  type GetSchema,
+  registerGolemSchemas,
+  specValidationErrorsLogger,
+} from '../schema.spec.utils';
+
+const SCHEMA_ID_UNDER_TEST = 'https://golemui.com/schemas/components/custom.schema.json';
+const FORM_WIDGET_REF = 'https://golemui.com/schemas/form.schema.json#/$defs/formWidget';
+
+describe('Custom widget schema validation', () => {
+  let ajv: Ajv2020;
+  let validate: GetSchema;
+
+  beforeEach(() => {
+    ajv = new Ajv2020({
+      allErrors: true,
+      strict: false,
+      verbose: true,
+    });
+    registerGolemSchemas(ajv);
+    validate = ajv.getSchema(SCHEMA_ID_UNDER_TEST) as GetSchema;
+    if (!validate) {
+      throw new Error(`Schema ${SCHEMA_ID_UNDER_TEST} was not found in the registry.`);
+    }
+  });
+
+  describe('Valid configurations', () => {
+    it('should validate a custom input widget with an open props bag', () => {
+      const widget = {
+        kind: 'input',
+        type: 'matTextInput',
+        path: 'user.email',
+        label: 'Email',
+        props: { appearance: 'outline', anything: 123, nested: { ok: true } },
+      };
+
+      const isValid = validate(widget);
+      if (!isValid) {
+        specValidationErrorsLogger(validate, widget);
+      }
+      expect(isValid).toBe(true);
+    });
+
+    it('should validate a custom display widget', () => {
+      const widget = { kind: 'display', type: 'heading', props: { text: 'Hello', level: 1 } };
+
+      const isValid = validate(widget);
+      if (!isValid) {
+        specValidationErrorsLogger(validate, widget);
+      }
+      expect(isValid).toBe(true);
+    });
+
+    it('should validate a custom action widget', () => {
+      const widget = {
+        kind: 'action',
+        type: 'matButton',
+        label: 'Send',
+        props: { color: 'primary' },
+      };
+
+      const isValid = validate(widget);
+      if (!isValid) {
+        specValidationErrorsLogger(validate, widget);
+      }
+      expect(isValid).toBe(true);
+    });
+
+    it('should validate a custom layout widget with children', () => {
+      const widget = {
+        kind: 'layout',
+        type: 'card',
+        props: { elevation: 2 },
+        children: [{ kind: 'input', type: 'textinput', path: 'name', props: {} }],
+      };
+
+      const isValid = validate(widget);
+      if (!isValid) {
+        specValidationErrorsLogger(validate, widget);
+      }
+      expect(isValid).toBe(true);
+    });
+
+    it('should accept arbitrary props keys and shapes (loose props)', () => {
+      const widget = {
+        kind: 'display',
+        type: 'fancyChart',
+        props: { series: [1, 2, 3], options: { legend: true }, 'data-id': 'x' },
+      };
+
+      const isValid = validate(widget);
+      if (!isValid) {
+        specValidationErrorsLogger(validate, widget);
+      }
+      expect(isValid).toBe(true);
+    });
+  });
+
+  describe('Invalid configurations', () => {
+    it('should reject unknown root-level keys (strict root)', () => {
+      // `level` belongs inside `props`, not at the root.
+      const widget = { kind: 'display', type: 'heading', level: 1, props: { text: 'Hi' } };
+      expect(validate(widget)).toBe(false);
+    });
+
+    it('should reject a custom input without a path', () => {
+      const widget = { kind: 'input', type: 'matTextInput', props: {} };
+      expect(validate(widget)).toBe(false);
+    });
+
+    it('should reject a custom layout without children', () => {
+      const widget = { kind: 'layout', type: 'card', props: {} };
+      expect(validate(widget)).toBe(false);
+    });
+
+    it('should not match a built-in widget type', () => {
+      const widget = { kind: 'input', type: 'textinput', path: 'name', props: {} };
+      expect(validate(widget)).toBe(false);
+    });
+  });
+
+  describe('formWidget oneOf resolution', () => {
+    let validateFormWidget: GetSchema;
+
+    beforeEach(() => {
+      validateFormWidget = ajv.compile({ $ref: FORM_WIDGET_REF });
+    });
+
+    it('should resolve a built-in widget to its strict schema', () => {
+      const widget = { kind: 'input', type: 'textinput', path: 'name', props: {} };
+      const isValid = validateFormWidget(widget);
+      if (!isValid) {
+        specValidationErrorsLogger(validateFormWidget, widget);
+      }
+      expect(isValid).toBe(true);
+    });
+
+    it('should resolve an unknown widget type to the custom fallback', () => {
+      const widget = { kind: 'display', type: 'heading', props: { text: 'Hi' } };
+      const isValid = validateFormWidget(widget);
+      if (!isValid) {
+        specValidationErrorsLogger(validateFormWidget, widget);
+      }
+      expect(isValid).toBe(true);
+    });
+
+    it('should not mask a typo in a built-in widget (matches zero branches)', () => {
+      // `icon` must be a string on a built-in textinput. The custom branch excludes built-in
+      // types, so this matches no branch and errors instead of silently passing as custom.
+      const widget = { kind: 'input', type: 'textinput', path: 'name', props: { icon: 123 } };
+      expect(validateFormWidget(widget)).toBe(false);
+    });
+  });
+
+  describe('knownWidgetTypes enum stays in sync with built-in component schemas', () => {
+    it('should match every built-in component schema type const', () => {
+      // @ts-expect-error import.meta.glob is provided by Vite/Vitest at runtime
+      const componentSchemas: Record<string, any> = import.meta.glob('./*.schema.json', {
+        eager: true,
+        import: 'default',
+      });
+
+      const builtInTypes = new Set<string>();
+      for (const path in componentSchemas) {
+        const typeConst = componentSchemas[path]?.properties?.type?.const;
+        if (typeof typeConst === 'string') {
+          builtInTypes.add(typeConst);
+        }
+      }
+
+      const enumTypes = new Set<string>(commonSchema.$defs.knownWidgetTypes.enum as string[]);
+
+      expect([...enumTypes].sort()).toEqual([...builtInTypes].sort());
+    });
+  });
+});

--- a/libs/gui/schemas/src/lib/form.schema.json
+++ b/libs/gui/schemas/src/lib/form.schema.json
@@ -122,6 +122,9 @@
           "$ref": "./components/toggle.schema.json"
         },
         {
+          "$ref": "./components/custom.schema.json"
+        },
+        {
           "$ref": "#/$defs/chunkRef"
         }
       ]


### PR DESCRIPTION
## Summary

JSON form authoring only allowed the 27 built-in widget types, so any form using a registered custom component failed schema validation. This adds a `custom` fallback to the `formWidget` `oneOf` so custom widgets validate and get IntelliSense.
