### PR TITLE
fix(gui-components): styling issues

### DIFF
--- a/libs/gui/components/src/lib/components/currency.ts
+++ b/libs/gui/components/src/lib/components/currency.ts
@@ -166,12 +166,18 @@ export class GuiCurrency extends LitElement {
     if (value === '' || value === undefined || value === null || isNaN(value as number)) return '';
 
     try {
+      // Resolve max first, then clamp min so it never exceeds max — otherwise
+      // e.g. `maximumFractionDigits: 0` with the default min of 2 would make
+      // Intl.NumberFormat throw "maximumFractionDigits value is out of range".
+      const maximumFractionDigits =
+        this.maximumFractionDigits ?? Math.max(this.minimumFractionDigits ?? 2, 2);
+      const minimumFractionDigits = Math.min(this.minimumFractionDigits ?? 2, maximumFractionDigits);
+
       return new Intl.NumberFormat(this.localeId ?? 'en', {
         style: 'currency',
         currency: this.currency ?? 'USD',
-        maximumFractionDigits:
-          this.maximumFractionDigits ?? Math.max(this.minimumFractionDigits ?? 2, 2),
-        minimumFractionDigits: this.minimumFractionDigits ?? 2,
+        maximumFractionDigits,
+        minimumFractionDigits,
       }).format(value as number);
     } catch (e) {
       console.warn('Invalid locale or currency', e);

--- a/libs/gui/components/src/lib/components/currency.ts
+++ b/libs/gui/components/src/lib/components/currency.ts
@@ -136,9 +136,10 @@ export class GuiCurrency extends LitElement {
       const target = event.target as HTMLInputElement;
       this.displayValue = this.formatCurrency(target.valueAsNumber);
 
+      const value = target.valueAsNumber;
       this.dispatchEvent(
         new CustomEvent('input', {
-          detail: { value: target.valueAsNumber },
+          detail: { value: Number.isNaN(value) ? undefined : value },
           bubbles: true,
           composed: true,
         }),

--- a/libs/gui/components/src/lib/components/markdown.ts
+++ b/libs/gui/components/src/lib/components/markdown.ts
@@ -389,6 +389,7 @@ export class GuiMarkdown extends LitElement {
   private toolbarBtnClass(format?: string) {
     return classMap({
       'gui-markdown__toolbar-button': true,
+      'gui-markdown__toolbar-button--disabled': this.disabled === true || this.readOnly === true,
       'gui-markdown__toolbar-button--active': !!format && !!this.activeFormats[format],
     });
   }

--- a/libs/gui/components/src/lib/components/number.ts
+++ b/libs/gui/components/src/lib/components/number.ts
@@ -195,9 +195,10 @@ export class GuiNumber extends LitElement {
 
     if (!this.readOnly) {
       const target = event.target as HTMLInputElement;
+      const value = target.valueAsNumber;
       this.dispatchEvent(
         new CustomEvent('input', {
-          detail: { value: target.valueAsNumber },
+          detail: { value: Number.isNaN(value) ? undefined : value },
           bubbles: true,
           composed: true,
         }),

--- a/libs/gui/components/src/styles/currency.scss
+++ b/libs/gui/components/src/styles/currency.scss
@@ -10,6 +10,7 @@ gui-currency {
       font-size: var(--gui-font-sm);
       top: 13px;
       inset-inline-start: 13px;
+      pointer-events: none;
 
       transition: all 0.2s ease-in-out;
 

--- a/libs/gui/components/src/styles/markdown.scss
+++ b/libs/gui/components/src/styles/markdown.scss
@@ -74,7 +74,6 @@ gui-markdown {
   }
 
   .gui-markdown__toolbar {
-    width: calc(100% - (var(--gui-space-2) * 2));
     display: flex;
     justify-content: space-between;
     padding: var(--gui-space-1) var(--gui-space-2) var(--gui-space-1);

--- a/libs/gui/components/src/styles/markdown.scss
+++ b/libs/gui/components/src/styles/markdown.scss
@@ -123,6 +123,10 @@ gui-markdown {
           fill: var(--gui-intent-primary-text);
         }
       }
+
+      &--disabled {
+        pointer-events: none;
+      }
     }
 
     ul {

--- a/libs/gui/components/src/styles/number.scss
+++ b/libs/gui/components/src/styles/number.scss
@@ -1,5 +1,6 @@
 gui-number {
   display: inline-block;
+  width: 100%;
 
   .gui-widget {
     display: inline-flex;

--- a/libs/gui/components/src/styles/number.scss
+++ b/libs/gui/components/src/styles/number.scss
@@ -56,6 +56,7 @@ gui-number {
       padding-bottom: 0;
       font-size: 20px;
       width: 100%;
+      box-sizing: content-box;
       max-width: 80px;
       height: var(--gui-widget-size);
       font-variant-numeric: tabular-nums;

--- a/libs/gui/components/src/styles/toggle.scss
+++ b/libs/gui/components/src/styles/toggle.scss
@@ -11,6 +11,7 @@ gui-toggle {
     margin-bottom: 0;
     width: auto;
     min-width: auto;
+    height: var(--gui-toggle-height);
 
     &__container {
       display: flex;
@@ -41,6 +42,8 @@ gui-toggle {
     min-width: var(--gui-toggle-width);
     min-height: var(--gui-toggle-height);
     align-self: start;
+    /* Correct top position in comparison with checkboxes that have 16px height instead of 20px */
+    margin-top: -2px;
 
     /* Hide default HTML checkbox */
     input {

--- a/libs/ui-testing/src/lib/golem-features/validators.cy.ts
+++ b/libs/ui-testing/src/lib/golem-features/validators.cy.ts
@@ -334,7 +334,7 @@ export const runValidatorsComponentTests = (mountFn: MountComponentFn) => {
         cy.get('[data-cy="requiredNumber_number"]').type('1{backspace}');
         cy.get('[data-cy="requiredNumber_validator-errors"]').should('exist');
         cy.get('[data-cy="requiredNumber_validator-error"]').contains(
-          'Invalid input: expected number, received NaN',
+          'Invalid input: expected number, received undefined',
         );
 
         cy.get('[data-cy="requiredNumber_number"]').type('1');


### PR DESCRIPTION
- Fix markdown toolbar width calculation
- Disable markdown toolbar with disabled/readonly state
- Grow number hint and validation errors
- Set fixed box-sizing to properly compute width with normalizers
- Number/currency widgets when emptied are emitting NaN instead of undefined, which triggers validation errors even with no validators defined
- Avoid selections in currency label
- Clamp min/max fraction digits to currency input
- Center vertically toggle switch position