### PR TITLE
fix: runtime functions were failing on init

### DIFF
--- a/apps/apps-shared/src/lib/mocks/tabs/renderer.dx.ts
+++ b/apps/apps-shared/src/lib/mocks/tabs/renderer.dx.ts
@@ -19,4 +19,8 @@ export const buildRendererTab = (render: (api: any) => unknown) =>
       placeholder: 'Type to see the renderer above react live',
       hint: 'The renderer reads $form.rendererClientName and re-renders on every keystroke.',
     }),
+    gui.inputs.booleanInput('registerMode', (params) => ({
+      label: params.$form.registerMode ? 'Switch to login' : 'Switch to register',
+      hint: 'Runtime functions can change also your props.'
+    })),
   ]);

--- a/libs/core/src/lib/form-widget.ts
+++ b/libs/core/src/lib/form-widget.ts
@@ -337,10 +337,7 @@ const functionWidgetDecoder: Decoder<FunctionWidget<string>> = new Decoder((json
   const jsonTypeof = typeof json;
   if (jsonTypeof === 'function') {
     const fnWidget = json as FunctionWidget<string>;
-    // Probe call to extract uid/type/path before any form data exists; the
-    // FunctionWidgetParams contract guarantees `$form` is an object, so pass at
-    // least `{}` — a widget function reading `$form.field` must get `undefined`,
-    // not crash.
+    // Widget functions expect an empty object for `$form`, otherwise the evaluation crashes
     const widget = fnWidget({
       $form: {},
       errors: undefined,

--- a/libs/core/src/lib/form-widget.ts
+++ b/libs/core/src/lib/form-widget.ts
@@ -337,7 +337,16 @@ const functionWidgetDecoder: Decoder<FunctionWidget<string>> = new Decoder((json
   const jsonTypeof = typeof json;
   if (jsonTypeof === 'function') {
     const fnWidget = json as FunctionWidget<string>;
-    const widget = fnWidget(undefined);
+    // Probe call to extract uid/type/path before any form data exists; the
+    // FunctionWidgetParams contract guarantees `$form` is an object, so pass at
+    // least `{}` — a widget function reading `$form.field` must get `undefined`,
+    // not crash.
+    const widget = fnWidget({
+      $form: {},
+      errors: undefined,
+      touched: undefined,
+      translate: undefined,
+    });
     fnWidget.uid = widget.uid || shortUUID();
     fnWidget.type = widget.type;
     fnWidget.path = (widget as InputWidget<unknown>).path; // this could be undefined, and it's ok.

--- a/libs/core/src/lib/store/reducers/initialize.spec.ts
+++ b/libs/core/src/lib/store/reducers/initialize.spec.ts
@@ -106,9 +106,8 @@ describe('initialize - undeclared state reference diagnostic', () => {
   });
 });
 
-// The decoder probes function widgets once (before any form data exists) to extract
-// uid/type/path. The probe must honor the FunctionWidgetParams contract ($form is
-// always an object) so unguarded `$form.field` reads return undefined, not crash.
+// FunctionWidgetParams contract says ($form is always an object) check that
+// `$form.field` reads return undefined, not crash because `$form` is `undefined`.
 describe('initialize - function widget decode probe', () => {
   const init = (formDef: Record<string, any>) =>
     initialize(createInitialState('en-US'), {

--- a/libs/core/src/lib/store/reducers/initialize.spec.ts
+++ b/libs/core/src/lib/store/reducers/initialize.spec.ts
@@ -105,3 +105,27 @@ describe('initialize - undeclared state reference diagnostic', () => {
     expect(errorSpy).not.toHaveBeenCalled();
   });
 });
+
+// The decoder probes function widgets once (before any form data exists) to extract
+// uid/type/path. The probe must honor the FunctionWidgetParams contract ($form is
+// always an object) so unguarded `$form.field` reads return undefined, not crash.
+describe('initialize - function widget decode probe', () => {
+  const init = (formDef: Record<string, any>) =>
+    initialize(createInitialState('en-US'), {
+      type: 'INITIALIZE',
+      payload: { formName: 'f', formDef },
+    });
+
+  it('decodes a function widget that reads `$form.field` without optional chaining', () => {
+    const fnWidget = ({ $form }: any) => ({
+      uid: 'agreed',
+      kind: 'input' as const,
+      type: 'checkbox',
+      path: 'agreed',
+      label: $form.rtlMode ? 'RTL' : 'LTR',
+    });
+    const result = init({ form: [fnWidget] });
+    expect(result.formHealth.status).toBe('ok');
+    expect(result.flatForm['agreed']).toBeDefined();
+  });
+});

--- a/libs/gui/shared/src/lib/dx/__tests__/inputs.pipeline.spec.ts
+++ b/libs/gui/shared/src/lib/dx/__tests__/inputs.pipeline.spec.ts
@@ -108,6 +108,23 @@ describe('DX Pipeline — Inputs', () => {
       expect(withErrors.label).toBe('Fix!');
       expect(withoutErrors.label).toBe('Msg');
     });
+
+    // The decode probe calls function widgets before form data exists; the pipeline
+    // must normalize params so an unguarded `$form.field` read gets undefined, not a crash.
+    it('resolves a callback reading `$form.field` without optional chaining when params carry no $form', () => {
+      const result = processDx(
+        _guiBooleanInput('agreed', ({ $form }) => ({
+          label: $form.rtlMode ? 'RTL' : 'LTR',
+        })),
+      );
+
+      const rawChild = getRawChild(result, 0);
+      expect(typeof rawChild).toBe('function');
+
+      const resolved = resolveDynamic(rawChild) as { label?: string; path?: string };
+      expect(resolved.label).toBe('LTR');
+      expect(resolved.path).toBe('agreed');
+    });
   });
 
   describe('Validators', () => {

--- a/libs/gui/shared/src/lib/dx/core/itemWalker.service.ts
+++ b/libs/gui/shared/src/lib/dx/core/itemWalker.service.ts
@@ -28,6 +28,7 @@ import {
 } from './itemTypeRegistry';
 import { type EventWiringService } from './eventWiring.service';
 import { type StateExpansionService } from './stateExpansion.service';
+import { withForm } from './withForm';
 
 function createEventIdGenerator(): EventIdGenerator {
   let count = 0;
@@ -262,7 +263,7 @@ export class ItemWalker {
 
     if (typeof baseProvider === 'function') {
       return (params: FunctionWidgetParams<any>) => {
-        const safeParams = params ?? ({} as FunctionWidgetParams<any>);
+        const safeParams = withForm(params);
         const hotMapping = baseProvider(safeParams);
         return parsed.path != null ? { ...hotMapping, path: parsed.path } : hotMapping;
       };

--- a/libs/gui/shared/src/lib/dx/core/withForm.ts
+++ b/libs/gui/shared/src/lib/dx/core/withForm.ts
@@ -1,0 +1,17 @@
+import type { FunctionWidgetParams } from '@golemui/core';
+
+/**
+ * Runtime functions can run during the build walk / decode probe before form
+ * data exists; the FunctionWidgetParams contract guarantees `$form` is an
+ * object, so normalize it to at least `{}` — a callback reading
+ * `params.$form.field` must get `undefined`, not crash.
+ */
+export function withForm(params?: FunctionWidgetParams<any>): FunctionWidgetParams<any> {
+  return {
+    errors: undefined,
+    touched: undefined,
+    translate: undefined,
+    ...(params ?? {}),
+    $form: params?.$form ?? {},
+  };
+}

--- a/libs/gui/shared/src/lib/dx/shortcuts/display/register.ts
+++ b/libs/gui/shared/src/lib/dx/shortcuts/display/register.ts
@@ -9,20 +9,8 @@ import {
 import { type MergeResult } from '../../core/dx.domain';
 import { type BuildWidgetContext } from '../../core/itemTypeRegistry';
 import { defineShortcutType } from '../../core/defineShortcutType';
+import { withForm } from '../../core/withForm';
 import { type DisplayDecorator, type DisplayEntry, type GslDisplaysConfig } from './display.domain';
-
-// Render runs during the build walk before form data exists; the FunctionWidgetParams contract
-// guarantees `$form` is an object, so normalize it to at least `{}` — a render reading
-// `params.$form.field` must get `undefined`, not crash.
-function withForm(params?: FunctionWidgetParams<any>): FunctionWidgetParams<any> {
-  return {
-    errors: undefined,
-    touched: undefined,
-    translate: undefined,
-    ...(params ?? {}),
-    $form: params?.$form ?? {},
-  };
-}
 
 function mapToWidget<StateKeys extends UiState = never, FormData extends Record<string, any> = any>(
   def: DisplayDecorator,


### PR DESCRIPTION
[We fixed initialization errors with Renderer components](https://github.com/golemui/golemui/pull/183) but not with Runtime Functions.

This PR fixes Runtime Functions errors on initialize when they try to use `$form` data. We can avoid this with optional chaining, but the real fix is to initializa the `$form` with `{}` so users don't have to add it.

I've moved `withForm()` function outside `display` register so it can be consumed by the `itemWalker` service.