### PR TITLE
fix(gui-components): Update textarea value on set programmatically

### DIFF
--- a/libs/gui/components/src/lib/components/textarea.ts
+++ b/libs/gui/components/src/lib/components/textarea.ts
@@ -126,6 +126,7 @@ export class GuiTextarea extends LitElement {
           ?readonly=${templateData.readonly}
           placeholder=${templateData.placeholder || nothing}
           autocomplete=${this.autocomplete || nothing}
+          .value=${this.value || ''}
           @input=${this.valueChanged}
           @blur=${this.onBlur}
         ></textarea>


### PR DESCRIPTION
When textarea is updating its value programmatically, the input is not updating its value. A `value` property binding was missing.