### PR TITLE
fix: firefox issues with date inputs, numeric inputs and dropdown

### DIFF
--- a/.github/workflows/component-tests.yml
+++ b/.github/workflows/component-tests.yml
@@ -56,26 +56,32 @@ jobs:
           fi
 
   # ─────────────────────────────────────────────────────────────────────────────
-  # Job 2: Run component tests - one dedicated runner per affected project.
+  # Job 2: Run component tests - one dedicated runner per affected project
+  # and browser (Chrome + Firefox).
   #
   # Each runner is completely isolated, so there is no memory contention
   # between frameworks.  fail-fast: false ensures all shards complete and
   # report results even when one of them fails.
   # ─────────────────────────────────────────────────────────────────────────────
   component-test:
-    name: '${{ matrix.project }}'
+    name: '${{ matrix.project }} (${{ matrix.browser }})'
     needs: determine-matrix
     # Skip entirely when no projects are affected (avoids the empty-matrix error).
     if: needs.determine-matrix.outputs.has-projects == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.determine-matrix.outputs.matrix) }}
+      matrix:
+        project: ${{ fromJSON(needs.determine-matrix.outputs.matrix).project }}
+        browser: [chrome, firefox]
     env:
       # Disable the Nx daemon so each runner starts with a clean slate.
       NX_DAEMON: false
-      # Cap Node's heap at 4 GB, leaving headroom for Chrome and the dev server.
+      # Cap Node's heap at 4 GB, leaving headroom for the browser and the dev server.
       NODE_OPTIONS: '--max-old-space-size=4096'
+      # Run in a timezone behind UTC so date widgets are exercised against
+      # timezone shifts (UTC would hide day-off-by-one regressions).
+      TZ: 'America/New_York'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -91,4 +97,4 @@ jobs:
         run: npm ci
 
       - name: Run component tests
-        run: npx nx run ${{ matrix.project }}:component-test --browser chrome
+        run: npx nx run ${{ matrix.project }}:component-test --browser ${{ matrix.browser }}

--- a/libs/gui/angular/cypress/test/golem-features/currency.cy.ts
+++ b/libs/gui/angular/cypress/test/golem-features/currency.cy.ts
@@ -1,0 +1,4 @@
+import { runCurrencyComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runCurrencyComponentTests(mountFramework);

--- a/libs/gui/angular/cypress/test/golem-features/datepicker.cy.ts
+++ b/libs/gui/angular/cypress/test/golem-features/datepicker.cy.ts
@@ -1,0 +1,4 @@
+import { runDatePickerComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runDatePickerComponentTests(mountFramework);

--- a/libs/gui/angular/cypress/test/golem-features/dropdown.cy.ts
+++ b/libs/gui/angular/cypress/test/golem-features/dropdown.cy.ts
@@ -1,0 +1,4 @@
+import { runDropdownComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runDropdownComponentTests(mountFramework);

--- a/libs/gui/angular/cypress/test/golem-features/number.cy.ts
+++ b/libs/gui/angular/cypress/test/golem-features/number.cy.ts
@@ -1,0 +1,4 @@
+import { runNumberComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runNumberComponentTests(mountFramework);

--- a/libs/gui/angular/src/lib/components/date-picker/date-picker.component.ts
+++ b/libs/gui/angular/src/lib/components/date-picker/date-picker.component.ts
@@ -92,6 +92,10 @@ export class DatePickerComponent implements OnInit, OnDestroy, WithWidget {
 
   toggleCalendar(event: Event) {
     const target = event.target as HTMLElement;
+    // Day selections are committed by the calendar change event, which closes
+    // the calendar; the toggle must not reopen it from the same click
+    if (target.closest('.gui-calendar__day-button')) return;
+
     const isInputClick = target.closest('.gui-date-input__part');
     const isCalendarClick = target.closest('gui-calendar');
     if (isInputClick || isCalendarClick) {

--- a/libs/gui/angular/src/lib/components/date-picker/date-picker.component.ts
+++ b/libs/gui/angular/src/lib/components/date-picker/date-picker.component.ts
@@ -92,8 +92,7 @@ export class DatePickerComponent implements OnInit, OnDestroy, WithWidget {
 
   toggleCalendar(event: Event) {
     const target = event.target as HTMLElement;
-    // Day selections are committed by the calendar change event, which closes
-    // the calendar; the toggle must not reopen it from the same click
+
     if (target.closest('.gui-calendar__day-button')) return;
 
     const isInputClick = target.closest('.gui-date-input__part');

--- a/libs/gui/angular/src/lib/components/dropdown/dropdown.component.html
+++ b/libs/gui/angular/src/lib/components/dropdown/dropdown.component.html
@@ -19,6 +19,7 @@
     type="text"
     class="gui-widget-input"
     [id]="widget.uid"
+    [attr.data-cy]="widget.uid + '_textinput'"
     [required]="templateData.validator?.required"
     [disabled]="templateData.disabled"
     [readonly]="templateData.readonly"

--- a/libs/gui/angular/src/lib/components/dropdown/dropdown.component.ts
+++ b/libs/gui/angular/src/lib/components/dropdown/dropdown.component.ts
@@ -169,16 +169,13 @@ export class DropdownComponent implements OnInit, OnDestroy, WithWidget {
       const hasSearchFields = searchFields.length > 0;
       const items = templateData.items || [];
       const filtered = items.filter((item: any) => {
-        // If it's a primitive value, we search by value. Note: Object.keys on a
-        // string returns its character indices, so check the type instead
         const isPrimitiveValue = item === null || typeof item !== 'object';
+
         if (isPrimitiveValue) {
           return item != null && item.toString().toLowerCase().includes(filterValue.toLowerCase());
         }
 
         const keys = Object.keys(item);
-
-        // Otherwise, we search by object
         const reduceFunc = (acc: boolean, prop: string) =>
           acc || item[prop].toString().toLowerCase().includes(filterValue.toLowerCase());
 

--- a/libs/gui/angular/src/lib/components/dropdown/dropdown.component.ts
+++ b/libs/gui/angular/src/lib/components/dropdown/dropdown.component.ts
@@ -169,13 +169,14 @@ export class DropdownComponent implements OnInit, OnDestroy, WithWidget {
       const hasSearchFields = searchFields.length > 0;
       const items = templateData.items || [];
       const filtered = items.filter((item: any) => {
-        const keys = Object.keys(item);
-
-        // If it's a primitive value, we search by value
-        const isPrimitiveValue = !keys.length;
+        // If it's a primitive value, we search by value. Note: Object.keys on a
+        // string returns its character indices, so check the type instead
+        const isPrimitiveValue = item === null || typeof item !== 'object';
         if (isPrimitiveValue) {
-          return item.toString().toLowerCase().includes(filterValue.toLowerCase());
+          return item != null && item.toString().toLowerCase().includes(filterValue.toLowerCase());
         }
+
+        const keys = Object.keys(item);
 
         // Otherwise, we search by object
         const reduceFunc = (acc: boolean, prop: string) =>

--- a/libs/gui/components/src/lib/components/abstract-calendar.ts
+++ b/libs/gui/components/src/lib/components/abstract-calendar.ts
@@ -2,7 +2,13 @@ import { html, LitElement, nothing, type TemplateResult } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { GUIAriaController } from '../controllers/aria.controller';
 import { repeat } from 'lit-html/directives/repeat.js';
-import { getMonthYearParts, getWeekdayLabels, toISODateString, weekDaysOrder } from '../utils/date';
+import {
+  getMonthYearParts,
+  getWeekdayLabels,
+  parseISODateString,
+  toISODateString,
+  weekDaysOrder,
+} from '../utils/date';
 import { addErrors, addLabel } from '../utils/templates';
 import type { DateRange } from '@golemui/gui-shared/internals';
 
@@ -389,11 +395,11 @@ export abstract class AbstractCalendar extends LitElement {
   }
 
   protected get _effectiveMinYear(): number {
-    return this.minDate ? new Date(this.minDate).getFullYear() : 1900;
+    return this.minDate ? parseISODateString(this.minDate).getFullYear() : 1900;
   }
 
   protected get _effectiveMaxYear(): number {
-    return this.maxDate ? new Date(this.maxDate).getFullYear() : 2099;
+    return this.maxDate ? parseISODateString(this.maxDate).getFullYear() : 2099;
   }
 
   protected get _yearList(): number[] {

--- a/libs/gui/components/src/lib/components/calendar.ts
+++ b/libs/gui/components/src/lib/components/calendar.ts
@@ -6,6 +6,7 @@ import {
   isDateInVisibleMonths,
   isSameDay,
   isToday,
+  parseISODateString,
   toISODateString,
 } from '../utils/date';
 import { AbstractCalendar } from './abstract-calendar';
@@ -36,7 +37,7 @@ export class GuiCalendar extends AbstractCalendar {
   override willUpdate(changedProperties: PropertyValues): void {
     if (changedProperties.has('value')) {
       if (this.value) {
-        const date = new Date(this.value);
+        const date = parseISODateString(this.value);
         if (
           !isNaN(date.getTime()) &&
           !isDateInVisibleMonths(date, this._currentDate, this.numberOfMonths ?? 1)
@@ -63,7 +64,7 @@ export class GuiCalendar extends AbstractCalendar {
         class=${classMap(classes)}
         tabindex=${day.isFocusable ? 0 : -1}
         ?disabled=${!day.isCurrentMonth || day.isDisabled}
-        data-date=${day.date.toISOString()}
+        data-date=${toISODateString(day.date)}
         @click=${() => this.selectDate(day)}
         @keydown=${(e: KeyboardEvent) => this.handleKeydown(e, day)}
         aria-selected=${day.isSelected}
@@ -85,7 +86,7 @@ export class GuiCalendar extends AbstractCalendar {
     let days = rawDates.map((date) => {
       const isCurrentMonth = date.getMonth() === targetMonth;
       const isDisabled = this.isDisabled(date);
-      const isSelected = !!this.value && isSameDay(date, new Date(this.value));
+      const isSelected = !!this.value && isSameDay(date, parseISODateString(this.value));
       const isTodayDate = isToday(date);
       const isFocusable = (isSelected || isTodayDate) && isCurrentMonth;
 
@@ -109,7 +110,7 @@ export class GuiCalendar extends AbstractCalendar {
     }
 
     if (offset === 0 && !days.some((d) => d.isFocusable)) {
-      const referenceDate = this.value ? new Date(this.value) : new Date();
+      const referenceDate = this.value ? parseISODateString(this.value) : new Date();
       if (!isDateInVisibleMonths(referenceDate, this._currentDate, this.numberOfMonths ?? 1)) {
         const firstDay = days.find((d) => d.isCurrentMonth && !d.isDisabled);
         if (firstDay) firstDay.isFocusable = true;

--- a/libs/gui/components/src/lib/components/currency.ts
+++ b/libs/gui/components/src/lib/components/currency.ts
@@ -4,6 +4,7 @@ import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { GUIAriaController } from '../controllers/aria.controller';
 import { addErrors, addIcon, addLabel, type ControlTemplateData } from '../utils/templates';
+import { blockNonNumericInput, blockNonNumericKeys } from '../utils/numeric';
 
 @customElement('gui-currency')
 export class GuiCurrency extends LitElement {
@@ -110,6 +111,8 @@ export class GuiCurrency extends LitElement {
           placeholder=${this.placeholder || nothing}
           autocomplete=${this.autocomplete || nothing}
           @input=${this.handleInput}
+          @beforeinput=${blockNonNumericInput}
+          @keydown=${blockNonNumericKeys}
           @focus=${this.handleFocus}
           @blur=${this.handleBlur}
         />

--- a/libs/gui/components/src/lib/components/date-input.ts
+++ b/libs/gui/components/src/lib/components/date-input.ts
@@ -5,7 +5,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { live } from 'lit/directives/live.js';
 import { GUIAriaController } from '../controllers/aria.controller';
-import { toISODateString } from '../utils/date';
+import { parseISODateString, toISODateString } from '../utils/date';
 import { addErrors, addLabel, type ControlTemplateData } from '../utils/templates';
 
 @customElement('gui-date')
@@ -178,7 +178,7 @@ export class GuiDate extends LitElement {
       this._year = '';
       return;
     }
-    const date = new Date(isoValue);
+    const date = parseISODateString(isoValue);
     if (!isNaN(date.getTime())) {
       this._day = date.getDate().toString().padStart(2, '0');
       this._month = (date.getMonth() + 1).toString().padStart(2, '0');

--- a/libs/gui/components/src/lib/components/number.ts
+++ b/libs/gui/components/src/lib/components/number.ts
@@ -2,6 +2,7 @@ import { html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { GUIAriaController } from '../controllers/aria.controller';
 import { addErrors, addLabel, type ControlTemplateData } from '../utils/templates';
+import { blockNonNumericInput, blockNonNumericKeys } from '../utils/numeric';
 import type { NumberinputProps } from '@golemui/gui-shared/internals';
 import { styleMap } from 'lit-html/directives/style-map.js';
 
@@ -104,6 +105,7 @@ export class GuiNumber extends LitElement {
           placeholder=${this.placeholder || nothing}
           autocomplete=${this.autocomplete || nothing}
           @input=${this.valueChanged}
+          @beforeinput=${blockNonNumericInput}
           @keydown=${this.keyDown}
           @blur=${this.onBlur}
         />
@@ -127,6 +129,7 @@ export class GuiNumber extends LitElement {
 
   keyDown(event: KeyboardEvent) {
     event.stopPropagation();
+    blockNonNumericKeys(event);
 
     switch (event.key) {
       case 'ArrowUp':

--- a/libs/gui/components/src/lib/components/range-calendar.ts
+++ b/libs/gui/components/src/lib/components/range-calendar.ts
@@ -8,6 +8,8 @@ import {
   isSameDay,
   isToday,
   mergeDateRanges,
+  parseISODateString,
+  toISODateString,
 } from '../utils/date';
 import { AbstractCalendar, type AbstractCalendarDay } from './abstract-calendar';
 import './pills';
@@ -56,7 +58,7 @@ export class GuiRangeCalendar extends AbstractCalendar {
           : [{ start: this.value as unknown as string }];
 
         if (value.length > 0 && value[0].start) {
-          const date = new Date(value[0].start);
+          const date = parseISODateString(value[0].start);
           if (
             !isNaN(date.getTime()) &&
             !isDateInVisibleMonths(date, this._currentDate, this.numberOfMonths ?? 1)
@@ -68,7 +70,7 @@ export class GuiRangeCalendar extends AbstractCalendar {
     }
     if (changedProperties.has('focusDate')) {
       if (this.focusDate) {
-        const date = new Date(this.focusDate);
+        const date = parseISODateString(this.focusDate);
         if (!isNaN(date.getTime())) {
           if (!isDateInVisibleMonths(date, this._currentDate, this.numberOfMonths ?? 1)) {
             this._currentDate = date;
@@ -101,7 +103,7 @@ export class GuiRangeCalendar extends AbstractCalendar {
         class=${classMap(classes)}
         tabindex=${day.isFocusable ? 0 : -1}
         ?disabled=${!day.isCurrentMonth || day.isDisabled}
-        data-date=${day.date.toISOString()}
+        data-date=${toISODateString(day.date)}
         @click=${(e: MouseEvent) => this.selectDate(day, e)}
         @mouseover=${() => this.onMouseOver(day)}
         @focus=${() => this.onMouseOver(day)}
@@ -159,7 +161,7 @@ export class GuiRangeCalendar extends AbstractCalendar {
       const todayVisible = isDateInVisibleMonths(new Date(), this._currentDate, months);
       const rangeStartVisible =
         this.value?.some((range) =>
-          isDateInVisibleMonths(new Date(range.start), this._currentDate, months),
+          isDateInVisibleMonths(parseISODateString(range.start), this._currentDate, months),
         ) ?? false;
 
       if (!todayVisible && !rangeStartVisible) {
@@ -189,7 +191,7 @@ export class GuiRangeCalendar extends AbstractCalendar {
 
     if (this.value && Array.isArray(this.value)) {
       for (const range of this.value) {
-        const start = new Date(range.start);
+        const start = parseISODateString(range.start);
 
         if (isSameDay(date, start)) {
           isRangeStart = true;
@@ -197,7 +199,7 @@ export class GuiRangeCalendar extends AbstractCalendar {
         }
 
         if (range.end) {
-          const end = new Date(range.end);
+          const end = parseISODateString(range.end);
 
           if (isSameDay(date, end)) {
             isRangeEnd = true;
@@ -375,7 +377,7 @@ export class GuiRangeCalendar extends AbstractCalendar {
   };
 
   private formatDateForDisplay(isoDate: string): string {
-    const date = new Date(isoDate);
+    const date = parseISODateString(isoDate);
     if (isNaN(date.getTime())) return isoDate;
     return new Intl.DateTimeFormat(this.localeId ?? 'en', {
       year: 'numeric',
@@ -387,12 +389,12 @@ export class GuiRangeCalendar extends AbstractCalendar {
   private getSortedPills(): DateRange[] {
     if (!this.value || !Array.isArray(this.value)) return [];
     return [...this.value].sort(
-      (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
+      (a, b) => parseISODateString(a.start).getTime() - parseISODateString(b.start).getTime(),
     );
   }
 
   private navigateToDate(isoDate: string) {
-    const date = new Date(isoDate);
+    const date = parseISODateString(isoDate);
     if (
       !isNaN(date.getTime()) &&
       !isDateInVisibleMonths(date, this._currentDate, this.numberOfMonths ?? 1)

--- a/libs/gui/components/src/lib/components/range-date-input.ts
+++ b/libs/gui/components/src/lib/components/range-date-input.ts
@@ -5,7 +5,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { live } from 'lit/directives/live.js';
 import { GUIAriaController } from '../controllers/aria.controller';
-import { mergeDateRanges, toISODateString } from '../utils/date';
+import { mergeDateRanges, parseISODateString, toISODateString } from '../utils/date';
 import { addErrors, addLabel, type ControlTemplateData } from '../utils/templates';
 import './pills';
 import type { GuiPillEventDetail, GuiPillItem } from './pills';
@@ -271,7 +271,7 @@ export class GuiRangeDateInput extends LitElement {
   }
 
   private formatDateForDisplay(isoDate: string): string {
-    const date = new Date(isoDate);
+    const date = parseISODateString(isoDate);
     if (isNaN(date.getTime())) return isoDate;
     return new Intl.DateTimeFormat(this.localeId ?? 'en', {
       year: 'numeric',
@@ -283,7 +283,7 @@ export class GuiRangeDateInput extends LitElement {
   private getSortedPills(): DateRange[] {
     if (!this.value || !Array.isArray(this.value)) return [];
     return [...this.value].sort(
-      (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
+      (a, b) => parseISODateString(a.start).getTime() - parseISODateString(b.start).getTime(),
     );
   }
 

--- a/libs/gui/components/src/lib/utils/date.ts
+++ b/libs/gui/components/src/lib/utils/date.ts
@@ -16,6 +16,25 @@ export function toISODateString(date: Date): string {
 }
 
 /**
+ * Parses an ISO 8601 date string (YYYY-MM-DD) into a Date at local midnight.
+ *
+ * `new Date('YYYY-MM-DD')` interprets date-only strings as UTC midnight, so in
+ * timezones behind UTC the resulting Date falls on the previous local day.
+ * Calendar values are timezone-less calendar days, so they must be parsed in
+ * local time. Strings that are not date-only fall back to native parsing.
+ *
+ * @param {string} value - The ISO date string to parse.
+ * @return {Date} The parsed Date anchored to the local timezone.
+ */
+export function parseISODateString(value: string): Date {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (match) {
+    return new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+  }
+  return new Date(value);
+}
+
+/**
  * Determines whether the given date is today's date.
  *
  * @param {Date} date - The date to be checked.
@@ -184,8 +203,8 @@ export function mergeDateRanges(ranges: DateRange[]): DateRange[] {
   // Sort dates by "start"
   const sorted = ranges
     .map((r) => ({
-      start: new Date(r.start).getTime(),
-      end: new Date(r.end ?? r.start).getTime(),
+      start: parseISODateString(r.start).getTime(),
+      end: parseISODateString(r.end ?? r.start).getTime(),
     }))
     .sort((a, b) => a.start - b.start);
 

--- a/libs/gui/components/src/lib/utils/numeric.ts
+++ b/libs/gui/components/src/lib/utils/numeric.ts
@@ -1,0 +1,45 @@
+/**
+ * Characters accepted by an `<input type="number">`: digits, decimal separators
+ * ('.' and the locale-dependent ','), exponent markers and signs.
+ */
+const VALID_NUMBER_INPUT_CHARS = /^[0-9.,eE+-]+$/;
+
+/**
+ * Prevents text that is not valid inside an `<input type="number">` from being
+ * inserted. Chrome filters these characters natively but Firefox does not, so
+ * without this guard letters can be typed (or pasted) into number inputs.
+ *
+ * Intended to be attached as a `beforeinput` listener.
+ *
+ * @param {InputEvent} event - The `beforeinput` event fired on the input.
+ */
+export function blockNonNumericInput(event: InputEvent): void {
+  const data = event.data ?? event.dataTransfer?.getData('text');
+
+  // Deletions and other non-inserting input types carry no data
+  if (!data) return;
+
+  if (!VALID_NUMBER_INPUT_CHARS.test(data)) {
+    event.preventDefault();
+  }
+}
+
+/**
+ * Prevents keystrokes that would insert characters not accepted by an
+ * `<input type="number">`. Complements {@link blockNonNumericInput} in
+ * browsers or automation tools where `beforeinput` is not dispatched.
+ *
+ * Intended to be attached as a `keydown` listener.
+ *
+ * @param {KeyboardEvent} event - The `keydown` event fired on the input.
+ */
+export function blockNonNumericKeys(event: KeyboardEvent): void {
+  if (event.ctrlKey || event.metaKey || event.altKey || event.isComposing) return;
+
+  // Multi-character keys (Backspace, Tab, ArrowLeft...) never insert text
+  if (event.key.length !== 1) return;
+
+  if (!VALID_NUMBER_INPUT_CHARS.test(event.key)) {
+    event.preventDefault();
+  }
+}

--- a/libs/gui/lit/cypress/test/golem-features/currency.cy.ts
+++ b/libs/gui/lit/cypress/test/golem-features/currency.cy.ts
@@ -1,0 +1,4 @@
+import { runCurrencyComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runCurrencyComponentTests(mountFramework);

--- a/libs/gui/lit/cypress/test/golem-features/datepicker.cy.ts
+++ b/libs/gui/lit/cypress/test/golem-features/datepicker.cy.ts
@@ -1,0 +1,4 @@
+import { runDatePickerComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runDatePickerComponentTests(mountFramework);

--- a/libs/gui/lit/cypress/test/golem-features/dropdown.cy.ts
+++ b/libs/gui/lit/cypress/test/golem-features/dropdown.cy.ts
@@ -1,0 +1,4 @@
+import { runDropdownComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runDropdownComponentTests(mountFramework);

--- a/libs/gui/lit/cypress/test/golem-features/number.cy.ts
+++ b/libs/gui/lit/cypress/test/golem-features/number.cy.ts
@@ -1,0 +1,4 @@
+import { runNumberComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runNumberComponentTests(mountFramework);

--- a/libs/gui/lit/src/lib/components/date-picker.element.ts
+++ b/libs/gui/lit/src/lib/components/date-picker.element.ts
@@ -193,8 +193,7 @@ export class DatePickerElement extends LitElement implements WithWidget {
 
   toggleCalendar(event: Event) {
     const target = event.target as HTMLElement;
-    // Day selections are committed by the calendar change event, which closes
-    // the calendar; the toggle must not reopen it from the same click
+
     if (target.closest('.gui-calendar__day-button')) return;
 
     const isInputClick = target.closest('.gui-date-input__part');

--- a/libs/gui/lit/src/lib/components/date-picker.element.ts
+++ b/libs/gui/lit/src/lib/components/date-picker.element.ts
@@ -193,6 +193,10 @@ export class DatePickerElement extends LitElement implements WithWidget {
 
   toggleCalendar(event: Event) {
     const target = event.target as HTMLElement;
+    // Day selections are committed by the calendar change event, which closes
+    // the calendar; the toggle must not reopen it from the same click
+    if (target.closest('.gui-calendar__day-button')) return;
+
     const isInputClick = target.closest('.gui-date-input__part');
     const isCalendarClick = target.closest('gui-calendar');
     if (isInputClick || isCalendarClick) {

--- a/libs/gui/lit/src/lib/components/dropdown.element.ts
+++ b/libs/gui/lit/src/lib/components/dropdown.element.ts
@@ -192,13 +192,14 @@ export class DropdownElement extends LitElement implements WithWidget {
       const hasSearchFields = searchFields.length > 0;
       const items = templateData.items || [];
       const filteredItems = items.filter((item: any) => {
-        const keys = Object.keys(item);
-
-        // If it's a primitive value, we search by value
-        const isPrimitiveValue = !keys.length;
+        // If it's a primitive value, we search by value. Note: Object.keys on a
+        // string returns its character indices, so check the type instead
+        const isPrimitiveValue = item === null || typeof item !== 'object';
         if (isPrimitiveValue) {
-          return item.toString().toLowerCase().includes(filterValue.toLowerCase());
+          return item != null && item.toString().toLowerCase().includes(filterValue.toLowerCase());
         }
+
+        const keys = Object.keys(item);
 
         // Otherwise, we search by object
         const reduceFunc = (acc: boolean, prop: string) =>

--- a/libs/gui/lit/src/lib/components/dropdown.element.ts
+++ b/libs/gui/lit/src/lib/components/dropdown.element.ts
@@ -192,16 +192,13 @@ export class DropdownElement extends LitElement implements WithWidget {
       const hasSearchFields = searchFields.length > 0;
       const items = templateData.items || [];
       const filteredItems = items.filter((item: any) => {
-        // If it's a primitive value, we search by value. Note: Object.keys on a
-        // string returns its character indices, so check the type instead
         const isPrimitiveValue = item === null || typeof item !== 'object';
+
         if (isPrimitiveValue) {
           return item != null && item.toString().toLowerCase().includes(filterValue.toLowerCase());
         }
 
         const keys = Object.keys(item);
-
-        // Otherwise, we search by object
         const reduceFunc = (acc: boolean, prop: string) =>
           acc || item[prop].toString().toLowerCase().includes(filterValue.toLowerCase());
 

--- a/libs/gui/react/cypress/test/golem-features/currency.cy.ts
+++ b/libs/gui/react/cypress/test/golem-features/currency.cy.ts
@@ -1,0 +1,4 @@
+import { runCurrencyComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runCurrencyComponentTests(mountFramework);

--- a/libs/gui/react/cypress/test/golem-features/datepicker.cy.ts
+++ b/libs/gui/react/cypress/test/golem-features/datepicker.cy.ts
@@ -1,0 +1,4 @@
+import { runDatePickerComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runDatePickerComponentTests(mountFramework);

--- a/libs/gui/react/cypress/test/golem-features/dropdown.cy.ts
+++ b/libs/gui/react/cypress/test/golem-features/dropdown.cy.ts
@@ -1,0 +1,4 @@
+import { runDropdownComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runDropdownComponentTests(mountFramework);

--- a/libs/gui/react/cypress/test/golem-features/number.cy.ts
+++ b/libs/gui/react/cypress/test/golem-features/number.cy.ts
@@ -1,0 +1,4 @@
+import { runNumberComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runNumberComponentTests(mountFramework);

--- a/libs/gui/react/src/lib/components/DatePicker.tsx
+++ b/libs/gui/react/src/lib/components/DatePicker.tsx
@@ -120,8 +120,7 @@ export function DatePicker(widgetInstance: WithWidget) {
 
   const toggleCalendar = (event: React.MouseEvent) => {
     const target = event.target as HTMLElement;
-    // Day selections are committed by the calendar change event, which closes
-    // the calendar; the toggle must not reopen it from the same click
+
     if (target.closest('.gui-calendar__day-button')) return;
 
     const isInputClick = target.closest('.gui-date-input__part');

--- a/libs/gui/react/src/lib/components/DatePicker.tsx
+++ b/libs/gui/react/src/lib/components/DatePicker.tsx
@@ -120,6 +120,10 @@ export function DatePicker(widgetInstance: WithWidget) {
 
   const toggleCalendar = (event: React.MouseEvent) => {
     const target = event.target as HTMLElement;
+    // Day selections are committed by the calendar change event, which closes
+    // the calendar; the toggle must not reopen it from the same click
+    if (target.closest('.gui-calendar__day-button')) return;
+
     const isInputClick = target.closest('.gui-date-input__part');
     const isCalendarClick = target.closest('gui-calendar');
     if (isInputClick || isCalendarClick) {

--- a/libs/gui/react/src/lib/components/Dropdown.tsx
+++ b/libs/gui/react/src/lib/components/Dropdown.tsx
@@ -199,16 +199,13 @@ export function Dropdown(widgetInstance: WithWidget) {
         const hasSearchFields = searchFields.length > 0;
         const items = templateData.items || [];
         const filteredItems = items.filter((item: any) => {
-          // If it's a primitive value, we search by value. Note: Object.keys on a
-          // string returns its character indices, so check the type instead
           const isPrimitiveValue = item === null || typeof item !== 'object';
+
           if (isPrimitiveValue) {
             return item != null && item.toString().toLowerCase().includes(filterValue.toLowerCase());
           }
 
           const keys = Object.keys(item);
-
-          // Otherwise, we search by object
           const reduceFunc = (acc: boolean, prop: string) =>
             acc || item[prop].toString().toLowerCase().includes(filterValue.toLowerCase());
 

--- a/libs/gui/react/src/lib/components/Dropdown.tsx
+++ b/libs/gui/react/src/lib/components/Dropdown.tsx
@@ -199,13 +199,14 @@ export function Dropdown(widgetInstance: WithWidget) {
         const hasSearchFields = searchFields.length > 0;
         const items = templateData.items || [];
         const filteredItems = items.filter((item: any) => {
-          const keys = Object.keys(item);
-
-          // If it's a primitive value, we search by value
-          const isPrimitiveValue = !keys.length;
+          // If it's a primitive value, we search by value. Note: Object.keys on a
+          // string returns its character indices, so check the type instead
+          const isPrimitiveValue = item === null || typeof item !== 'object';
           if (isPrimitiveValue) {
-            return item.toString().toLowerCase().includes(filterValue.toLowerCase());
+            return item != null && item.toString().toLowerCase().includes(filterValue.toLowerCase());
           }
+
+          const keys = Object.keys(item);
 
           // Otherwise, we search by object
           const reduceFunc = (acc: boolean, prop: string) =>

--- a/libs/gui/vue/cypress/test/golem-features/currency.cy.ts
+++ b/libs/gui/vue/cypress/test/golem-features/currency.cy.ts
@@ -1,0 +1,4 @@
+import { runCurrencyComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runCurrencyComponentTests(mountFramework);

--- a/libs/gui/vue/cypress/test/golem-features/datepicker.cy.ts
+++ b/libs/gui/vue/cypress/test/golem-features/datepicker.cy.ts
@@ -1,0 +1,4 @@
+import { runDatePickerComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runDatePickerComponentTests(mountFramework);

--- a/libs/gui/vue/cypress/test/golem-features/dropdown.cy.ts
+++ b/libs/gui/vue/cypress/test/golem-features/dropdown.cy.ts
@@ -1,0 +1,4 @@
+import { runDropdownComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runDropdownComponentTests(mountFramework);

--- a/libs/gui/vue/cypress/test/golem-features/number.cy.ts
+++ b/libs/gui/vue/cypress/test/golem-features/number.cy.ts
@@ -1,0 +1,4 @@
+import { runNumberComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runNumberComponentTests(mountFramework);

--- a/libs/gui/vue/src/lib/components/DatePicker.vue
+++ b/libs/gui/vue/src/lib/components/DatePicker.vue
@@ -115,6 +115,10 @@ const onFocusOut = (event: FocusEvent) => {
 
 const toggleCalendar = (event: MouseEvent) => {
   const target = event.target as HTMLElement;
+  // Day selections are committed by the calendar change event, which closes
+  // the calendar; the toggle must not reopen it from the same click
+  if (target.closest('.gui-calendar__day-button')) return;
+
   const isInputClick = target.closest('.gui-date-input__part');
   const isCalendarClick = target.closest('gui-calendar');
   if (isInputClick || isCalendarClick) {

--- a/libs/gui/vue/src/lib/components/DatePicker.vue
+++ b/libs/gui/vue/src/lib/components/DatePicker.vue
@@ -23,8 +23,7 @@ const {
 const required = computed(() => (templateData.value.validator as Validator)?.required);
 const showErrors = computed(() => isTouched.value && errors.value && errors.value.length > 0);
 
-// Default to the same values as the Lit element's class-field initializers so
-// we never pass undefined or '' (which Intl.DateTimeFormat rejects with a RangeError).
+// Default to the same values as the Lit element's class-field initializers
 const dayFormat = computed(() => templateData.value.dayFormat || 'numeric');
 const weekdayFormat = computed(() => templateData.value.weekdayFormat || 'narrow');
 const monthFormat = computed(() => templateData.value.monthFormat || 'long');
@@ -115,8 +114,7 @@ const onFocusOut = (event: FocusEvent) => {
 
 const toggleCalendar = (event: MouseEvent) => {
   const target = event.target as HTMLElement;
-  // Day selections are committed by the calendar change event, which closes
-  // the calendar; the toggle must not reopen it from the same click
+
   if (target.closest('.gui-calendar__day-button')) return;
 
   const isInputClick = target.closest('.gui-date-input__part');

--- a/libs/gui/vue/src/lib/components/Dropdown.vue
+++ b/libs/gui/vue/src/lib/components/Dropdown.vue
@@ -196,11 +196,12 @@ const filterItems = (filterValue: string) => {
     const hasSearchFields = searchFields.length > 0;
     const items = templateData.value.items || [];
     const filtered = items.filter((item: any) => {
-      const keys = Object.keys(item);
-      const isPrimitive = !keys.length;
+      // Object.keys on a string returns its character indices, so check the type instead
+      const isPrimitive = item === null || typeof item !== 'object';
       if (isPrimitive) {
-        return item.toString().toLowerCase().includes(filterValue.toLowerCase());
+        return item != null && item.toString().toLowerCase().includes(filterValue.toLowerCase());
       }
+      const keys = Object.keys(item);
       const reduceFn = (acc: boolean, prop: string) =>
         acc || item[prop].toString().toLowerCase().includes(filterValue.toLowerCase());
       return hasSearchFields

--- a/libs/gui/vue/src/lib/components/Dropdown.vue
+++ b/libs/gui/vue/src/lib/components/Dropdown.vue
@@ -138,11 +138,6 @@ onMounted(() => {
   if (labelRef.value && inputRef.value && listRef.value) {
     labelRef.value.targetElement = [inputRef.value, listRef.value];
   }
-  // Seed the input's initial display value once at mount — mirrors React's
-  // `defaultValue={value ?? ''}` behavior. After this, the input is uncontrolled
-  // and all updates go through imperative inputRef.value.value assignments
-  // (in handleValueChange and the selectedItem watcher) so labelField-based
-  // display labels aren't clobbered by Vue re-applying a reactive :value binding.
   if (inputRef.value) {
     inputRef.value.value = String(value.value ?? '');
   }
@@ -196,14 +191,16 @@ const filterItems = (filterValue: string) => {
     const hasSearchFields = searchFields.length > 0;
     const items = templateData.value.items || [];
     const filtered = items.filter((item: any) => {
-      // Object.keys on a string returns its character indices, so check the type instead
       const isPrimitive = item === null || typeof item !== 'object';
+
       if (isPrimitive) {
         return item != null && item.toString().toLowerCase().includes(filterValue.toLowerCase());
       }
+
       const keys = Object.keys(item);
       const reduceFn = (acc: boolean, prop: string) =>
         acc || item[prop].toString().toLowerCase().includes(filterValue.toLowerCase());
+
       return hasSearchFields
         ? keys.filter((p: string) => searchFields.includes(p)).reduce(reduceFn, false)
         : keys.reduce(reduceFn, false);

--- a/libs/ui-testing/src/index.ts
+++ b/libs/ui-testing/src/index.ts
@@ -19,6 +19,10 @@ export * from './lib/core-features/widget-loaders.cy';
 
 // Golem features and components
 export * from './lib/golem-features/alert.cy';
+export * from './lib/golem-features/currency.cy';
+export * from './lib/golem-features/datepicker.cy';
+export * from './lib/golem-features/dropdown.cy';
+export * from './lib/golem-features/number.cy';
 export * from './lib/golem-features/repeater.cy';
 export * from './lib/golem-features/select.cy';
 export * from './lib/golem-features/validators.cy';

--- a/libs/ui-testing/src/lib/golem-features/currency.cy.ts
+++ b/libs/ui-testing/src/lib/golem-features/currency.cy.ts
@@ -1,0 +1,52 @@
+import { defineForm, identityTranslator } from '@golemui/core';
+import { type MountComponentFn } from '../utils';
+
+export const runCurrencyComponentTests = (mountFn: MountComponentFn) => {
+  describe('Currency Component', () => {
+    beforeEach(() => {
+      mountFn({
+        // Pin the locale so the formatted value assertion does not depend on
+        // the machine running the tests
+        localization: identityTranslator('en-US'),
+        formDef: defineForm({
+          form: [
+            {
+              uid: 'testSubject',
+              kind: 'input',
+              type: 'currency',
+              path: 'myField',
+              props: {
+                currency: 'USD',
+              },
+            },
+            {
+              uid: 'submitBtn',
+              kind: 'action',
+              type: 'button',
+              label: 'Submit',
+              actionType: 'submit',
+            },
+          ],
+        }),
+      });
+    });
+
+    // Chrome filters letters natively on number inputs but Firefox does not,
+    // so the widget must block them itself
+    it('should not allow typing letters', () => {
+      cy.get('[data-cy="testSubject_currency"]').type('abc');
+      cy.get('[data-cy="testSubject_currency"]').should('have.value', '');
+    });
+
+    it('should keep only the numeric characters when typing mixed input', () => {
+      cy.get('[data-cy="testSubject_currency"]').type('x1y2z3');
+      cy.get('[data-cy="testSubject_currency"]').should('have.value', '123');
+    });
+
+    it('should show the formatted currency value on blur', () => {
+      cy.get('[data-cy="testSubject_currency"]').type('1234.5');
+      cy.get('[data-cy="testSubject_currency"]').blur();
+      cy.get('.gui-currency__format-value').should('contain.text', '$1,234.50');
+    });
+  });
+};

--- a/libs/ui-testing/src/lib/golem-features/datepicker.cy.ts
+++ b/libs/ui-testing/src/lib/golem-features/datepicker.cy.ts
@@ -1,0 +1,84 @@
+import { defineForm } from '@golemui/core';
+import { type MountComponentFn } from '../utils';
+
+export const runDatePickerComponentTests = (mountFn: MountComponentFn) => {
+  describe('DatePicker Component', () => {
+    const mountWithDate = (formSubmit?: (event: any) => void) => {
+      mountFn({
+        data: { myDate: '2026-06-15' },
+        formDef: defineForm({
+          form: [
+            {
+              uid: 'testSubject',
+              kind: 'input',
+              type: 'datePicker',
+              path: 'myDate',
+            },
+            {
+              uid: 'submitBtn',
+              kind: 'action',
+              type: 'button',
+              label: 'Submit',
+              actionType: 'submit',
+            },
+          ],
+        }),
+        formSubmit,
+      });
+    };
+
+    // These specs guard against timezone regressions: date-only ISO strings
+    // parsed as UTC render as the previous day in timezones behind UTC
+
+    it('should display the default value date parts regardless of timezone', () => {
+      mountWithDate();
+
+      cy.get('gui-date input[data-type="day"]').should('have.value', '15');
+      cy.get('gui-date input[data-type="month"]').should('have.value', '06');
+      cy.get('gui-date input[data-type="year"]').should('have.value', '2026');
+    });
+
+    it('should highlight the day of the current value in the calendar', () => {
+      mountWithDate();
+
+      cy.get('gui-date input[data-type="day"]').click();
+      cy.get('gui-calendar button[data-date="2026-06-15"]').should(
+        'have.attr',
+        'aria-selected',
+        'true',
+      );
+    });
+
+    it('should select the exact day that is clicked', () => {
+      const formSubmitHandler = cy.stub().as('formSubmitHandler');
+      mountWithDate(formSubmitHandler);
+
+      cy.get('gui-date input[data-type="day"]').click();
+      cy.get('gui-calendar button[data-date="2026-06-18"]').click();
+
+      // The date input must show the clicked day, not the day before
+      cy.get('gui-date input[data-type="day"]').should('have.value', '18');
+      cy.get('gui-date input[data-type="month"]').should('have.value', '06');
+      cy.get('gui-date input[data-type="year"]').should('have.value', '2026');
+
+      // Re-opening the calendar must highlight the clicked day
+      cy.get('gui-date input[data-type="day"]').click();
+      cy.get('gui-calendar button[data-date="2026-06-18"]').should(
+        'have.attr',
+        'aria-selected',
+        'true',
+      );
+
+      // Close the calendar so it does not cover the submit button
+      cy.get('body').click(0, 0);
+      cy.get('gui-calendar').should('not.exist');
+
+      // The submitted value must be the clicked day
+      cy.get('[data-cy="submitBtn_button"]').click();
+      cy.get('@formSubmitHandler').then((stub: any) => {
+        const submittedData = stub.getCall(0).args[0].data;
+        expect(submittedData).to.deep.equal({ myDate: '2026-06-18' });
+      });
+    });
+  });
+};

--- a/libs/ui-testing/src/lib/golem-features/dropdown.cy.ts
+++ b/libs/ui-testing/src/lib/golem-features/dropdown.cy.ts
@@ -1,0 +1,76 @@
+import { defineForm } from '@golemui/core';
+import { type MountComponentFn } from '../utils';
+
+export const runDropdownComponentTests = (mountFn: MountComponentFn) => {
+  describe('Dropdown Component', () => {
+    const mountWithItems = (items: unknown[], extraProps: Record<string, unknown> = {}) => {
+      mountFn({
+        formDef: defineForm({
+          form: [
+            {
+              uid: 'testSubject',
+              kind: 'input',
+              type: 'dropdown',
+              path: 'myField',
+              props: {
+                items,
+                inputDebounce: 0,
+                ...extraProps,
+              },
+            },
+          ],
+        }),
+      });
+    };
+
+    const visibleItems = () =>
+      cy.get('gui-list:not([hidden]) .gui-list__item-wrapper').filter(':visible');
+
+    it('should filter primitive items with a multi-character search', () => {
+      mountWithItems(['React', 'Angular', 'Vue']);
+
+      cy.get('[data-cy="testSubject_textinput"]').type('R');
+      visibleItems().should('have.length', 2);
+
+      // Regression: multi-character searches returned no results for
+      // primitive items because each character was matched individually
+      cy.get('[data-cy="testSubject_textinput"]').type('e');
+      visibleItems().should('have.length', 1);
+      visibleItems().first().should('contain.text', 'React');
+    });
+
+    it('should show all primitive items again when the search is cleared', () => {
+      mountWithItems(['React', 'Angular', 'Vue']);
+
+      cy.get('[data-cy="testSubject_textinput"]').type('Re');
+      visibleItems().should('have.length', 1);
+
+      cy.get('[data-cy="testSubject_textinput"]').clear();
+      visibleItems().should('have.length', 3);
+    });
+
+    it('should select a filtered primitive item', () => {
+      mountWithItems(['React', 'Angular', 'Vue']);
+
+      cy.get('[data-cy="testSubject_textinput"]').type('Re');
+      visibleItems().first().click();
+
+      cy.get('[data-cy="testSubject_textinput"]').should('have.value', 'React');
+    });
+
+    it('should filter object items by their search fields', () => {
+      mountWithItems(
+        [
+          { label: 'React', value: 'react' },
+          { label: 'Angular', value: 'angular' },
+          { label: 'Vue', value: 'vue' },
+        ],
+        { labelField: 'label', valueField: 'value' },
+      );
+
+      cy.get('[data-cy="testSubject_textinput"]').type('Re');
+      visibleItems().should('have.length', 1);
+      visibleItems().first().should('contain.text', 'React');
+    });
+  });
+};

--- a/libs/ui-testing/src/lib/golem-features/number.cy.ts
+++ b/libs/ui-testing/src/lib/golem-features/number.cy.ts
@@ -1,0 +1,45 @@
+import { defineForm } from '@golemui/core';
+import { type MountComponentFn } from '../utils';
+
+export const runNumberComponentTests = (mountFn: MountComponentFn) => {
+  describe('Number Component', () => {
+    beforeEach(() => {
+      mountFn({
+        formDef: defineForm({
+          form: [
+            {
+              uid: 'testSubject',
+              kind: 'input',
+              type: 'number',
+              path: 'myField',
+            },
+            {
+              uid: 'submitBtn',
+              kind: 'action',
+              type: 'button',
+              label: 'Submit',
+              actionType: 'submit',
+            },
+          ],
+        }),
+      });
+    });
+
+    // Chrome filters letters natively on number inputs but Firefox does not,
+    // so the widget must block them itself
+    it('should not allow typing letters', () => {
+      cy.get('[data-cy="testSubject_number"]').type('abc');
+      cy.get('[data-cy="testSubject_number"]').should('have.value', '');
+    });
+
+    it('should keep only the numeric characters when typing mixed input', () => {
+      cy.get('[data-cy="testSubject_number"]').type('x1y2z3');
+      cy.get('[data-cy="testSubject_number"]').should('have.value', '123');
+    });
+
+    it('should accept decimal numbers', () => {
+      cy.get('[data-cy="testSubject_number"]').type('12.5');
+      cy.get('[data-cy="testSubject_number"]').should('have.value', '12.5');
+    });
+  });
+};

--- a/libs/ui-testing/src/lib/golem-features/validators.cy.ts
+++ b/libs/ui-testing/src/lib/golem-features/validators.cy.ts
@@ -41,6 +41,7 @@ export const runValidatorsComponentTests = (mountFn: MountComponentFn) => {
             ],
           }),
         });
+        cy.get('[data-cy="requiredString_textinput"]').should('exist');
         cy.get('[data-cy="testButton_button"]').click();
         cy.get('[data-cy="requiredString_validator-errors"]').should('exist');
         cy.get('[data-cy="requiredString_validator-error"]').contains(


### PR DESCRIPTION
Fix timezone issues with date inputs: Added parseISODateString() to date.ts (parses YYYY-MM-DD at local midnight) and replaced every UTC re-parse in calendar, range-calendar, date-input, range-date-input and abstract-calendar. Also fixed mergeDateRanges, which UTC-parsed and then local-formatted and changed the day buttons' data-date to the local ISO date.

Fix numeric input issues in Firefox: Chrome filters keystrokes on input type="number" natively; Firefox doesn't. Added numeric.ts with keydown + beforeinput guards (blocks typing and pasting of anything outside 0-9 . , e E + -) and wired it into number.ts and currency.ts.

Fix dropdown search: When we filter plain value items and we don't have a `seachField` value the filter was not working because we were failing trying to identify if it was a primitive. Fixed the "isPrimitive" with a new guard.

Added interaction tests for currency, date picker, dropdown, and number. Also added Firefox to cypress tests.