### PR TITLE
feat: add $item / $index scope to repeater templates

### DIFF
--- a/apps/angular-playground/src/app/pages/modular-dx/modular-dx.component.ts
+++ b/apps/angular-playground/src/app/pages/modular-dx/modular-dx.component.ts
@@ -3,9 +3,14 @@ import { Component } from '@angular/core';
 import { modularDx, onFormEvent } from '@golemui/apps-shared';
 import type { FormEvent, FormHealth, FormSubmitEvent } from '@golemui/core';
 import { FormComponent } from '@golemui/gui-angular';
-import type { GuiFormInitConfig } from '@golemui/gui-shared';
+import type { Dependencies, GuiFormInitConfig } from '@golemui/gui-shared';
+import snarkdown from 'snarkdown';
 
-const md = modularDx;
+const formExample = modularDx;
+
+const dependencies: Dependencies = {
+  markdown: { parse: (markdown: string) => snarkdown(markdown) },
+};
 
 @Component({
   imports: [CommonModule, FormComponent],
@@ -14,10 +19,11 @@ const md = modularDx;
 })
 export class ModularDxPage {
   protected config: GuiFormInitConfig = {
-    formDef: md.formDef,
-    data: md.data,
-    formSelectors: md.formSelectors,
-    formConfig: md.formConfig,
+    formDef: formExample.formDef,
+    data: formExample.data,
+    formSelectors: formExample.formSelectors,
+    formConfig: formExample.formConfig,
+    dependencies,
   };
   protected error = '';
 

--- a/apps/apps-shared/src/lib/mocks/index.dx.ts
+++ b/apps/apps-shared/src/lib/mocks/index.dx.ts
@@ -1,1 +1,2 @@
 export * from './tests.dx';
+export * from './invoice.dx';

--- a/apps/apps-shared/src/lib/mocks/index.ts
+++ b/apps/apps-shared/src/lib/mocks/index.ts
@@ -3,6 +3,8 @@ export * from './demo-a11y';
 export * from './demo-i18n';
 export * from './demo-validation';
 export * from './flight-tickets';
+export * from './invoice';
+export * from './invoice-nested';
 export * from './item-renderers';
 export * from './kitchen-sink';
 export * from './kitchen-sink.dx';

--- a/apps/apps-shared/src/lib/mocks/invoice-nested.form.json
+++ b/apps/apps-shared/src/lib/mocks/invoice-nested.form.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://golemui.com/schemas/form.schema.json",
+  "form": [
+    {
+      "kind": "display",
+      "type": "markdownText",
+      "props": { "md": "## Freelance invoice by project" }
+    },
+    {
+      "kind": "display",
+      "type": "markdownText",
+      "props": {
+        "md": "Bill each project's tasks (hours x rate). This is a repeater of tasks nested inside a repeater of projects, so `$item` and `$index` always resolve to the innermost item: the task."
+      }
+    },
+    {
+      "kind": "input",
+      "type": "repeater",
+      "path": "projects",
+      "label": "Projects",
+      "validator": { "type": "array", "required": true, "minItems": 1 },
+      "props": {
+        "addLabel": "Add project",
+        "removeLabel": "Remove project",
+        "title": "Project",
+        "template": {
+          "kind": "layout",
+          "type": "flex",
+          "props": { "direction": "column", "gap": 12 },
+          "children": [
+            {
+              "kind": "input",
+              "type": "textinput",
+              "path": "projects.items.name",
+              "label": "Project name",
+              "validator": { "type": "string", "required": true, "minLength": 1 },
+              "props": { "placeholder": "e.g. Website redesign" }
+            },
+            {
+              "kind": "input",
+              "type": "repeater",
+              "path": "projects.items.tasks",
+              "label": "Tasks",
+              "validator": { "type": "array", "required": true, "minItems": 1 },
+              "props": {
+                "addLabel": "Add task",
+                "removeLabel": "Remove",
+                "title": "Task",
+                "template": {
+                  "kind": "layout",
+                  "type": "flex",
+                  "props": { "direction": "row", "gap": 12 },
+                  "children": [
+                    {
+                      "kind": "input",
+                      "type": "textinput",
+                      "path": "projects.items.tasks.items.description",
+                      "size": 5,
+                      "label": "Task",
+                      "validator": { "type": "string", "required": true, "minLength": 1 }
+                    },
+                    {
+                      "kind": "input",
+                      "type": "number",
+                      "path": "projects.items.tasks.items.hours",
+                      "size": 2,
+                      "label": "Hours",
+                      "validator": { "type": "number", "required": true, "minimum": 0 },
+                      "props": { "minimum": 0, "step": 0.5 }
+                    },
+                    {
+                      "kind": "input",
+                      "type": "currency",
+                      "path": "projects.items.tasks.items.rate",
+                      "size": 3,
+                      "label": "Hourly rate",
+                      "validator": { "type": "number", "required": true },
+                      "props": {
+                        "currency": "USD",
+                        "minimumFractionDigits": 2,
+                        "maximumFractionDigits": 2
+                      }
+                    },
+                    {
+                      "kind": "display",
+                      "type": "markdownText",
+                      "size": 2,
+                      "props": {
+                        "md": "**Task {{$index + 1}}**  \n${{ (($item.hours ?? 0) * ($item.rate ?? 0)).toFixed(2) }}"
+                      },
+                      "include": { "when": "$item.hours !== undefined" }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "kind": "display",
+              "type": "alert",
+              "props": {
+                "level": "info",
+                "text": "Project subtotal: ${{ ($item.tasks?.reduce((sum, task) => sum + ((task.hours ?? 0) * (task.rate ?? 0)), 0) ?? 0).toFixed(2) }}"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "kind": "display",
+      "type": "alert",
+      "props": {
+        "level": "success",
+        "text": "Total due: ${{ ($form.projects?.reduce((total, project) => total + (project.tasks?.reduce((sum, task) => sum + ((task.hours ?? 0) * (task.rate ?? 0)), 0) ?? 0), 0) ?? 0).toFixed(2) }}"
+      }
+    },
+    {
+      "kind": "layout",
+      "type": "flex",
+      "props": { "direction": "row", "align": "end" },
+      "children": [
+        {
+          "kind": "action",
+          "type": "button",
+          "actionType": "submit",
+          "label": "Send invoice",
+          "disabled": { "when": "$formIsInvalid" },
+          "props": { "variant": "filled" }
+        }
+      ]
+    }
+  ]
+}

--- a/apps/apps-shared/src/lib/mocks/invoice-nested.ts
+++ b/apps/apps-shared/src/lib/mocks/invoice-nested.ts
@@ -1,0 +1,33 @@
+import { type Form } from '@golemui/core';
+import { type Example } from './types';
+
+const data = {
+  projects: [
+    {
+      name: 'Website redesign',
+      tasks: [
+        { description: 'Homepage design', hours: 12, rate: 95 },
+        { description: 'Responsive layout', hours: 8, rate: 95 },
+      ],
+    },
+    {
+      name: 'Brand identity',
+      tasks: [{ description: 'Logo design', hours: 6, rate: 110 }],
+    },
+  ],
+};
+
+/**
+ * i18next Resource Bundle
+ */
+const resources = {};
+
+export const invoiceNested: Example = {
+  data,
+  form: async () => {
+    const baseUrl = new URL('/assets/mocks/invoice-nested.form.json', window.location.href).href;
+    const json = await fetch(baseUrl).then((r) => r.json());
+    return json as unknown as Form<string>;
+  },
+  resources,
+};

--- a/apps/apps-shared/src/lib/mocks/invoice.dx.ts
+++ b/apps/apps-shared/src/lib/mocks/invoice.dx.ts
@@ -1,0 +1,166 @@
+import type { DxDefinitionItem, DxFormConfig } from '@golemui/gui-shared';
+import { gui } from '@golemui/gui-shared';
+import { type DxModule } from './modular.dx';
+
+const data = {};
+
+const SUBTOTAL_EXPR =
+  '$form.lineItems?.reduce((acc, item) => acc + ((item.quantity ?? 0) * (item.unitPrice ?? 0)), 0) ?? 0';
+
+const formDef: DxDefinitionItem[] = [
+  gui.displays.markdownText({ md: '## Invoice' }),
+
+  gui.layouts.grid(
+    [
+      gui.displays.markdownText({ md: '**From**', size: 6 }),
+      gui.displays.markdownText({ md: '**Bill To**', size: 6 }),
+      gui.inputs.textInput('company.name', {
+        label: 'Company Name',
+        size: 6,
+        placeholder: 'Acme Inc.',
+        validator: { required: true, minLength: 1 },
+      }),
+      gui.inputs.textInput('client.name', {
+        label: 'Invoiced To Name',
+        size: 6,
+        placeholder: 'Client name',
+        validator: { required: true, minLength: 1 },
+      }),
+      gui.inputs.textInput('company.id', {
+        label: 'Company ID',
+        size: 6,
+        placeholder: 'Tax ID / Reg. no.',
+        validator: { required: true, minLength: 1 },
+      }),
+      gui.inputs.textInput('client.id', {
+        label: 'Invoiced To ID',
+        size: 6,
+        placeholder: 'Tax ID / Reg. no.',
+        validator: { required: true, minLength: 1 },
+      }),
+    ],
+    { direction: 'row', autoFit: false, columnGap: 24, rowGap: 8 },
+  ),
+
+  gui.displays.markdownText({ md: '#### Invoice details' }),
+  gui.layouts.grid(
+    [
+      gui.inputs.textInput('invoice.number', {
+        label: 'Invoice Number',
+        size: 3,
+        placeholder: 'INV-0001',
+        validator: { required: true, minLength: 1 },
+      }),
+      gui.inputs.datePicker('invoice.date', {
+        label: 'Date',
+        size: 3,
+        validator: { required: true, format: 'date' },
+      }),
+      gui.inputs.select('invoice.currency', {
+        label: 'Invoice Currency',
+        size: 3,
+        placeholder: 'Select currency',
+        options: [
+          { value: 'EUR', label: 'EUR' },
+          { value: 'USD', label: 'USD' },
+        ],
+        validator: { type: 'string', required: true },
+      }),
+      gui.inputs.textInput('invoice.vatNumber', {
+        label: 'VAT Number',
+        size: 3,
+        placeholder: 'EU VAT',
+        include: { in: ['eurSelected'] },
+      }),
+    ],
+    { direction: 'row', autoFit: false, columnGap: 16, rowGap: 8 },
+  ),
+
+  gui.displays.markdownText({ md: '#### Line Items' }),
+  gui.inputs.repeater('lineItems', {
+    label: 'Line Items',
+    title: 'Line Item',
+    addLabel: 'Add line item',
+    removeLabel: 'Remove',
+    validator: { required: true, minItems: 1 },
+    template: [
+      gui.layouts.flex(
+        [
+          gui.inputs.numberInput('lineItems.items.quantity', {
+            label: 'Quantity',
+            size: 2,
+            minimum: 1,
+            step: 1,
+            // multipleOf 1 restricts the value to integers.
+            validator: { required: true, minimum: 1, multipleOf: 1 },
+          }),
+          gui.inputs.textInput('lineItems.items.description', {
+            label: 'Description',
+            size: 5,
+            validator: { required: true, minLength: 1 },
+          }),
+          gui.inputs.currency('lineItems.items.unitPrice', {
+            label: 'Unit Price',
+            size: 3,
+            currency: 'USD',
+            states: { eurSelected: { currency: 'EUR' } },
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+            validator: { required: true },
+          }),
+          gui.displays.markdownText({
+            md: '**Total**  \n{{ (($item.quantity ?? 0) * ($item.unitPrice ?? 0)).toFixed(2) }}',
+            size: 2,
+            include: { when: '$item.quantity !== undefined' },
+          }),
+        ],
+        { direction: 'row', gap: 12 },
+      ),
+    ],
+  }),
+
+  gui.displays.markdownText({ md: '#### Totals' }),
+  gui.layouts.grid(
+    [
+      gui.displays.markdownText({ md: '**Subtotal (Taxable Base)**', size: 9 }),
+      gui.displays.markdownText({ md: `{{(${SUBTOTAL_EXPR}).toFixed(2)}}`, size: 3 }),
+      gui.displays.markdownText({
+        md: "**Currency Tax ({{$form.invoice?.currency === 'EUR' ? '15%' : '2%'}})**",
+        size: 9,
+      }),
+      gui.displays.markdownText({
+        md: `{{((${SUBTOTAL_EXPR}) * ($form.invoice?.currency === 'EUR' ? 0.15 : 0.02)).toFixed(2)}}`,
+        size: 3,
+      }),
+    ],
+    { direction: 'row', autoFit: false, columnGap: 12, rowGap: 4 },
+  ),
+
+  gui.displays.alert({
+    level: 'success',
+    text: `Grand Total: {{$form.invoice?.currency === 'EUR' ? '€' : '$'}}{{((${SUBTOTAL_EXPR}) * ($form.invoice?.currency === 'EUR' ? 1.15 : 1.02)).toFixed(2)}}`,
+  }),
+
+  gui.layouts.flex(
+    [
+      gui.actions.button({
+        label: 'Submit Invoice',
+        actionType: 'submit',
+        variant: 'filled',
+        disabled: { when: '$formIsInvalid' },
+      }),
+    ],
+    { direction: 'row', align: 'end' },
+  ),
+];
+
+const formConfig: DxFormConfig = {
+  states: { eurSelected: "$form.invoice?.currency === 'EUR'" },
+};
+
+export const invoiceDxModular: DxModule = {
+  label: 'Invoice',
+  data,
+  formDef,
+  formConfig,
+};

--- a/apps/apps-shared/src/lib/mocks/invoice.form.json
+++ b/apps/apps-shared/src/lib/mocks/invoice.form.json
@@ -1,0 +1,271 @@
+{
+  "$schema": "https://golemui.com/schemas/form.schema.json",
+  "states": {
+    "eurSelected": "$form.invoice?.currency === 'EUR'"
+  },
+  "form": [
+    {
+      "kind": "display",
+      "type": "markdownText",
+      "props": { "md": "## Invoice" }
+    },
+    {
+      "kind": "layout",
+      "type": "grid",
+      "props": {
+        "autoFit": false,
+        "direction": "row",
+        "columnGap": 24,
+        "rowGap": 8
+      },
+      "children": [
+        {
+          "kind": "display",
+          "type": "markdownText",
+          "size": 6,
+          "props": { "md": "**From**" }
+        },
+        {
+          "kind": "display",
+          "type": "markdownText",
+          "size": 6,
+          "props": { "md": "**Bill To**" }
+        },
+        {
+          "kind": "input",
+          "type": "textinput",
+          "path": "company.name",
+          "size": 6,
+          "label": "Company Name",
+          "validator": { "type": "string", "required": true, "minLength": 1 },
+          "props": { "placeholder": "Acme Inc." }
+        },
+        {
+          "kind": "input",
+          "type": "textinput",
+          "path": "client.name",
+          "size": 6,
+          "label": "Invoiced To Name",
+          "validator": { "type": "string", "required": true, "minLength": 1 },
+          "props": { "placeholder": "Client name" }
+        },
+        {
+          "kind": "input",
+          "type": "textinput",
+          "path": "company.id",
+          "size": 6,
+          "label": "Company ID",
+          "validator": { "type": "string", "required": true, "minLength": 1 },
+          "props": { "placeholder": "Tax ID / Reg. no." }
+        },
+        {
+          "kind": "input",
+          "type": "textinput",
+          "path": "client.id",
+          "size": 6,
+          "label": "Invoiced To ID",
+          "validator": { "type": "string", "required": true, "minLength": 1 },
+          "props": { "placeholder": "Tax ID / Reg. no." }
+        }
+      ]
+    },
+    {
+      "kind": "display",
+      "type": "markdownText",
+      "props": { "md": "#### Invoice details" }
+    },
+    {
+      "kind": "layout",
+      "type": "grid",
+      "props": {
+        "autoFit": false,
+        "direction": "row",
+        "columnGap": 16,
+        "rowGap": 8
+      },
+      "children": [
+        {
+          "kind": "input",
+          "type": "textinput",
+          "path": "invoice.number",
+          "size": 3,
+          "label": "Invoice Number",
+          "validator": { "type": "string", "required": true, "minLength": 1 },
+          "props": { "placeholder": "INV-0001" }
+        },
+        {
+          "kind": "input",
+          "type": "datePicker",
+          "path": "invoice.date",
+          "size": 3,
+          "label": "Date",
+          "validator": { "type": "string", "required": true, "format": "date" }
+        },
+        {
+          "kind": "input",
+          "type": "select",
+          "path": "invoice.currency",
+          "size": 3,
+          "label": "Invoice Currency",
+          "validator": { "type": "string", "required": true },
+          "props": {
+            "placeholder": "Select currency",
+            "options": [
+              { "label": "EUR", "value": "EUR" },
+              { "label": "USD", "value": "USD" }
+            ]
+          }
+        },
+        {
+          "kind": "input",
+          "type": "textinput",
+          "path": "invoice.vatNumber",
+          "size": 3,
+          "label": "VAT Number",
+          "include": { "in": ["eurSelected"] },
+          "props": { "placeholder": "EU VAT" }
+        }
+      ]
+    },
+    {
+      "kind": "display",
+      "type": "markdownText",
+      "props": { "md": "#### Line Items" }
+    },
+    {
+      "kind": "input",
+      "type": "repeater",
+      "path": "lineItems",
+      "label": "Line Items",
+      "validator": { "type": "array", "required": true, "minItems": 1 },
+      "props": {
+        "addLabel": "Add line item",
+        "removeLabel": "Remove",
+        "title": "Line Item",
+        "template": {
+          "kind": "layout",
+          "type": "flex",
+          "props": {
+            "direction": "row",
+            "gap": 12
+          },
+          "children": [
+            {
+              "kind": "input",
+              "type": "number",
+              "path": "lineItems.items.quantity",
+              "size": 2,
+              "label": "Quantity",
+              "validator": { "type": "integer", "required": true, "minimum": 1 },
+              "props": { "minimum": 1, "step": 1 }
+            },
+            {
+              "kind": "input",
+              "type": "textinput",
+              "path": "lineItems.items.description",
+              "size": 5,
+              "label": "Description",
+              "validator": { "type": "string", "required": true, "minLength": 1 }
+            },
+            {
+              "kind": "input",
+              "type": "currency",
+              "path": "lineItems.items.unitPrice",
+              "size": 3,
+              "label": "Unit Price",
+              "validator": { "type": "number", "required": true },
+              "props": {
+                "currency": "USD",
+                "currency.eurSelected": "EUR",
+                "minimumFractionDigits": 2,
+                "maximumFractionDigits": 2
+              }
+            },
+            {
+              "kind": "display",
+              "type": "markdownText",
+              "size": 2,
+              "props": {
+                "md": "**Total**  \n{{ (($item.quantity ?? 0) * ($item.unitPrice ?? 0)).toFixed(2) }}"
+              },
+              "include": { "when": "$item.quantity !== undefined" }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "kind": "display",
+      "type": "markdownText",
+      "props": { "md": "#### Totals" }
+    },
+    {
+      "kind": "layout",
+      "type": "grid",
+      "props": {
+        "autoFit": false,
+        "direction": "row",
+        "columnGap": 12,
+        "rowGap": 4
+      },
+      "children": [
+        {
+          "kind": "display",
+          "type": "markdownText",
+          "size": 9,
+          "props": { "md": "**Subtotal (Taxable Base)**" }
+        },
+        {
+          "kind": "display",
+          "type": "markdownText",
+          "size": 3,
+          "props": {
+            "md": "{{($form.lineItems?.reduce((acc, item) => acc + ((item.quantity ?? 0) * (item.unitPrice ?? 0)), 0) ?? 0).toFixed(2)}}"
+          }
+        },
+        {
+          "kind": "display",
+          "type": "markdownText",
+          "size": 9,
+          "props": {
+            "md": "**Currency Tax ({{$form.invoice?.currency === 'EUR' ? '15%' : '2%'}})**"
+          }
+        },
+        {
+          "kind": "display",
+          "type": "markdownText",
+          "size": 3,
+          "props": {
+            "md": "{{(($form.lineItems?.reduce((acc, item) => acc + ((item.quantity ?? 0) * (item.unitPrice ?? 0)), 0) ?? 0) * ($form.invoice?.currency === 'EUR' ? 0.15 : 0.02)).toFixed(2)}}"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "display",
+      "type": "alert",
+      "props": {
+        "level": "success",
+        "text": "Grand Total: {{$form.invoice?.currency === 'EUR' ? '€' : '$'}}{{(($form.lineItems?.reduce((acc, item) => acc + ((item.quantity ?? 0) * (item.unitPrice ?? 0)), 0) ?? 0) * ($form.invoice?.currency === 'EUR' ? 1.15 : 1.02)).toFixed(2)}}"
+      }
+    },
+    {
+      "kind": "layout",
+      "type": "flex",
+      "props": {
+        "direction": "row",
+        "align": "end"
+      },
+      "children": [
+        {
+          "kind": "action",
+          "type": "button",
+          "actionType": "submit",
+          "label": "Submit Invoice",
+          "disabled": { "when": "$formIsInvalid" },
+          "props": { "variant": "filled" }
+        }
+      ]
+    }
+  ]
+}

--- a/apps/apps-shared/src/lib/mocks/invoice.ts
+++ b/apps/apps-shared/src/lib/mocks/invoice.ts
@@ -1,0 +1,19 @@
+import { type Form } from '@golemui/core';
+import { type Example } from './types';
+
+const data = {};
+
+/**
+ * i18next Resource Bundle
+ */
+const resources = {};
+
+export const invoice: Example = {
+  data,
+  form: async () => {
+    const baseUrl = new URL('/assets/mocks/invoice.form.json', window.location.href).href;
+    const json = await fetch(baseUrl).then((r) => r.json());
+    return json as unknown as Form<string>;
+  },
+  resources,
+};

--- a/apps/apps-shared/src/lib/mocks/modular.dx.ts
+++ b/apps/apps-shared/src/lib/mocks/modular.dx.ts
@@ -5,9 +5,10 @@ import type {
   GslSelectorsInput,
 } from '@golemui/gui-shared';
 import { gui } from '@golemui/gui-shared';
-import { testsDxModule } from './index.dx';
+import { testsDxModular, invoiceDxModular } from './index.dx';
 
-const dxMock: DxModule = testsDxModule;
+// Available Dx Modular mocks
+const dxModularMocks = {testsDxModular, invoiceDxModular};
 
 export interface DxModule {
   label: string;
@@ -41,4 +42,4 @@ export function buildModularDx(modules: DxModule[]): ModularDx {
   };
 }
 
-export const modularDx = buildModularDx([dxMock]);
+export const modularDx = buildModularDx([dxModularMocks.invoiceDxModular]);

--- a/apps/apps-shared/src/lib/mocks/tests.dx.ts
+++ b/apps/apps-shared/src/lib/mocks/tests.dx.ts
@@ -52,7 +52,7 @@ const formConfig: DxFormConfig = {
   states: { vip: '$form.isVip === true' },
 };
 
-export const testsDxModule: DxModule = {
+export const testsDxModular: DxModule = {
   label: 'Tests',
   data,
   formDef,

--- a/apps/lit-playground/src/app/pages/modular-dx/modular-dx.element.ts
+++ b/apps/lit-playground/src/app/pages/modular-dx/modular-dx.element.ts
@@ -1,17 +1,23 @@
 import { modularDx, onFormEvent } from '@golemui/apps-shared';
 import type { FormEvent, FormHealth, FormSubmitEvent } from '@golemui/core';
 import '@golemui/gui-lit';
-import { type GuiFormInitConfig } from '@golemui/gui-shared';
+import { type Dependencies, type GuiFormInitConfig } from '@golemui/gui-shared';
 import { html, LitElement, nothing } from 'lit';
 import { customElement } from 'lit/decorators.js';
+import snarkdown from 'snarkdown';
 
 const md = modularDx;
+
+const dependencies: Dependencies = {
+  markdown: { parse: (markdown: string) => snarkdown(markdown) },
+};
 
 const config: GuiFormInitConfig = {
   formDef: md.formDef,
   data: md.data,
   formSelectors: md.formSelectors,
   formConfig: md.formConfig,
+  dependencies,
 };
 
 @customElement('lit-modular-dx')

--- a/apps/react-playground/src/app/pages/modular-dx/modular-dx.page.tsx
+++ b/apps/react-playground/src/app/pages/modular-dx/modular-dx.page.tsx
@@ -1,14 +1,20 @@
 import { modularDx, onFormEvent } from '@golemui/apps-shared';
 import type { FormHealth, FormSubmitEvent } from '@golemui/core';
 import { GuiForm } from '@golemui/gui-react';
+import type { Dependencies } from '@golemui/gui-shared';
 import { useCallback, useState } from 'react';
+import snarkdown from 'snarkdown';
 
 const md = modularDx;
+const dependencies: Dependencies = {
+  markdown: { parse: (markdown: string) => snarkdown(markdown) },
+};
 const config = {
   formDef: md.formDef,
   data: md.data,
   formSelectors: md.formSelectors,
   formConfig: md.formConfig,
+  dependencies,
 };
 
 export function ModularDxPage() {

--- a/apps/vue-playground/src/app/pages/modular-dx/ModularDxPage.vue
+++ b/apps/vue-playground/src/app/pages/modular-dx/ModularDxPage.vue
@@ -2,15 +2,20 @@
 import { modularDx, onFormEvent } from '@golemui/apps-shared';
 import type { FormHealth, FormSubmitEvent } from '@golemui/core';
 import { GuiForm } from '@golemui/gui-vue';
-import type { GuiFormInitConfig } from '@golemui/gui-shared';
+import type { Dependencies, GuiFormInitConfig } from '@golemui/gui-shared';
 import { ref } from 'vue';
+import snarkdown from 'snarkdown';
 
 const md = modularDx;
+const dependencies: Dependencies = {
+  markdown: { parse: (markdown: string) => snarkdown(markdown) },
+};
 const config: GuiFormInitConfig = {
   formDef: md.formDef,
   data: md.data,
   formSelectors: md.formSelectors,
   formConfig: md.formConfig,
+  dependencies,
 };
 
 const errors = ref<string[]>([]);

--- a/libs/core/src/lib/shared.ts
+++ b/libs/core/src/lib/shared.ts
@@ -51,6 +51,14 @@ export type $Errors = {
 export type WidgetPropertyFunctionParams<FormType extends Record<string, any>> = {
   $form: ImmutableRecord<FormType>;
   translate?: I18nTranslator['translate'];
+  /**
+   * The current repeater item. Bound only when the widget is inside a repeater `props.template`, for nested repeaters it is the innermost enclosing item.
+   */
+  $item?: any;
+  /**
+   * Zero-based position of the current repeater item. Bound only when the widget is inside a repeater `props.template`.
+   */
+  $index?: number;
 };
 
 /**
@@ -65,6 +73,14 @@ export type FunctionWidgetParams<FormType> = {
   errors: ValidationStatus | undefined;
   touched: boolean | undefined;
   translate: I18nTranslator['translate'] | undefined;
+  /**
+   * The current repeater item. Bound only when the widget is inside a repeater `props.template`, for nested repeaters it is the innermost enclosing item.
+   */
+  $item?: any;
+  /**
+   * Zero-based position of the current repeater item. Bound only when the widget is inside a repeater `props.template`.
+   */
+  $index?: number;
 };
 
 /**

--- a/libs/core/src/lib/store/model.ts
+++ b/libs/core/src/lib/store/model.ts
@@ -1,5 +1,5 @@
 import { type Form, formDefDecoder } from '../form';
-import type { FormWidget, FunctionWidget } from '../form-widget';
+import type { FormWidget, FunctionWidget, NonFunctionWidget } from '../form-widget';
 import { type DotPath, type Uid, type ValidationStatus } from '../shared';
 
 // ------------------------------
@@ -67,6 +67,29 @@ export type State = {
   widgetFlags: Record<Uid, { hidden?: boolean; readonly?: boolean; disabled?: boolean }>;
 
   /**
+   * Maps every widget rendered inside a repeater item (by its materialized uid) to the repeater item that owns it.
+   * Used to bind the `$item` and `$index` expression scope variables.
+   * For nested repeaters the entry points to the innermost enclosing item.
+   * Built by `materializeRepeaterItems` on every reducer pipeline run.
+   *
+   * @example { 'quantity-number[0]': { itemPath: 'lineItems.0', index: 0 } }
+   * @example Nested repeater, keyed by the innermost item: { 'dev-name[2][0]': { itemPath: 'teams.2.devs.0', index: 0 } }
+   */
+  repeaterItemScopes: Record<Uid, RepeaterItemScope>;
+
+  /**
+   * State-managed copies of the repeater template widgets, one per repeater item, keyed by materialized uid.
+   * Each entry mirrors the widget the renderer mounts for that item:
+   * - the uid and data path carry the concrete indexes,
+   * - `when` expressions are rewritten for the item's row,
+   * - and function widgets are already resolved to plain configs.
+   * Built by `materializeRepeaterItems` on every reducer pipeline run and consumed by `calculateWidgetFlags`.
+   *
+   * @example { 'quantity-number[0]': { uid: 'quantity-number[0]', path: 'lineItems.0.quantity', ... } }
+   */
+  materializedRepeaterWidgets: Record<Uid, NonFunctionWidget<string>>;
+
+  /**
    * Allows overriding a widget’s `prop` properties externally via its event handler mechanism.
    * For example, this can be used to load options for a select widget asynchronously.
    */
@@ -120,6 +143,8 @@ export const createInitialState = (lang: string): State => ({
   injectedValidations: {},
   isFormValid: true,
   widgetFlags: {},
+  repeaterItemScopes: {},
+  materializedRepeaterWidgets: {},
   widgetPropOverrides: {},
   data: {},
   meta: {},
@@ -142,6 +167,16 @@ export type MiddlewareAPI<S, A> = {
 export type Middleware<S, A> = (
   api: MiddlewareAPI<S, A>,
 ) => (next: (action: A) => void) => (action: A) => void;
+
+/**
+ * Identifies the repeater item that owns a widget rendered inside a repeater `props.template`.
+ */
+export type RepeaterItemScope = {
+  /** Data path of the owning item, e.g. `lineItems.0` */
+  itemPath: DotPath;
+  /** Zero-based position of the owning item in the repeater array */
+  index: number;
+};
 
 /**
  * Represents the current operational state of the form.

--- a/libs/core/src/lib/store/reducer.ts
+++ b/libs/core/src/lib/store/reducer.ts
@@ -4,6 +4,7 @@ import { type I18nTranslator } from '../i18n';
 import { type ValidateOn } from '../shared';
 import { assertNever } from '../utils/assert-never';
 import { pipe } from '../utils/function';
+import { get } from '../utils/object';
 import { type Action } from './actions';
 import { type State } from './model';
 import {
@@ -13,6 +14,7 @@ import {
   calculateWidgetProps,
   initialize,
   injectValidationIssues,
+  materializeRepeaterItems,
   overrideWidgetProp,
   removeWidget,
   setData,
@@ -43,6 +45,7 @@ export const reducer =
         return pipe(
           setData(state, action),
           calculateCurrentState,
+          materializeRepeaterItems,
           calculateWidgetFlags,
           calculateWidgetProps(localization),
         );
@@ -51,6 +54,7 @@ export const reducer =
         return pipe(
           setMeta(state, action),
           calculateCurrentState,
+          materializeRepeaterItems,
           calculateWidgetFlags,
           calculateWidgetProps(localization),
         );
@@ -62,6 +66,7 @@ export const reducer =
         return pipe(
           addWidget(state, action),
           reduceIf(formIsHealthy, calculateCurrentState),
+          reduceIf(formIsHealthy, materializeRepeaterItems),
           reduceIf(formIsHealthy, calculateWidgetFlags),
           reduceIf(formIsHealthy, calculateWidgetProps(localization)),
         );
@@ -70,6 +75,7 @@ export const reducer =
         return pipe(
           removeWidget(state, action),
           calculateCurrentState,
+          materializeRepeaterItems,
           calculateWidgetFlags,
           calculateWidgetProps(localization),
         );
@@ -79,6 +85,7 @@ export const reducer =
         return pipe(
           setWidgetData(state, action),
           calculateCurrentState,
+          materializeRepeaterItems,
           calculateWidgetFlags,
           calculateWidgetProps(localization),
         );
@@ -87,6 +94,7 @@ export const reducer =
         return pipe(
           overrideWidgetProp(state, action),
           calculateCurrentState,
+          materializeRepeaterItems,
           calculateWidgetFlags,
           calculateWidgetProps(localization),
           // Apply validation here because this action can be dispatched from the form's event handlers callback
@@ -134,6 +142,7 @@ export const reducer =
           validateAll(validators, localization),
           // This handles $errors and $formIsValid expressions variables
           calculateCurrentState,
+          materializeRepeaterItems,
           calculateWidgetFlags,
           calculateWidgetProps(localization),
           calculateIsFormValid,
@@ -157,6 +166,7 @@ export const reducer =
             validateAll(validators, localization),
             // This handles $errors and $formIsValid expressions variables
             calculateCurrentState,
+            materializeRepeaterItems,
             calculateWidgetFlags,
             calculateWidgetProps(localization),
             // TODO: extract this into a separate function
@@ -166,12 +176,15 @@ export const reducer =
               const originalDerivedWidget = state.calculatedWidgets[uid];
               const originalSource = originalDerivedWidget.source;
               if (isFunctionWidget(originalSource)) {
+                const itemScope = state.repeaterItemScopes[uid];
                 // TODO: prev vs current validation comparison to avoid change detection here
                 const current = originalSource({
                   $form: state.data,
                   errors: state.validations[path],
                   touched: true,
                   translate: localization.translate,
+                  $item: itemScope ? get(state.data, itemScope.itemPath) : undefined,
+                  $index: itemScope?.index,
                 });
                 return {
                   ...state,

--- a/libs/core/src/lib/store/reducers/calculate-widget-flags.spec.ts
+++ b/libs/core/src/lib/store/reducers/calculate-widget-flags.spec.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { type FormWidget } from '../../form-widget';
+import { createInitialState, type State } from '../model';
+import { calculateWidgetFlags } from './calculate-widget-flags';
+import { materializeRepeaterItems } from './materialize-repeater-items';
+
+// -----------------------------------------------------------------------------
+// Test helpers
+// -----------------------------------------------------------------------------
+
+const displayChild = (uid: string, extra: Record<string, unknown> = {}) =>
+  ({
+    kind: 'display',
+    uid,
+    type: 'markdownText',
+    props: {},
+    ...extra,
+  }) as unknown as FormWidget<string>;
+
+const repeater = (uid: string, path: string, children: unknown[]) =>
+  ({
+    kind: 'input',
+    uid,
+    type: 'repeater',
+    path,
+    props: {
+      template: {
+        kind: 'layout',
+        uid: `${uid}-template`,
+        type: 'flex',
+        children,
+      },
+    },
+  }) as unknown as FormWidget<string>;
+
+// Flags read the maps built by the materialization stage, so run both, in pipeline order
+const runFlagsPipeline = (state: State) => calculateWidgetFlags(materializeRepeaterItems(state));
+
+describe('calculateWidgetFlags: $item / $index in item when conditions', () => {
+  let state: State;
+
+  beforeEach(() => {
+    state = createInitialState('en-US');
+  });
+
+  it('evaluates include.when with $item per item', () => {
+    state.flatForm = {
+      lineItems: repeater('lineItems', 'lineItems', [
+        displayChild('row-note', { include: { when: '$item.active === true' } }),
+      ]),
+    };
+    state.data = { lineItems: [{ active: true }, { active: false }] };
+
+    const next = runFlagsPipeline(state);
+
+    expect(next.widgetFlags['row-note[0]'].hidden).toBe(false);
+    expect(next.widgetFlags['row-note[1]'].hidden).toBe(true);
+  });
+
+  it('evaluates include.when with $index per item', () => {
+    state.flatForm = {
+      lineItems: repeater('lineItems', 'lineItems', [
+        displayChild('row-note', { include: { when: '$index === 0' } }),
+      ]),
+    };
+    state.data = { lineItems: [{}, {}] };
+
+    const next = runFlagsPipeline(state);
+
+    expect(next.widgetFlags['row-note[0]'].hidden).toBe(false);
+    expect(next.widgetFlags['row-note[1]'].hidden).toBe(true);
+  });
+
+  it('evaluates exclude.when and disabled.when with $item', () => {
+    state.flatForm = {
+      lineItems: repeater('lineItems', 'lineItems', [
+        displayChild('row-note', { exclude: { when: '$item.done === true' } }),
+        {
+          kind: 'input',
+          uid: 'row-qty',
+          type: 'number',
+          path: 'lineItems.items.quantity',
+          disabled: { when: '$item.locked === true' },
+        },
+      ]),
+    };
+    state.data = {
+      lineItems: [
+        { done: true, locked: false },
+        { done: false, locked: true },
+      ],
+    };
+
+    const next = runFlagsPipeline(state);
+
+    expect(next.widgetFlags['row-note[0]'].hidden).toBe(true);
+    expect(next.widgetFlags['row-note[1]'].hidden).toBe(false);
+    expect(next.widgetFlags['row-qty[0]'].disabled).toBe(false);
+    expect(next.widgetFlags['row-qty[1]'].disabled).toBe(true);
+  });
+
+  it('keeps the legacy items path token working alongside $item', () => {
+    state.flatForm = {
+      lineItems: repeater('lineItems', 'lineItems', [
+        displayChild('row-note', {
+          include: { when: '$form.lineItems.items.active === true' },
+        }),
+      ]),
+    };
+    state.data = { lineItems: [{ active: true }, { active: false }] };
+
+    const next = runFlagsPipeline(state);
+
+    expect(next.widgetFlags['row-note[0]'].hidden).toBe(false);
+    expect(next.widgetFlags['row-note[1]'].hidden).toBe(true);
+  });
+
+  it('creates no flag entry for repeater item widgets without reactive flags', () => {
+    state.flatForm = {
+      lineItems: repeater('lineItems', 'lineItems', [displayChild('row-note')]),
+    };
+    state.data = { lineItems: [{}, {}] };
+
+    const next = runFlagsPipeline(state);
+
+    expect(next.widgetFlags['row-note[0]']).toBeUndefined();
+    expect(next.widgetFlags['row-note[1]']).toBeUndefined();
+  });
+});

--- a/libs/core/src/lib/store/reducers/calculate-widget-flags.ts
+++ b/libs/core/src/lib/store/reducers/calculate-widget-flags.ts
@@ -1,22 +1,8 @@
-import {
-  type FormWidget,
-  type InputWidget,
-  isActionWidget,
-  isFunctionWidget,
-  isInputWidget,
-  type LayoutWidget,
-  type NonFunctionWidget,
-} from '../../form-widget';
+import { isActionWidget, isFunctionWidget, isInputWidget } from '../../form-widget';
 import { type $Errors } from '../../shared';
-import { filterMap, filterReduce, SKIP } from '../../utils/array';
-import { calculateValidationVariables, flattenForm } from '../../utils/form';
+import { calculateValidationVariables } from '../../utils/form';
 import { expressionIsTrue } from '../../utils/justin';
 import { get } from '../../utils/object';
-import {
-  makeRepeaterItemConfig,
-  toRepeaterItemUid,
-  transformRepeaterItemWhenExpression,
-} from '../../utils/repeater';
 import { type State } from '../model';
 import { hasWhen } from './utils';
 
@@ -26,10 +12,7 @@ export const calculateWidgetFlags = (state: State): State => {
 
   return {
     ...state,
-    widgetFlags: {
-      ...calculateFlags(state, $errors, $formIsInvalid),
-      ...calculateRepeaterFlags(state, $errors, $formIsInvalid),
-    },
+    widgetFlags: calculateFlags(state, $errors, $formIsInvalid),
   };
 };
 
@@ -38,24 +21,24 @@ function calculateFlags(
   $errors: $Errors,
   $formIsInvalid: boolean,
 ): State['widgetFlags'] {
-  return filterMap(Object.values(state.flatForm), (widget) => {
-    // Filters repeater items, because we process them already in calculateRepeaterFlags
-    if (!widget.uid?.includes('[')) {
-      if (isFunctionWidget(widget)) {
-        const widget_ = widget({
-          $form: state.data,
-          errors: undefined,
-          touched: undefined,
-          translate: undefined,
-        });
-        widget_.uid = widget.uid as string;
-        return widget_;
-      }
-      return widget;
-    } else {
-      return SKIP;
+  const plainWidgets = Object.values(state.flatForm).map((widget) => {
+    if (isFunctionWidget(widget)) {
+      const resolved = widget({
+        $form: state.data,
+        errors: undefined,
+        touched: undefined,
+        translate: undefined,
+      });
+      resolved.uid = widget.uid as string;
+      return resolved;
     }
-  })
+    return widget;
+  });
+
+  // Repeater item widgets come from the materialization stage: their uid is concrete, their `when` expressions are already rewritten for their item, and function widgets are already resolved
+  const repeaterItemWidgets = Object.values(state.materializedRepeaterWidgets);
+
+  return [...plainWidgets, ...repeaterItemWidgets]
     .filter((widget) => {
       if (widget.include && ('in' in widget.include || 'when' in widget.include)) {
         return true;
@@ -75,6 +58,12 @@ function calculateFlags(
       (flags, widget) => {
         flags[widget.uid] = flags[widget.uid] || {};
 
+        // Widgets inside a repeater item see that item through $item / $index
+        const itemScope = state.repeaterItemScopes[widget.uid];
+        const extraScope = itemScope
+          ? { $item: get(state.data, itemScope.itemPath), $index: itemScope.index }
+          : undefined;
+
         // show
         if (widget.include && 'in' in widget.include) {
           flags[widget.uid].hidden = !widget.include.in.some((widgetState) =>
@@ -87,6 +76,7 @@ function calculateFlags(
             state.meta,
             $errors,
             $formIsInvalid,
+            extraScope,
           );
         }
 
@@ -102,6 +92,7 @@ function calculateFlags(
             state.meta,
             $errors,
             $formIsInvalid,
+            extraScope,
           );
         }
 
@@ -117,6 +108,7 @@ function calculateFlags(
               state.meta,
               $errors,
               $formIsInvalid,
+              extraScope,
             );
           }
         }
@@ -129,6 +121,7 @@ function calculateFlags(
             state.meta,
             $errors,
             $formIsInvalid,
+            extraScope,
           );
         }
 
@@ -136,148 +129,4 @@ function calculateFlags(
       },
       {} as State['widgetFlags'],
     );
-}
-
-// -----------------------
-//
-// Repeater flags
-//
-// -----------------------
-
-// TODO: this is Golem specific. We should either move this to a middleware or make the repeater contract part of the core
-function calculateRepeaterFlags(
-  state: State,
-  $errors: $Errors,
-  $formIsInvalid: boolean,
-): State['widgetFlags'] {
-  return filterReduce(
-    Object.values(state.flatForm),
-    (w): w is NonFunctionWidget<string> => !isFunctionWidget(w) && w.type === 'repeater',
-    (flags, repeater) => ({
-      ...flags,
-      ...expandRepeaterFlags(state, repeater as RepeaterContract, [], $errors, $formIsInvalid),
-    }),
-    {} as State['widgetFlags'],
-  );
-}
-
-type RepeaterContract = InputWidget<string> & {
-  type: 'repeater';
-  props: {
-    template: LayoutWidget<string>;
-  };
-};
-
-function expandRepeaterFlags(
-  state: State,
-  repeaterWidget: RepeaterContract,
-  outerIndexes: number[],
-  $errors: $Errors,
-  $formIsInvalid: boolean,
-): State['widgetFlags'] {
-  const template = repeaterWidget.props.template;
-  const arrayData = get(state.data, (repeaterWidget as any).path as string);
-  if (!Array.isArray(arrayData)) {
-    return {};
-  }
-
-  const flags: State['widgetFlags'] = {};
-
-  arrayData.forEach((_, i) => {
-    const currentIndexes = [...outerIndexes, i];
-
-    flattenForm([template as FormWidget<never>]).forEach((widget) => {
-      let resolved: NonFunctionWidget<string>;
-      // TODO: repeater items are not decoded, so they dont have uid, type or kind!!!
-      if (isFunctionWidget(widget)) {
-        resolved = widget({
-          $form: state.data,
-          errors: undefined,
-          touched: undefined,
-          translate: undefined,
-        });
-        resolved.uid = widget.uid as string;
-      } else {
-        resolved = widget as NonFunctionWidget<string>;
-      }
-
-      if (resolved.type === 'repeater') {
-        const indexedNestedRepeater = makeRepeaterItemConfig(
-          resolved,
-          currentIndexes,
-        ) as RepeaterContract;
-        // recurse and mutate flags
-        Object.assign(
-          flags,
-          expandRepeaterFlags(
-            state,
-            indexedNestedRepeater,
-            currentIndexes,
-            $errors,
-            $formIsInvalid,
-          ),
-        );
-        return;
-      }
-
-      const uid = toRepeaterItemUid(resolved.uid, currentIndexes);
-      flags[uid] = flags[uid] || {};
-
-      // show
-      if (resolved.include && 'in' in resolved.include) {
-        flags[uid].hidden = !resolved.include.in.some((s) => state.currentStates.includes(s));
-      } else if (resolved.include && 'when' in resolved.include) {
-        flags[uid].hidden = !expressionIsTrue(
-          transformRepeaterItemWhenExpression(resolved.include.when, currentIndexes),
-          state.data,
-          state.meta,
-          $errors,
-          $formIsInvalid,
-        );
-      }
-
-      // hide
-      if (resolved.exclude && 'from' in resolved.exclude) {
-        flags[uid].hidden = resolved.exclude.from.some((s) => state.currentStates.includes(s));
-      } else if (resolved.exclude && 'when' in resolved.exclude) {
-        flags[uid].hidden = expressionIsTrue(
-          transformRepeaterItemWhenExpression(resolved.exclude.when, currentIndexes),
-          state.data,
-          state.meta,
-          $errors,
-          $formIsInvalid,
-        );
-      }
-
-      // disabled
-      if ((isInputWidget(resolved) || isActionWidget(resolved)) && hasWhen(resolved.disabled)) {
-        flags[uid].disabled = expressionIsTrue(
-          transformRepeaterItemWhenExpression(
-            (resolved.disabled as { when: string }).when,
-            currentIndexes,
-          ),
-          state.data,
-          state.meta,
-          $errors,
-          $formIsInvalid,
-        );
-      }
-
-      // readonly
-      if (isInputWidget(resolved) && hasWhen(resolved.readonly)) {
-        flags[uid].readonly = expressionIsTrue(
-          transformRepeaterItemWhenExpression(
-            (resolved.readonly as { when: string }).when,
-            currentIndexes,
-          ),
-          state.data,
-          state.meta,
-          $errors,
-          $formIsInvalid,
-        );
-      }
-    });
-  });
-
-  return flags;
 }

--- a/libs/core/src/lib/store/reducers/calculate-widget-props.spec.ts
+++ b/libs/core/src/lib/store/reducers/calculate-widget-props.spec.ts
@@ -787,6 +787,8 @@ describe('calculateWidgetProps', () => {
         children: [c1, c2],
       } satisfies LayoutWidget<string>;
       seed(state, 'row[0]', source);
+      // Live materialized widgets always carry a scope entry (built by materializeRepeaterItems)
+      state.repeaterItemScopes['row[0]'] = { itemPath: 'rows.0', index: 0 };
       state.widgetFlags['cell1[0]'] = { hidden: true };
 
       const next = run(state);
@@ -806,6 +808,8 @@ describe('calculateWidgetProps', () => {
         children: [c1, c2],
       } satisfies LayoutWidget<string>;
       seed(state, 'grid[2][3]', source);
+      // Live materialized widgets always carry a scope entry (built by materializeRepeaterItems)
+      state.repeaterItemScopes['grid[2][3]'] = { itemPath: 'grid.2.rows.3', index: 3 };
       state.widgetFlags['leaf1[2][3]'] = { hidden: true };
 
       const next = run(state);
@@ -1068,6 +1072,188 @@ describe('calculateWidgetProps', () => {
 
       expect((next.calculatedWidgets['d'].current as DisplayWidget<string>).props?.['text']).toBe(
         'true',
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // $item / $index repeater item scope
+  // ---------------------------------------------------------------------------
+
+  describe('$item / $index repeater item scope', () => {
+    const seedLineItems = () => {
+      state.data = {
+        lineItems: [
+          { quantity: 2, unitPrice: 10 },
+          { quantity: 3, unitPrice: 5 },
+        ],
+      };
+      state.repeaterItemScopes = {
+        'row-total[0]': { itemPath: 'lineItems.0', index: 0 },
+        'row-total[1]': { itemPath: 'lineItems.1', index: 1 },
+      };
+    };
+
+    it('interpolates {{$item.x}} and {{$index}} for a widget inside a repeater item', () => {
+      seedLineItems();
+      const source = {
+        kind: 'display',
+        uid: 'row-total[0]',
+        type: 'heading',
+        props: { text: 'Row {{$index + 1}}: {{($item.quantity ?? 0) * ($item.unitPrice ?? 0)}}' },
+      } satisfies DisplayWidget<string>;
+      seed(state, 'row-total[0]', source);
+
+      const next = run(state);
+
+      expect(
+        (next.calculatedWidgets['row-total[0]'].current as DisplayWidget<string>).props?.['text'],
+      ).toBe('Row 1: 20');
+    });
+
+    it('binds each widget to its own item', () => {
+      seedLineItems();
+      const makeSource = (uid: string) =>
+        ({
+          kind: 'display',
+          uid,
+          type: 'heading',
+          props: { text: '{{($item.quantity ?? 0) * ($item.unitPrice ?? 0)}}' },
+        }) satisfies DisplayWidget<string>;
+      seed(state, 'row-total[0]', makeSource('row-total[0]'));
+      seed(state, 'row-total[1]', makeSource('row-total[1]'));
+
+      const next = run(state);
+
+      expect(
+        (next.calculatedWidgets['row-total[0]'].current as DisplayWidget<string>).props?.['text'],
+      ).toBe('20');
+      expect(
+        (next.calculatedWidgets['row-total[1]'].current as DisplayWidget<string>).props?.['text'],
+      ).toBe('15');
+    });
+
+    it('pins the invoice per-row and aggregation expressions', () => {
+      seedLineItems();
+      const rowSource = {
+        kind: 'display',
+        uid: 'row-total[0]',
+        type: 'markdownText',
+        props: {
+          md: '**Total Price:** {{ (($item.quantity ?? 0) * ($item.unitPrice ?? 0)).toFixed(2) }}',
+        },
+      } satisfies DisplayWidget<string>;
+      const subtotalSource = {
+        kind: 'display',
+        uid: 'subtotal',
+        type: 'markdownText',
+        props: {
+          md: '**Subtotal:** {{($form.lineItems?.reduce((acc, item) => acc + ((item.quantity ?? 0) * (item.unitPrice ?? 0)), 0) ?? 0).toFixed(2)}}',
+        },
+      } satisfies DisplayWidget<string>;
+      seed(state, 'row-total[0]', rowSource);
+      seed(state, 'subtotal', subtotalSource);
+
+      const next = run(state);
+
+      expect(
+        (next.calculatedWidgets['row-total[0]'].current as DisplayWidget<string>).props?.['md'],
+      ).toBe('**Total Price:** 20.00');
+      expect(
+        (next.calculatedWidgets['subtotal'].current as DisplayWidget<string>).props?.['md'],
+      ).toBe('**Subtotal:** 35.00');
+    });
+
+    it('resolves $item and $index in i18n params', () => {
+      seedLineItems();
+      const source = {
+        kind: 'display',
+        uid: 'row-total[0]',
+        type: 'heading',
+        props: {
+          text: { key: 'row.total', params: { qty: '$item.quantity', row: '$index + 1' } },
+        },
+      } satisfies DisplayWidget<string>;
+      seed(state, 'row-total[0]', source);
+      const translator = makeTranslator();
+
+      run(state, translator);
+
+      expect(translator.calls[0]?.params).toEqual({ qty: 2, row: 1 });
+    });
+
+    it('passes $item and $index to a WidgetPropertyFunction prop', () => {
+      seedLineItems();
+      const source = {
+        kind: 'display',
+        uid: 'row-total[1]',
+        type: 'heading',
+        props: {
+          text: (params: any) => `Row ${params.$index}: ${params.$item.quantity}`,
+        },
+      } as unknown as DisplayWidget<string>;
+      seed(state, 'row-total[1]', source);
+
+      const next = run(state);
+
+      expect(
+        (next.calculatedWidgets['row-total[1]'].current as DisplayWidget<string>).props?.['text'],
+      ).toBe('Row 1: 3');
+    });
+
+    it('passes $item and $index to a FunctionWidget source', () => {
+      seedLineItems();
+      const source = Object.assign(
+        (params: any) =>
+          ({
+            kind: 'display',
+            uid: 'row-total[0]',
+            type: 'heading',
+            props: { text: `Row ${params?.$index}: ${params?.$item?.unitPrice}` },
+          }) as DisplayWidget<string>,
+        { uid: 'row-total[0]', type: 'heading' },
+      ) as unknown as FunctionWidget<string>;
+      seed(state, 'row-total[0]', source);
+
+      const next = run(state);
+
+      expect(
+        (next.calculatedWidgets['row-total[0]'].current as DisplayWidget<string>).props?.['text'],
+      ).toBe('Row 0: 10');
+    });
+
+    it('keeps the previous computation for a materialized uid whose item was removed', () => {
+      seedLineItems();
+      // Only item 0 remains registered in the scope map, simulating a removed row 1 whose component has not unmounted yet
+      delete state.repeaterItemScopes['row-total[1]'];
+      const source = {
+        kind: 'display',
+        uid: 'row-total[1]',
+        type: 'heading',
+        props: { text: '{{$item.quantity}}' },
+      } satisfies DisplayWidget<string>;
+      const previous = { source: source as any, current: { stale: true } as any };
+      state.calculatedWidgets['row-total[1]'] = previous;
+
+      const next = run(state);
+
+      expect(next.formHealth.status).toBe('ok');
+      expect(next.calculatedWidgets['row-total[1]']).toBe(previous);
+    });
+
+    it('leaves $item undefined for widgets outside any repeater', () => {
+      const source = {
+        kind: 'display',
+        uid: 'd',
+        type: 'heading',
+        props: { text: '{{$item?.quantity === undefined ? "no item" : "item"}}' },
+      } satisfies DisplayWidget<string>;
+      seed(state, 'd', source);
+
+      const next = run(state);
+
+      expect((next.calculatedWidgets['d'].current as DisplayWidget<string>).props?.['text']).toBe(
+        'no item',
       );
     });
   });

--- a/libs/core/src/lib/store/reducers/calculate-widget-props.ts
+++ b/libs/core/src/lib/store/reducers/calculate-widget-props.ts
@@ -22,7 +22,7 @@ import { type $Errors } from '../../shared';
 import { calculateValidationVariables } from '../../utils/form';
 import { normalizeArrayIndexes } from '../../utils/justin';
 import { get, set } from '../../utils/object';
-import { type DerivedWidget, type State } from '../model';
+import { type DerivedWidget, type RepeaterItemScope, type State } from '../model';
 import { hasWhen } from './utils';
 import { errorCodes } from '../../errors';
 
@@ -64,17 +64,30 @@ function calculateAll(state: State, localization: I18nTranslator): State['calcul
 
     const prev = state.calculatedWidgets[uid];
     const source = prev.source;
+    const itemScope = state.repeaterItemScopes[uid];
 
-    if (isFunctionWidget(source)) {
-      result[uid] = computeFunctionWidget(uid, source, state, localization);
+    // A removed repeater item leaves its widgets registered until their components unmount.
+    // Their item data is already gone, so keep the previous computation instead of evaluating expressions against it.
+    if (!itemScope && extractRepeaterIndexes(uid).length > 0) {
+      result[uid] = prev;
       continue;
     }
+
+    if (isFunctionWidget(source)) {
+      result[uid] = computeFunctionWidget(uid, source, state, localization, itemScope);
+      continue;
+    }
+
+    // Widgets inside a repeater item see that item through $item / $index
+    const widgetCtx = itemScope
+      ? { ...ctx, $item: get(ctx.$form, itemScope.itemPath), $index: itemScope.index }
+      : ctx;
 
     result[uid] = computeNonFunctionWidget(
       prev as DerivedWidget<NonFunctionWidget<string>>,
       source,
       state,
-      ctx,
+      widgetCtx,
     );
   }
 
@@ -90,12 +103,15 @@ function computeFunctionWidget(
   source: FunctionWidget<string>,
   state: State,
   localization: I18nTranslator,
+  itemScope?: RepeaterItemScope,
 ): DerivedWidget<FormWidget<string>> {
   const current = source({
     $form: state.data,
     errors: source.path ? state.validations[source.path] : undefined,
     touched: source.path ? state.touchedControls[source.path] : undefined,
     translate: localization.translate,
+    $item: itemScope ? get(state.data, itemScope.itemPath) : undefined,
+    $index: itemScope?.index,
   });
   current.uid = uid;
   // TODO: structural comparison to preserve ref when equal?
@@ -291,10 +307,20 @@ function applyOnField(t: ChangeTracker, ctx: ResolverCtx, subProp: string): void
 // Value-type resolvers - pure: (value, ctx) -> value.
 // -----------------------------------------------------------------------------
 
-type WidgetFn = (api: { $form: any; translate: I18nTranslator['translate'] }) => unknown;
+type WidgetFn = (api: {
+  $form: any;
+  translate: I18nTranslator['translate'];
+  $item?: any;
+  $index?: number;
+}) => unknown;
 
 function resolveFunctionProp(fn: WidgetFn, ctx: ResolverCtx): unknown {
-  return fn({ $form: ctx.$form, translate: ctx.localization.translate });
+  return fn({
+    $form: ctx.$form,
+    translate: ctx.localization.translate,
+    $item: ctx.$item,
+    $index: ctx.$index,
+  });
 }
 
 function resolveTranslationConfig(tc: TranslationConfig, ctx: ResolverCtx): string {
@@ -316,6 +342,8 @@ function resolveString(input: string, ctx: ResolverCtx): string {
         $meta: ctx.$meta,
         $errors: ctx.$errors,
         $formIsInvalid: ctx.$formIsInvalid,
+        $item: ctx.$item,
+        $index: ctx.$index,
       });
       return result == null ? '' : String(result);
     } catch (err) {
@@ -402,6 +430,8 @@ function isPotentialExpression(value: string): boolean {
     value.startsWith('$form') ||
     value.startsWith('$meta') ||
     value.startsWith('$errors') ||
+    value.startsWith('$item') ||
+    value.startsWith('$index') ||
     value === '$formIsInvalid'
   );
 }
@@ -428,6 +458,8 @@ function resolveI18nParams(
           $meta: ctx.$meta,
           $errors: ctx.$errors,
           $formIsInvalid: ctx.$formIsInvalid,
+          $item: ctx.$item,
+          $index: ctx.$index,
         });
         acc[key] = result ?? param;
       } catch (err) {
@@ -490,6 +522,10 @@ interface ResolverCtx {
   $formIsInvalid: boolean;
   $errors: $Errors;
   localization: I18nTranslator;
+  /** Set only for widgets inside a repeater item: the item object itself */
+  $item?: unknown;
+  /** Set only for widgets inside a repeater item: the item's position. */
+  $index?: number;
 }
 
 function makeResolverCtx(

--- a/libs/core/src/lib/store/reducers/index.ts
+++ b/libs/core/src/lib/store/reducers/index.ts
@@ -4,6 +4,7 @@ export { calculateWidgetFlags } from './calculate-widget-flags';
 export { calculateWidgetProps } from './calculate-widget-props';
 export { initialize } from './initialize';
 export { injectValidationIssues } from './inject-validation-issues';
+export { materializeRepeaterItems } from './materialize-repeater-items';
 export { overrideWidgetProp } from './override-widget-prop';
 export { removeWidget } from './remove-widget';
 export { setData } from './set-data';

--- a/libs/core/src/lib/store/reducers/materialize-repeater-items.spec.ts
+++ b/libs/core/src/lib/store/reducers/materialize-repeater-items.spec.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { type FormWidget, type FunctionWidget } from '../../form-widget';
+import { createInitialState, type State } from '../model';
+import { materializeRepeaterItems } from './materialize-repeater-items';
+
+// -----------------------------------------------------------------------------
+// Test helpers
+// -----------------------------------------------------------------------------
+
+const displayChild = (uid: string, extra: Record<string, unknown> = {}) =>
+  ({
+    kind: 'display',
+    uid,
+    type: 'markdownText',
+    props: {},
+    ...extra,
+  }) as unknown as FormWidget<string>;
+
+const inputChild = (uid: string, path: string, extra: Record<string, unknown> = {}) =>
+  ({
+    kind: 'input',
+    uid,
+    type: 'number',
+    path,
+    props: {},
+    ...extra,
+  }) as unknown as FormWidget<string>;
+
+const repeater = (uid: string, path: string, children: unknown[]) =>
+  ({
+    kind: 'input',
+    uid,
+    type: 'repeater',
+    path,
+    props: {
+      template: {
+        kind: 'layout',
+        uid: `${uid}-template`,
+        type: 'flex',
+        children,
+      },
+    },
+  }) as unknown as FormWidget<string>;
+
+describe('materializeRepeaterItems: repeater item scopes', () => {
+  let state: State;
+
+  beforeEach(() => {
+    state = createInitialState('en-US');
+  });
+
+  it('builds a scope entry for every template descendant of every item', () => {
+    state.flatForm = {
+      lineItems: repeater('lineItems', 'lineItems', [displayChild('row-note')]),
+    };
+    state.data = { lineItems: [{ active: true }, { active: false }] };
+
+    const next = materializeRepeaterItems(state);
+
+    expect(next.repeaterItemScopes['row-note[0]']).toEqual({
+      itemPath: 'lineItems.0',
+      index: 0,
+    });
+    expect(next.repeaterItemScopes['row-note[1]']).toEqual({
+      itemPath: 'lineItems.1',
+      index: 1,
+    });
+    // The template root layout is a descendant too.
+    expect(next.repeaterItemScopes['lineItems-template[0]']).toEqual({
+      itemPath: 'lineItems.0',
+      index: 0,
+    });
+  });
+
+  it('gives nested repeater descendants the innermost item scope', () => {
+    state.flatForm = {
+      teams: repeater('teams', 'teams', [
+        repeater('devs', 'teams.items.devs', [displayChild('dev-name')]),
+      ]),
+    };
+    state.data = {
+      teams: [{ devs: [{ firstName: 'Alice' }, { firstName: 'Bob' }] }],
+    };
+
+    const next = materializeRepeaterItems(state);
+
+    // The nested repeater widget itself belongs to the outer item
+    expect(next.repeaterItemScopes['devs[0]']).toEqual({ itemPath: 'teams.0', index: 0 });
+    // Its template descendants belong to the inner items
+    expect(next.repeaterItemScopes['dev-name[0][0]']).toEqual({
+      itemPath: 'teams.0.devs.0',
+      index: 0,
+    });
+    expect(next.repeaterItemScopes['dev-name[0][1]']).toEqual({
+      itemPath: 'teams.0.devs.1',
+      index: 1,
+    });
+  });
+
+  it('produces an empty scope map when the repeater data is not an array', () => {
+    state.flatForm = {
+      lineItems: repeater('lineItems', 'lineItems', [displayChild('row-note')]),
+    };
+    state.data = {};
+
+    const next = materializeRepeaterItems(state);
+
+    expect(next.repeaterItemScopes).toEqual({});
+    expect(next.materializedRepeaterWidgets).toEqual({});
+  });
+
+  it('rebuilds both maps from scratch on every run', () => {
+    state.flatForm = {
+      lineItems: repeater('lineItems', 'lineItems', [displayChild('row-note')]),
+    };
+    state.data = { lineItems: [{}, {}] };
+    state.repeaterItemScopes = {
+      'stale[9]': { itemPath: 'lineItems.9', index: 9 },
+    };
+    state.materializedRepeaterWidgets = {
+      'stale[9]': displayChild('stale[9]') as never,
+    };
+
+    const next = materializeRepeaterItems(state);
+
+    expect(next.repeaterItemScopes['stale[9]']).toBeUndefined();
+    expect(next.materializedRepeaterWidgets['stale[9]']).toBeUndefined();
+    expect(next.repeaterItemScopes['row-note[0]']).toBeDefined();
+    expect(next.repeaterItemScopes['row-note[1]']).toBeDefined();
+  });
+});
+
+describe('materializeRepeaterItems: materialized widgets', () => {
+  let state: State;
+
+  beforeEach(() => {
+    state = createInitialState('en-US');
+  });
+
+  it('bakes the item indexes into uid and input path', () => {
+    state.flatForm = {
+      lineItems: repeater('lineItems', 'lineItems', [
+        inputChild('row-qty', 'lineItems.items.quantity'),
+      ]),
+    };
+    state.data = { lineItems: [{}, {}] };
+
+    const next = materializeRepeaterItems(state);
+
+    expect(next.materializedRepeaterWidgets['row-qty[0]']).toMatchObject({
+      uid: 'row-qty[0]',
+      path: 'lineItems.0.quantity',
+    });
+    expect(next.materializedRepeaterWidgets['row-qty[1]']).toMatchObject({
+      uid: 'row-qty[1]',
+      path: 'lineItems.1.quantity',
+    });
+  });
+
+  it('rewrites items path tokens in when expressions per item', () => {
+    state.flatForm = {
+      lineItems: repeater('lineItems', 'lineItems', [
+        displayChild('row-note', {
+          include: { when: '$form.lineItems.items.active === true' },
+        }),
+      ]),
+    };
+    state.data = { lineItems: [{}, {}] };
+
+    const next = materializeRepeaterItems(state);
+
+    expect(next.materializedRepeaterWidgets['row-note[0]']).toMatchObject({
+      include: { when: '$form.lineItems.0.active === true' },
+    });
+    expect(next.materializedRepeaterWidgets['row-note[1]']).toMatchObject({
+      include: { when: '$form.lineItems.1.active === true' },
+    });
+  });
+
+  it('resolves function widgets once per item with $item and $index', () => {
+    const functionWidget: FunctionWidget<string> = (api) =>
+      ({
+        kind: 'display',
+        type: 'markdownText',
+        props: { md: `${api?.$index}:${(api?.$item as { name: string } | undefined)?.name}` },
+      }) as never;
+    functionWidget.uid = 'row-note' as never;
+    state.flatForm = {
+      lineItems: repeater('lineItems', 'lineItems', [functionWidget]),
+    };
+    state.data = { lineItems: [{ name: 'a' }, { name: 'b' }] };
+
+    const next = materializeRepeaterItems(state);
+
+    expect(next.materializedRepeaterWidgets['row-note[0]']).toMatchObject({
+      uid: 'row-note[0]',
+      props: { md: '0:a' },
+    });
+    expect(next.materializedRepeaterWidgets['row-note[1]']).toMatchObject({
+      uid: 'row-note[1]',
+      props: { md: '1:b' },
+    });
+  });
+
+  it('keeps nested repeater containers out of the widget map but in the scope map', () => {
+    state.flatForm = {
+      teams: repeater('teams', 'teams', [
+        repeater('devs', 'teams.items.devs', [displayChild('dev-name')]),
+      ]),
+    };
+    state.data = { teams: [{ devs: [{}] }] };
+
+    const next = materializeRepeaterItems(state);
+
+    expect(next.repeaterItemScopes['devs[0]']).toBeDefined();
+    expect(next.materializedRepeaterWidgets['devs[0]']).toBeUndefined();
+    expect(next.materializedRepeaterWidgets['dev-name[0][0]']).toBeDefined();
+  });
+});

--- a/libs/core/src/lib/store/reducers/materialize-repeater-items.ts
+++ b/libs/core/src/lib/store/reducers/materialize-repeater-items.ts
@@ -1,0 +1,102 @@
+import {
+  type FormWidget,
+  type InputWidget,
+  isFunctionWidget,
+  type LayoutWidget,
+  type NonFunctionWidget,
+} from '../../form-widget';
+import { flattenForm } from '../../utils/form';
+import { get } from '../../utils/object';
+import {
+  makeRepeaterItemConfig,
+  toRepeaterItemUid,
+  transformWidgetWhenExpressions,
+} from '../../utils/repeater';
+import { type State } from '../model';
+
+/**
+ * Walks every repeater's live array data and derives, per item, the same concrete widgets the renderer mounts for that item.
+ * Produces two maps keyed by materialized uid, both rebuilt from scratch on every run:
+ * - `repeaterItemScopes`: which item owns each widget (binds `$item` / `$index`).
+ * - `materializedRepeaterWidgets`: the item-concrete widget configs, with uid and path baked, `when` expressions rewritten for the item's row, and function widgets resolved.
+ *
+ * `calculateWidgetFlags` and `calculateWidgetProps` consume these maps, so this stage must run before them in the pipeline.
+ */
+// TODO: this is Golem specific. We should either move this to a middleware or make the repeater contract part of the core
+export const materializeRepeaterItems = (state: State): State => {
+  const scopes: State['repeaterItemScopes'] = {};
+  const widgets: State['materializedRepeaterWidgets'] = {};
+
+  const repeaters = Object.values(state.flatForm).filter(
+    (w): w is RepeaterContract => !isFunctionWidget(w) && w.type === 'repeater',
+  );
+  for (const repeater of repeaters) {
+    expandRepeaterItems(state, repeater, [], scopes, widgets);
+  }
+
+  return { ...state, repeaterItemScopes: scopes, materializedRepeaterWidgets: widgets };
+};
+
+type RepeaterContract = InputWidget<string> & {
+  type: 'repeater';
+  props: {
+    template: LayoutWidget<string>;
+  };
+};
+
+function expandRepeaterItems(
+  state: State,
+  repeaterWidget: RepeaterContract,
+  outerIndexes: number[],
+  scopes: State['repeaterItemScopes'],
+  widgets: State['materializedRepeaterWidgets'],
+): void {
+  const template = repeaterWidget.props.template;
+  const arrayData = get(state.data, (repeaterWidget as any).path as string);
+  if (!Array.isArray(arrayData)) {
+    return;
+  }
+
+  arrayData.forEach((item, i) => {
+    const currentIndexes = [...outerIndexes, i];
+    // For nested recursion the repeater widget is already materialized, so its path is concrete.
+    const itemScope = { itemPath: `${(repeaterWidget as any).path}.${i}`, index: i };
+
+    flattenForm([template as FormWidget<never>]).forEach((widget) => {
+      let resolved: NonFunctionWidget<string>;
+      // TODO: repeater items are not decoded, so they dont have uid, type or kind!!!
+      if (isFunctionWidget(widget)) {
+        resolved = widget({
+          $form: state.data,
+          $item: item,
+          $index: i,
+          errors: undefined,
+          touched: undefined,
+          translate: undefined,
+        });
+        resolved.uid = widget.uid as string;
+      } else {
+        resolved = widget as NonFunctionWidget<string>;
+      }
+
+      if (resolved.type === 'repeater') {
+        const indexedNestedRepeater = makeRepeaterItemConfig(
+          resolved,
+          currentIndexes,
+        ) as RepeaterContract;
+        // The nested repeater widget itself belongs to the outer item; its template children get innermost entries from the recursion below.
+        // The container is not added to the widget map, so its own `when` flags are never evaluated (same as before this stage existed).
+        scopes[toRepeaterItemUid(resolved.uid, currentIndexes)] = itemScope;
+        expandRepeaterItems(state, indexedNestedRepeater, currentIndexes, scopes, widgets);
+        return;
+      }
+
+      const materialized = transformWidgetWhenExpressions(
+        makeRepeaterItemConfig(resolved, currentIndexes),
+        currentIndexes,
+      );
+      scopes[materialized.uid] = itemScope;
+      widgets[materialized.uid] = materialized;
+    });
+  });
+}

--- a/libs/core/src/lib/utils/justin.spec.ts
+++ b/libs/core/src/lib/utils/justin.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { expressionIsTrue } from './justin';
+import { expressionIsTrue, normalizeArrayIndexes } from './justin';
 
 describe('justin', () => {
   const $form = {
@@ -105,6 +105,87 @@ describe('justin', () => {
       expect(expressionIsTrue('$errors.address.street !== null', {}, {}, $errors, false)).toBe(
         true,
       );
+    });
+  });
+
+  describe('normalizeArrayIndexes', () => {
+    it('converts dot numeric indexes to bracket notation', () => {
+      expect(normalizeArrayIndexes('$form.teams.1.developers?.0?.firstName')).toBe(
+        '$form.teams[1].developers?.[0]?.firstName',
+      );
+    });
+
+    it('converts consecutive numeric indexes', () => {
+      expect(normalizeArrayIndexes('$form.matrix.1.0.value')).toBe('$form.matrix[1][0].value');
+    });
+
+    it('converts an index after an identifier ending in a digit', () => {
+      expect(normalizeArrayIndexes('$form.item2.0.name')).toBe('$form.item2[0].name');
+    });
+
+    it('keeps decimal number literals untouched', () => {
+      expect(normalizeArrayIndexes('35 * 0.02')).toBe('35 * 0.02');
+      expect(normalizeArrayIndexes("$form.x === 'EUR' ? 0.15 : 0.02")).toBe(
+        "$form.x === 'EUR' ? 0.15 : 0.02",
+      );
+      expect(normalizeArrayIndexes('0.5')).toBe('0.5');
+    });
+
+    it('keeps a leading-dot decimal untouched', () => {
+      expect(normalizeArrayIndexes('$form.total * .5')).toBe('$form.total * .5');
+    });
+
+    it('handles indexes and decimals in the same expression', () => {
+      expect(normalizeArrayIndexes('$form.lineItems.0.unitPrice * 1.15')).toBe(
+        '$form.lineItems[0].unitPrice * 1.15',
+      );
+    });
+
+    it('evaluates a decimal multiplication end to end', () => {
+      expect(
+        expressionIsTrue('($form.subtotal ?? 0) * 0.5 === 17.5', { subtotal: 35 }, {}, {}, false),
+      ).toBe(true);
+    });
+  });
+
+  describe('expressionIsTrue with $item / $index extra scope', () => {
+    const extraScope = { $item: { quantity: 2, unitPrice: 10 }, $index: 1 };
+
+    it('reads an $item property', () => {
+      expect(expressionIsTrue('$item.quantity === 2', {}, {}, {}, false, extraScope)).toBe(true);
+    });
+
+    it('computes with $item values', () => {
+      expect(
+        expressionIsTrue('$item.quantity * $item.unitPrice === 20', {}, {}, {}, false, extraScope),
+      ).toBe(true);
+    });
+
+    it('reads $index', () => {
+      expect(expressionIsTrue('$index === 1', {}, {}, {}, false, extraScope)).toBe(true);
+    });
+
+    it('guards a missing $item leaf with nullish coalescing', () => {
+      expect(expressionIsTrue('($item.missing ?? 0) === 0', {}, {}, {}, false, extraScope)).toBe(
+        true,
+      );
+    });
+
+    it('combines $item with $form in a single expression', () => {
+      expect(
+        expressionIsTrue(
+          '$item.quantity === 2 && $form.teams.0.developers.0.firstName === "Alice"',
+          $form,
+          {},
+          {},
+          false,
+          extraScope,
+        ),
+      ).toBe(true);
+    });
+
+    it('treats $item as undefined when no extra scope is provided', () => {
+      expect(expressionIsTrue('$item?.quantity === undefined', {}, {}, {}, false)).toBe(true);
     });
   });
 

--- a/libs/core/src/lib/utils/justin.ts
+++ b/libs/core/src/lib/utils/justin.ts
@@ -3,6 +3,14 @@ import { type $Errors, type ReactiveExpression } from '../shared';
 import { type State } from '../store/model';
 import { Debug } from './debug';
 
+/**
+ * Extra scope variables available to expressions evaluated inside a repeater `props.template`: the current item object and its position
+ */
+export type RepeaterItemExpressionScope = {
+  $item?: unknown;
+  $index?: number;
+};
+
 // TODO: caching or memoization
 export function expressionIsTrue(
   expression: ReactiveExpression,
@@ -10,6 +18,7 @@ export function expressionIsTrue(
   $meta: State['meta'],
   $errors: $Errors,
   $formIsInvalid: boolean,
+  extraScope?: RepeaterItemExpressionScope,
 ): boolean {
   const ast = parse(normalizeArrayIndexes(expression));
   const evaluate = compile(ast);
@@ -19,6 +28,7 @@ export function expressionIsTrue(
     $errors,
     $formIsInvalid,
     $log: Debug.log,
+    ...extraScope,
   });
   return result === true;
 }
@@ -26,6 +36,42 @@ export function expressionIsTrue(
 // TODO: add a fast-path conditional to shortcircuit the regexp. Is it worth it?
 // Converts dot notation numeric indexes to bracket notation for JS compatibility.
 // e.g. '$form.teams.1.developers?.0?.firstName' -> '$form.teams[1].developers?.[0]?.firstName'
+// Decimal number literals are left untouched: '0.15' stays '0.15'.
 export function normalizeArrayIndexes(expression: string): string {
-  return expression.replace(/\?\.(\d+)/g, '?.[$1]').replace(/\.(\d+)/g, '[$1]');
+  return expression.replace(
+    /(\?\.|\.)(\d+)/g,
+    (match, dot: string, digits: string, offset: number) => {
+      if (dot === '.' && isDecimalPoint(expression, offset)) {
+        return match;
+      }
+      return dot === '?.' ? `?.[${digits}]` : `[${digits}]`;
+    },
+  );
+}
+
+// Decides whether the dot at `dotIndex` is the decimal point of a number
+// literal ('0.15', '* .5') rather than a path index separator ('teams.1',
+// 'teams.1.0', 'item2.0').
+function isDecimalPoint(expression: string, dotIndex: number): boolean {
+  let i = dotIndex - 1;
+  let hasDigitsBefore = false;
+  while (i >= 0 && expression[i] >= '0' && expression[i] <= '9') {
+    hasDigitsBefore = true;
+    i--;
+  }
+  if (i < 0) {
+    // The expression starts with a number ('0.15') or a bare decimal ('.5').
+    return true;
+  }
+  const charBeforeNumber = expression[i];
+  if (hasDigitsBefore) {
+    // Digits before the dot are a path segment when they follow another dot
+    // ('teams.1.0') or an identifier tail ('item2.0'); otherwise they are the
+    // integer part of a number literal ('35 * 0.02').
+    return !/[\w$.\]]/.test(charBeforeNumber);
+  }
+  // No digits before the dot: member access on an identifier, call result or
+  // index result keeps index behavior ('teams.1'); anything else is a
+  // leading-dot decimal ('* .5').
+  return !/[\w$)\]]/.test(charBeforeNumber);
 }

--- a/libs/core/src/lib/utils/repeater.spec.ts
+++ b/libs/core/src/lib/utils/repeater.spec.ts
@@ -1,10 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { isInputWidget, type NonFunctionWidget } from '../form-widget';
-import { makeRepeaterItemConfig, transformRepeaterItemWhenExpression } from './repeater';
+import { isInputWidget, type FunctionWidget, type NonFunctionWidget } from '../form-widget';
+import {
+  makeRepeaterItemConfig,
+  transformRepeaterItemWhenExpression,
+  transformWidgetWhenExpressions,
+} from './repeater';
 
-// Mock the external dependency to easily control the execution branch
+// Mock the external dependency to easily control the execution branch.
+// isFunctionWidget keeps its real behavior so function widgets take their branch.
 vi.mock('../form-widget', () => ({
   isInputWidget: vi.fn(),
+  isFunctionWidget: vi.fn((widget: unknown) => typeof widget === 'function'),
 }));
 
 describe('makeRepeaterItemConfig', () => {
@@ -61,6 +67,46 @@ describe('makeRepeaterItemConfig', () => {
         uid: 'user-address-street[1][3]',
         path: 'users.1.addresses.3.street',
       });
+    });
+  });
+
+  describe('Function widgets', () => {
+    it('should wrap the function so it stays callable and materialize uid, type and path', () => {
+      vi.mocked(isInputWidget).mockReturnValue(false);
+
+      const resolvedWidget = { kind: 'display', type: 'markdownText' };
+      const original = Object.assign(
+        vi.fn(() => resolvedWidget),
+        { uid: 'row-total', type: 'markdownText', path: 'users.items.total' },
+      ) as unknown as FunctionWidget<string>;
+
+      const result = makeRepeaterItemConfig(original, [1]) as FunctionWidget<string>;
+
+      expect(typeof result).toBe('function');
+      expect(result).not.toBe(original);
+      expect(result.uid).toBe('row-total[1]');
+      expect(result.type).toBe('markdownText');
+      expect(result.path).toBe('users.1.total');
+
+      const api = { $form: {}, errors: undefined, touched: undefined, translate: undefined };
+      expect(result(api)).toBe(resolvedWidget);
+      expect(original).toHaveBeenCalledWith(api);
+
+      // Ensure the original function was not mutated
+      expect(original.uid).toBe('row-total');
+      expect(original.path).toBe('users.items.total');
+    });
+
+    it('should not materialize a path when the function widget has none', () => {
+      const original = Object.assign(vi.fn(), {
+        uid: 'fn-widget',
+        type: 'markdownText',
+      }) as unknown as FunctionWidget<string>;
+
+      const result = makeRepeaterItemConfig(original, [0]) as FunctionWidget<string>;
+
+      expect(result.uid).toBe('fn-widget[0]');
+      expect(result.path).toBeUndefined();
     });
   });
 
@@ -144,5 +190,62 @@ describe('transformRepeaterItemWhenExpression', () => {
         'users.1?.addresses.items?.active',
       );
     });
+  });
+});
+
+describe('transformWidgetWhenExpressions', () => {
+  it('should rewrite the when expression of every reactive flag field', () => {
+    const widget = {
+      uid: 'row-qty[1]',
+      include: { when: '$form.users.items.active' },
+      exclude: { when: '$form.users.items.done' },
+      disabled: { when: '$form.users.items.locked' },
+      readonly: { when: '$form.users.items.frozen' },
+    } as unknown as NonFunctionWidget<string>;
+
+    const result = transformWidgetWhenExpressions(widget, [1]);
+
+    expect(result).toEqual({
+      uid: 'row-qty[1]',
+      include: { when: '$form.users.1.active' },
+      exclude: { when: '$form.users.1.done' },
+      disabled: { when: '$form.users.1.locked' },
+      readonly: { when: '$form.users.1.frozen' },
+    });
+    // Ensure the original widget and its flag objects were not mutated
+    expect(result).not.toBe(widget);
+    expect((widget as { include?: { when: string } }).include?.when).toBe(
+      '$form.users.items.active',
+    );
+  });
+
+  it('should leave state-based and boolean flag fields untouched', () => {
+    const widget = {
+      uid: 'row-note[0]',
+      include: { in: ['editing'] },
+      exclude: { from: ['summary'] },
+      disabled: true,
+    } as unknown as NonFunctionWidget<string>;
+
+    const result = transformWidgetWhenExpressions(widget, [0]);
+
+    expect(result).toEqual({
+      uid: 'row-note[0]',
+      include: { in: ['editing'] },
+      exclude: { from: ['summary'] },
+      disabled: true,
+    });
+  });
+
+  it('should return an equivalent widget when no flag field is present', () => {
+    const widget = {
+      uid: 'row-note[0]',
+      props: { md: 'hello' },
+    } as unknown as NonFunctionWidget<string>;
+
+    const result = transformWidgetWhenExpressions(widget, [0]);
+
+    expect(result).toEqual(widget);
+    expect(result).not.toBe(widget);
   });
 });

--- a/libs/core/src/lib/utils/repeater.ts
+++ b/libs/core/src/lib/utils/repeater.ts
@@ -1,24 +1,53 @@
-import { isInputWidget, type NonFunctionWidget } from '../form-widget';
+import {
+  type FormWidget,
+  type FunctionWidget,
+  isFunctionWidget,
+  isInputWidget,
+  type NonFunctionWidget,
+} from '../form-widget';
 import { type DotPath, type Uid } from '../shared';
 
 /**
- * Derives a concrete widget config for a specific repeater item by stamping
- * the provided indexes into the widget's `uid` (and `path` for input widgets).
+ * Derives a concrete widget config for a specific repeater item by materializing the provided indexes into the
+ * widget's `uid` (and `path` for input widgets).
+ *
+ * Function widgets are wrapped in a new function that delegates to the original, so they stay callable while
+ * carrying the materialized `uid` and `path`.
  *
  * @param widget - The base widget config defined on the repeater template.
- * @param repeaterIndexes - Ordered list of indexes for each nesting level,
- *   e.g. `[2, 0]` for the first item of a nested repeater inside the third
- *   item of an outer repeater.
- * @returns A new widget config with the indexes baked in; the original is not mutated.
+ * @param repeaterIndexes - Ordered list of indexes for each nesting level
+ *   e.g. `[2, 0]` for the first item of a nested repeater inside the third item of an outer repeater.
+ * @returns A new widget config with the indexes baked in. The original is not mutated.
  *
  * @example
  * makeRepeaterItemConfig(widget, [1]) // { uid: 'user-name[1]', path: 'users.1.name' }
+ *
+ * @example
+ * // Nested repeater: the first item of an inner repeater inside the third item of the outer one.
+ * makeRepeaterItemConfig(widget, [2, 0]) // { uid: 'dev-name[2][0]', path: 'teams.2.devs.0.name' }
  */
 export function makeRepeaterItemConfig(
   widget: NonFunctionWidget<string>,
   repeaterIndexes: number[],
-): NonFunctionWidget<string> {
-  const uid = toRepeaterItemUid(widget.uid, repeaterIndexes);
+): NonFunctionWidget<string>;
+export function makeRepeaterItemConfig(
+  widget: FormWidget<string>,
+  repeaterIndexes: number[],
+): FormWidget<string>;
+export function makeRepeaterItemConfig(
+  widget: FormWidget<string>,
+  repeaterIndexes: number[],
+): FormWidget<string> {
+  const uid = toRepeaterItemUid(widget.uid as Uid, repeaterIndexes);
+  if (isFunctionWidget(widget)) {
+    const materialized: FunctionWidget<string> = (api) => widget(api);
+    materialized.uid = uid;
+    materialized.type = widget.type;
+    if (widget.path !== undefined) {
+      materialized.path = toRepeaterItemPath(widget.path, repeaterIndexes);
+    }
+    return materialized;
+  }
   if (isInputWidget(widget)) {
     return {
       ...widget,
@@ -92,4 +121,50 @@ export function transformRepeaterItemWhenExpression(
     }
     return `.${index}${optionalChaining}.`;
   });
+}
+
+const WHEN_FIELDS = ['include', 'exclude', 'disabled', 'readonly'] as const;
+
+/**
+ * Returns a copy of a repeater item widget whose reactive flag conditions
+ * (`include.when`, `exclude.when`, `disabled.when`, `readonly.when`) are rewritten
+ * for a concrete item via {@link transformRepeaterItemWhenExpression}.
+ *
+ * State-based flags (`include.in`, `exclude.from`) carry no expression and are left untouched.
+ *
+ * @param widget - A widget already materialized for a repeater item (see {@link makeRepeaterItemConfig}).
+ * @param repeaterIndexes - Ordered list of indexes for each nesting level.
+ * @returns A new widget config with item-concrete `when` expressions. The original is not mutated.
+ *
+ * @example
+ * // repeaterIndexes = [1]
+ * // { include: { when: '$form.lineItems.items.active' } }
+ * //   -> { include: { when: '$form.lineItems.1.active' } }
+ */
+export function transformWidgetWhenExpressions(
+  widget: NonFunctionWidget<string>,
+  repeaterIndexes: number[],
+): NonFunctionWidget<string> {
+  const transformed = { ...widget } as Record<string, unknown>;
+
+  for (const field of WHEN_FIELDS) {
+    const value = transformed[field];
+    if (hasWhenExpression(value)) {
+      transformed[field] = {
+        ...value,
+        when: transformRepeaterItemWhenExpression(value.when, repeaterIndexes),
+      };
+    }
+  }
+
+  return transformed as NonFunctionWidget<string>;
+}
+
+function hasWhenExpression(value: unknown): value is { when: string } {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    'when' in value &&
+    typeof (value as { when: unknown }).when === 'string'
+  );
 }

--- a/libs/gui/mcp/src/dx/dx-lint.ts
+++ b/libs/gui/mcp/src/dx/dx-lint.ts
@@ -61,7 +61,7 @@ export function lintDxSnippet(ts: typeof TS, sourceText: string, lineOffset: num
     return ts.isIdentifier(e) && e.text === 'gui';
   };
 
-  const visit = (node: TS.Node): void => {
+  const visit = (node: TS.Node, inTemplate: boolean): void => {
     // (1) Misplaced common field as a sibling of a `gui.*` spread.
     if (ts.isObjectLiteralExpression(node)) {
       const spreadsGui = node.properties.some(
@@ -99,14 +99,21 @@ export function lintDxSnippet(ts: typeof TS, sourceText: string, lineOffset: num
       ts.isStringLiteralLike(node.initializer)
     ) {
       const { line, column } = posOf(node.initializer);
-      for (const f of checkReactiveExpression(node.initializer.text, `when@${line}:${column}`)) {
+      const findings = checkReactiveExpression(node.initializer.text, `when@${line}:${column}`, {
+        inRepeaterTemplate: inTemplate,
+      });
+      for (const f of findings) {
         expressionWarnings.push(f);
       }
     }
 
-    ts.forEachChild(node, visit);
+    // A repeater's `template:` subtree gets the `$item`/`$index` scope; the flag
+    // is sticky so nested templates inherit it (innermost semantics).
+    const childInTemplate =
+      inTemplate || (ts.isPropertyAssignment(node) && nameOf(node.name) === 'template');
+    ts.forEachChild(node, (child) => visit(child, childInTemplate));
   };
 
-  visit(sf);
+  visit(sf, false);
   return { diagnostics, expressionWarnings };
 }

--- a/libs/gui/mcp/src/json/string-interpolation.ts
+++ b/libs/gui/mcp/src/json/string-interpolation.ts
@@ -16,18 +16,24 @@ export type InterpolationFinding = {
  */
 export function lintStringInterpolations(formDefinition: unknown): InterpolationFinding[] {
   const findings: InterpolationFinding[] = [];
-  walk(formDefinition, '', findings);
+  walk(formDefinition, '', findings, false, false);
   return findings;
 }
 
 const SLOT_REGEX = /\{\{([^}]*(?:\}[^}]+)*)\}\}/g;
 
-function walk(node: unknown, path: string, out: InterpolationFinding[]): void {
+function walk(
+  node: unknown,
+  path: string,
+  out: InterpolationFinding[],
+  inTemplate: boolean,
+  propsOfRepeater: boolean,
+): void {
   if (node === null || typeof node !== 'object') {
     return;
   }
   if (Array.isArray(node)) {
-    node.forEach((item, i) => walk(item, `${path}/${i}`, out));
+    node.forEach((item, i) => walk(item, `${path}/${i}`, out, inTemplate, false));
     return;
   }
   const obj = node as Record<string, unknown>;
@@ -53,9 +59,12 @@ function walk(node: unknown, path: string, out: InterpolationFinding[]): void {
     }
     const childPath = `${path}/${key}`;
     if (typeof value === 'string') {
-      checkTemplate(value, childPath, out);
+      checkTemplate(value, childPath, out, inTemplate);
     } else {
-      walk(value, childPath, out);
+      // A repeater's `props.template` subtree gets the `$item`/`$index` scope.
+      // The flag is sticky so nested templates inherit it (innermost semantics).
+      const childInTemplate = inTemplate || (propsOfRepeater && key === 'template');
+      walk(value, childPath, out, childInTemplate, obj['type'] === 'repeater' && key === 'props');
     }
   }
 }
@@ -80,7 +89,12 @@ function checkParamExpression(value: string, path: string, out: InterpolationFin
   }
 }
 
-function checkTemplate(value: string, path: string, out: InterpolationFinding[]): void {
+function checkTemplate(
+  value: string,
+  path: string,
+  out: InterpolationFinding[],
+  inTemplate: boolean,
+): void {
   // S3 — unbalanced delimiters: count {{ and }} occurrences
   const openCount = (value.match(/\{\{/g) ?? []).length;
   const closeCount = (value.match(/\}\}/g) ?? []).length;
@@ -101,11 +115,17 @@ function checkTemplate(value: string, path: string, out: InterpolationFinding[])
   while ((match = SLOT_REGEX.exec(value)) !== null) {
     const slot = match[0];
     const expr = match[1];
-    checkSlot(expr, slot, path, out);
+    checkSlot(expr, slot, path, out, inTemplate);
   }
 }
 
-function checkSlot(expr: string, slot: string, path: string, out: InterpolationFinding[]): void {
+function checkSlot(
+  expr: string,
+  slot: string,
+  path: string,
+  out: InterpolationFinding[],
+  inTemplate: boolean,
+): void {
   const trimmed = expr.trim();
 
   // S1 — empty slot
@@ -131,14 +151,25 @@ function checkSlot(expr: string, slot: string, path: string, out: InterpolationF
   }
 
   // S2 — missing scope reference
-  if (!/\$form\b|\$meta\b|\$errors\b|\$formIsInvalid\b/.test(trimmed)) {
+  const referencesItemScope = /\$item\b|\$index\b/.test(trimmed);
+  const hasGlobalRoot = /\$form\b|\$meta\b|\$errors\b|\$formIsInvalid\b/.test(trimmed);
+  if (referencesItemScope && !inTemplate) {
+    out.push({
+      path,
+      slot,
+      message:
+        'Interpolation slot references `$item` or `$index`, which are only available inside a repeater `props.template`.',
+      suggestion:
+        'Move the widget inside the repeater template, or read the data through `$form` (e.g. `$form.lineItems?.[0]?.quantity`).',
+    });
+  } else if (!hasGlobalRoot && !(inTemplate && referencesItemScope)) {
     out.push({
       path,
       slot,
       message:
         'Interpolation slot does not reference `$form`, `$meta`, `$errors`, or `$formIsInvalid`.',
       suggestion:
-        'GolemUI template slots read data via `$form.fieldName`, metadata via `$meta.key`, validation errors via `$errors.fieldName`, or the built-in `$formIsInvalid` boolean.',
+        'GolemUI template slots read data via `$form.fieldName`, metadata via `$meta.key`, validation errors via `$errors.fieldName`, or the built-in `$formIsInvalid` boolean. Inside a repeater `props.template` the current item is available via `$item` and its position via `$index`.',
     });
   }
 

--- a/libs/gui/mcp/src/json/validate-form-definition.spec.ts
+++ b/libs/gui/mcp/src/json/validate-form-definition.spec.ts
@@ -450,14 +450,107 @@ describe('json_validate_form_definition', () => {
       // The ref `$form.x` here is operand of `??`, not `>`. The wrapper `(... ?? 0)` is what's > 180.
       expect(has(r, /comparison or arithmetic/)).toBe(false);
     });
-    it('flags `$index > 0` for missing root reference, not comparison/arithmetic', () => {
+    it('flags `$index > 0` outside a repeater template, not comparison/arithmetic', () => {
       const r = validateFormDefinition(formWith('$index > 0'));
-      expect(has(r, /does not reference/)).toBe(true);
+      expect(has(r, /only available inside a repeater/)).toBe(true);
+      expect(has(r, /does not reference/)).toBe(false);
       expect(has(r, /comparison or arithmetic/)).toBe(false);
     });
     it('does not flag a guarded comparison', () => {
       const r = validateFormDefinition(formWith('$form.size !== undefined && $form.size > 180'));
       expect(has(r, /comparison or arithmetic/)).toBe(false);
+    });
+  });
+
+  describe('$item / $index repeater template scope', () => {
+    const repeaterFormWith = (when: string, md = '## Row') => ({
+      formDefinition: {
+        form: [
+          {
+            kind: 'input',
+            type: 'repeater',
+            path: 'lineItems',
+            props: {
+              template: {
+                kind: 'layout',
+                type: 'flex',
+                props: { direction: 'column' },
+                children: [
+                  {
+                    kind: 'display',
+                    type: 'markdownText',
+                    props: { md },
+                    include: { when },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    it('accepts `$item` in a `when` inside a repeater template', () => {
+      const r = validateFormDefinition(repeaterFormWith('$item.quantity !== undefined'));
+      expect(has(r, /only available inside a repeater/)).toBe(false);
+      expect(has(r, /does not reference/)).toBe(false);
+    });
+
+    it('accepts `$index` in a `when` inside a repeater template', () => {
+      const r = validateFormDefinition(repeaterFormWith('$index === 0'));
+      expect(has(r, /only available inside a repeater/)).toBe(false);
+      expect(has(r, /does not reference/)).toBe(false);
+    });
+
+    it('accepts `$item` in an interpolation slot inside a repeater template', () => {
+      const r = validateFormDefinition(
+        repeaterFormWith(
+          '$item.quantity !== undefined',
+          '**Total:** {{(($item.quantity ?? 0) * ($item.unitPrice ?? 0)).toFixed(2)}}',
+        ),
+      );
+      expect(
+        r.interpolationWarnings.some((w) => /only available inside a repeater/.test(w.message)),
+      ).toBe(false);
+      expect(r.interpolationWarnings.some((w) => /does not reference/.test(w.message))).toBe(false);
+    });
+
+    it('flags `$item` in a `when` outside a repeater template', () => {
+      const r = validateFormDefinition(formWith('$item.quantity !== undefined'));
+      expect(has(r, /only available inside a repeater/)).toBe(true);
+      expect(has(r, /does not reference/)).toBe(false);
+    });
+
+    it('flags `$item` in an interpolation slot outside a repeater template', () => {
+      const r = validateFormDefinition({
+        formDefinition: {
+          form: [
+            {
+              kind: 'display',
+              type: 'markdownText',
+              props: { md: '{{$item.quantity}}' },
+            },
+          ],
+        },
+      });
+      expect(
+        r.interpolationWarnings.some((w) => /only available inside a repeater/.test(w.message)),
+      ).toBe(true);
+    });
+
+    it('flags `$item` in a `states` expression (global scope)', () => {
+      const r = validateFormDefinition({
+        formDefinition: {
+          states: { hasQuantity: '$item.quantity !== undefined' },
+          form: [{ kind: 'input', type: 'textinput', path: 'x' }],
+        },
+      });
+      expect(has(r, /only available inside a repeater/)).toBe(true);
+    });
+
+    it('applies the defensive rules to `$item` references inside templates', () => {
+      const r = validateFormDefinition(repeaterFormWith('!$item.done'));
+      expect(has(r, /negates a `\$form/)).toBe(true);
     });
   });
 

--- a/libs/gui/mcp/src/shared/get-concept.ts
+++ b/libs/gui/mcp/src/shared/get-concept.ts
@@ -367,6 +367,7 @@ const STRING_INTERPOLATION_CONCEPT: GetConceptResult = {
 
   rules: [
     'Slots must reference at least one of `$form`, `$meta`, `$errors`, or `$formIsInvalid`. A bare identifier without a scope prefix is invalid inside `{{}}`: use `{{$form.name}}` not `{{name}}`. `$formIsInvalid` is a bare boolean — do not chain properties onto it.',
+    'Inside a repeater `props.template`, slots can additionally reference `$item` (the current repeater item object) and `$index` (its zero-based position): `{{($item.quantity ?? 0) * ($item.unitPrice ?? 0)}}`. Outside a template, `$item`/`$index` are undefined and invalid.',
     'If an expression evaluates to `null` or `undefined`, the slot renders as an empty string in display text.',
     'Use optional chaining (`?.`) when accessing nested fields that may not yet exist: `{{$form.address?.city}}` not `{{$form.address.city}}`.',
     'Do not use assignment `=` inside a slot — slots are read-only. Use `===` for equality checks.',
@@ -386,9 +387,11 @@ const REACTIVE_SCOPE_CONCEPT: GetConceptResult = {
   concept: 'reactive-scope',
   summary:
     'GolemUI reactive expressions (used in `states`, `include.when`, `exclude.when`, and `{{}}` template slots) ' +
-    'share a common read-only scope object. The scope exposes four variables: ' +
+    'share a common read-only scope object. The scope exposes four global variables: ' +
     '`$form` (live form data), `$meta` (host-supplied metadata), `$errors` (validation error messages), ' +
     'and `$formIsInvalid` (built-in boolean). ' +
+    'Inside a repeater `props.template` two more variables are available: ' +
+    '`$item` (the current repeater item object) and `$index` (its zero-based position). ' +
     'All variables are read-only — expressions can only read from them, never write to them.',
 
   patterns: [
@@ -506,10 +509,60 @@ const REACTIVE_SCOPE_CONCEPT: GetConceptResult = {
         },
       },
     },
+    {
+      name: '$item / $index — current repeater item (template scope only)',
+      description:
+        '`$item` is the data object of the repeater item a widget belongs to, and `$index` is that ' +
+        "item's zero-based position in the array. They are available ONLY to widgets inside a " +
+        'repeater `props.template` — in `include`/`exclude`/`disabled`/`readonly` `when` conditions, ' +
+        '`{{}}` template slots, and i18n params. Outside a template they are `undefined` and the ' +
+        'linter flags them. For nested repeaters, `$item`/`$index` refer to the INNERMOST enclosing ' +
+        'item; to address an outer level, use the `items` path token through `$form` instead ' +
+        '(e.g. `$form.teams.items.name` resolves against each item of the `teams` repeater). ' +
+        '`$item` leaf values may be `undefined` while the user fills in the row, so guard them; ' +
+        '`$index` is always a defined number.',
+      example: {
+        $schema: 'https://golemui.com/schemas/form.schema.json',
+        form: [
+          {
+            kind: 'input',
+            type: 'repeater',
+            path: 'lineItems',
+            label: 'Line Items',
+            props: {
+              template: {
+                kind: 'layout',
+                type: 'flex',
+                props: { direction: 'column' },
+                children: [
+                  {
+                    kind: 'input',
+                    type: 'number',
+                    path: 'lineItems.items.quantity',
+                    label: 'Quantity {{$index + 1}}',
+                  },
+                  {
+                    kind: 'display',
+                    type: 'markdownText',
+                    props: {
+                      md: '**Total:** {{(($item.quantity ?? 0) * ($item.unitPrice ?? 0)).toFixed(2)}}',
+                    },
+                    include: { when: '$item.quantity !== undefined' },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    },
   ],
 
   rules: [
-    'All four scope variables are read-only. Expressions may only read values, never assign them.',
+    'All scope variables are read-only. Expressions may only read values, never assign them.',
+    '`$item` and `$index` exist only for widgets inside a repeater `props.template`. In `states` and in widgets outside a template they are undefined and invalid.',
+    'For nested repeaters `$item`/`$index` bind to the innermost enclosing item. Use the `items` path token through `$form` to address outer levels.',
+    '`$item` leaf values (`$item.someField`) may be `undefined` until the user fills them in — guard with `??` or explicit comparisons. `$index` is always a defined number.',
     '`$form` is always a defined object. Its leaf values (`$form.someField`) may be `undefined` until the user fills them in.',
     'Use optional chaining (`?.`) at every intermediate segment of a nested path. `$form.address?.city` is safe; `$form.address.city` throws if `address` is undefined.',
     'A widget\'s `path` value maps directly to a `$form` key path using the same dot segments. `path: "shipping.address.zip"` -> `$form.shipping?.address?.zip`.',

--- a/libs/gui/mcp/src/shared/lint/reactive-expressions.ts
+++ b/libs/gui/mcp/src/shared/lint/reactive-expressions.ts
@@ -18,9 +18,17 @@ export type ExpressionFinding = {
  */
 export function lintReactiveExpressions(formDefinition: unknown): ExpressionFinding[] {
   const findings: ExpressionFinding[] = [];
-  walk(formDefinition, '', findings);
+  walk(formDefinition, '', findings, false, false);
   return findings;
 }
+
+export type CheckExpressionOptions = {
+  /**
+   * True when the expression lives inside a repeater `props.template`, where the
+   * `$item` and `$index` scope variables are available.
+   */
+  inRepeaterTemplate?: boolean;
+};
 
 /**
  * Lint a single reactive expression string in isolation, against the same rules
@@ -29,16 +37,26 @@ export function lintReactiveExpressions(formDefinition: unknown): ExpressionFind
  * object tree, the DX linter has the AST — both funnel each `when` expression
  * through here so the two surfaces can never drift.
  */
-export function checkReactiveExpression(expression: string, path = ''): ExpressionFinding[] {
+export function checkReactiveExpression(
+  expression: string,
+  path = '',
+  options: CheckExpressionOptions = {},
+): ExpressionFinding[] {
   const out: ExpressionFinding[] = [];
-  checkExpression(expression, path, out);
+  checkExpression(expression, path, out, options.inRepeaterTemplate === true);
   return out;
 }
 
-function walk(node: unknown, path: string, out: ExpressionFinding[]): void {
+function walk(
+  node: unknown,
+  path: string,
+  out: ExpressionFinding[],
+  inTemplate: boolean,
+  propsOfRepeater: boolean,
+): void {
   if (node === null || typeof node !== 'object') return;
   if (Array.isArray(node)) {
-    node.forEach((item, i) => walk(item, `${path}/${i}`, out));
+    node.forEach((item, i) => walk(item, `${path}/${i}`, out, inTemplate, false));
     return;
   }
   const obj = node as Record<string, unknown>;
@@ -49,16 +67,17 @@ function walk(node: unknown, path: string, out: ExpressionFinding[]): void {
     if (child && typeof child === 'object' && 'when' in (child as object)) {
       const expr = (child as { when: unknown }).when;
       if (typeof expr === 'string') {
-        checkExpression(expr, `${path}/${key}/when`, out);
+        checkExpression(expr, `${path}/${key}/when`, out, inTemplate);
       }
     }
   }
 
   // states map: { someState: '...expression...' }
+  // States are global scope, so `$item`/`$index` are never available here.
   if (path === '' && obj['states'] && typeof obj['states'] === 'object') {
     for (const [name, expr] of Object.entries(obj['states'] as Record<string, unknown>)) {
       if (typeof expr === 'string') {
-        checkExpression(expr, `/states/${name}`, out);
+        checkExpression(expr, `/states/${name}`, out, false);
       }
     }
   }
@@ -68,16 +87,24 @@ function walk(node: unknown, path: string, out: ExpressionFinding[]): void {
     if (v && typeof v === 'object' && !Array.isArray(v) && 'when' in (v as object)) {
       const expr = (v as { when: unknown }).when;
       if (typeof expr === 'string' && k !== 'include' && k !== 'exclude') {
-        checkExpression(expr, `${path}/${k}/when`, out);
+        checkExpression(expr, `${path}/${k}/when`, out, inTemplate);
       }
     }
     if (typeof v === 'object' && v !== null) {
-      walk(v, `${path}/${k}`, out);
+      // A repeater's `props.template` subtree gets the `$item`/`$index` scope.
+      // The flag is sticky so nested templates inherit it (innermost semantics).
+      const childInTemplate = inTemplate || (propsOfRepeater && k === 'template');
+      walk(v, `${path}/${k}`, out, childInTemplate, obj['type'] === 'repeater' && k === 'props');
     }
   }
 }
 
-function checkExpression(expr: string, path: string, out: ExpressionFinding[]): void {
+function checkExpression(
+  expr: string,
+  path: string,
+  out: ExpressionFinding[],
+  inTemplate: boolean,
+): void {
   const trimmed = expr.trim();
   if (!trimmed) {
     out.push({ path, expression: expr, message: 'Expression is empty.' });
@@ -113,13 +140,25 @@ function checkExpression(expr: string, path: string, out: ExpressionFinding[]): 
   //   $form           — form data
   //   $meta           — user-supplied form metadata (e.g. systemMessage, connectionStatus)
   //   $formIsInvalid  — boolean; true when any field currently fails validation
-  if (!/\$form\b|\$meta\b|\$formIsInvalid\b/.test(trimmed)) {
+  //   $item / $index  — current repeater item and its position; only inside a repeater `props.template`
+  const referencesItemScope = /\$item\b|\$index\b/.test(trimmed);
+  const hasGlobalRoot = /\$form\b|\$meta\b|\$formIsInvalid\b/.test(trimmed);
+  if (referencesItemScope && !inTemplate) {
+    out.push({
+      path,
+      expression: expr,
+      message:
+        'Expression references `$item` or `$index`, which are only available inside a repeater `props.template`.',
+      suggestion:
+        'Move the widget inside the repeater template, or read the data through `$form` (e.g. `$form.lineItems?.[0]?.quantity`).',
+    });
+  } else if (!hasGlobalRoot && !(inTemplate && referencesItemScope)) {
     out.push({
       path,
       expression: expr,
       message: 'Expression does not reference `$form`, `$meta`, or `$formIsInvalid`.',
       suggestion:
-        'GolemUI expressions read form data via `$form.fieldName`, form metadata via `$meta.key`, or the built-in `$formIsInvalid` boolean. Did you forget the prefix?',
+        'GolemUI expressions read form data via `$form.fieldName`, form metadata via `$meta.key`, or the built-in `$formIsInvalid` boolean. Inside a repeater `props.template` the current item is available via `$item` and its position via `$index`. Did you forget the prefix?',
     });
   }
 
@@ -160,13 +199,15 @@ function checkExpression(expr: string, path: string, out: ExpressionFinding[]): 
     });
   }
 
-  // R2: negation of a `$form`/`$meta` reference (`!$form.x`).
+  // R2: negation of a `$form`/`$meta`/`$item` reference (`!$form.x`).
   // The lookbehind/lookahead exclude `!=` and `!==` operators.
-  if (/(?<![=!])!\s*\$(?:form|meta)\b/.test(trimmed)) {
+  // `$index` is exempt from the defensive rules: it is always a defined number.
+  if (/(?<![=!])!\s*\$(?:form|meta|item)\b/.test(trimmed)) {
     out.push({
       path,
       expression: expr,
-      message: 'Expression negates a `$form`/`$meta` reference (relies on truthy/falsy coercion).',
+      message:
+        'Expression negates a `$form`/`$meta`/`$item` reference (relies on truthy/falsy coercion).',
       suggestion:
         'Form data values can be `undefined`. Pick the case you actually mean and write it explicitly — `$form.x === undefined`, `$form.x === null`, `$form.x === 0`, `$form.x === ""` — instead of `!$form.x`.',
     });
@@ -175,7 +216,7 @@ function checkExpression(expr: string, path: string, out: ExpressionFinding[]): 
   // R3: chained nested-property access without optional chaining.
   // For each `$root.<chain>` match, split the chain on `.` and walk segment pairs.
   // A transition from segments[i] to segments[i+1] is safe iff segments[i] ends with `?`.
-  const refChainRe = /\$(?:form|meta)\b((?:\.[\w?]+)*)/g;
+  const refChainRe = /\$(?:form|meta|item)\b((?:\.[\w?]+)*)/g;
   let chainFlagged = false;
   let chainMatch: RegExpExecArray | null;
   while ((chainMatch = refChainRe.exec(trimmed)) !== null) {
@@ -207,9 +248,9 @@ function checkExpression(expr: string, path: string, out: ExpressionFinding[]): 
   //   (a) the whole expression is a bare reference (`$form.x`)
   //   (b) reference followed by `&&` / `||` / ternary `?` (and not `??` or `?.`)
   //   (c) `&&` / `||` followed by a trailing reference at the end of the expression
-  const refOnly = /^\$(?:form|meta)(?:\.[\w?]+)*$/;
-  const refBeforeBool = /\$(?:form|meta)(?:\.[\w?]+)*\s*(?:&&|\|\||\?(?![.?]))/;
-  const refAfterBool = /(?:&&|\|\|)\s*\$(?:form|meta)(?:\.[\w?]+)*\s*$/;
+  const refOnly = /^\$(?:form|meta|item)(?:\.[\w?]+)*$/;
+  const refBeforeBool = /\$(?:form|meta|item)(?:\.[\w?]+)*\s*(?:&&|\|\||\?(?![.?]))/;
+  const refAfterBool = /(?:&&|\|\|)\s*\$(?:form|meta|item)(?:\.[\w?]+)*\s*$/;
   if (refOnly.test(trimmed) || refBeforeBool.test(trimmed) || refAfterBool.test(trimmed)) {
     out.push({
       path,
@@ -230,7 +271,7 @@ function checkExpression(expr: string, path: string, out: ExpressionFinding[]): 
   // the unsafe operator, assume the LHS is the guard (`$form.x !== undefined && $form.x > 180`
   // idiom) and skip. This produces occasional false negatives but no false positives on the
   // common guarding pattern.
-  const refForCmpRe = /\$(?:form|meta)(?:\.[\w?]+)+/g;
+  const refForCmpRe = /\$(?:form|meta|item)(?:\.[\w?]+)+/g;
   let r5Flagged = false;
   let cmpMatch: RegExpExecArray | null;
   while ((cmpMatch = refForCmpRe.exec(trimmed)) !== null) {

--- a/libs/gui/schemas/src/lib/components/repeater.schema.json
+++ b/libs/gui/schemas/src/lib/components/repeater.schema.json
@@ -20,7 +20,7 @@
       "description": "Maximum number of items the user can add. No limit when omitted."
     },
     "templateProp": {
-      "description": "Widget tree used as the template for each repeated item. Paths inside are resolved relative to the item's index in the array.",
+      "description": "Widget tree used as the template for each repeated item. Paths inside are resolved relative to the item's index in the array. Widgets inside the template can reference the current item in reactive expressions ('when' conditions, '{{}}' interpolation slots, and i18n params) through the scope variables '$item' (the item object, e.g. '$item.quantity') and '$index' (the item's zero-based position). For nested repeaters these bind to the innermost enclosing item.",
       "$ref": "../layout-widget.schema.json"
     },
     "titleProp": {

--- a/libs/react/src/lib/WidgetRenderer.tsx
+++ b/libs/react/src/lib/WidgetRenderer.tsx
@@ -38,7 +38,12 @@ function WidgetRenderer(props: Props) {
         const loadedComponent = await formContext.widgetRegistry.loadWidget(props.widget.type);
         if (isMounted.current) {
           if (repeaterIndexes.length > 0) {
-            setWidget(makeRepeaterItemConfig(cloneObject(props.widget), repeaterIndexes));
+            const materializedWidget = makeRepeaterItemConfig(
+              cloneObject(props.widget),
+              repeaterIndexes,
+            );
+            // Wrapped in a closure to avoid being treated as a setState updater function!
+            setWidget(() => materializedWidget);
           }
           setComponent(() => loadedComponent);
         }

--- a/libs/ui-testing/src/lib/golem-features/repeater.cy.ts
+++ b/libs/ui-testing/src/lib/golem-features/repeater.cy.ts
@@ -455,6 +455,224 @@ export const runRepeaterComponentTests = (mountFn: MountComponentFn) => {
         cy.get('[id="companyStatusAlert[0]"]').should('contain.text', 'Company is Msoft');
       });
 
+      it('should interpolate $item and $index independently per repeater item', () => {
+        const LINE_ITEMS_PATH = 'lineItems';
+        const getItemScopeFormDefinition = () =>
+          defineForm({
+            form: [
+              {
+                uid: 'lineItemsRepeater',
+                kind: 'input',
+                type: 'repeater',
+                path: LINE_ITEMS_PATH,
+                props: {
+                  addLabel: 'Add line item',
+                  removeLabel: 'Remove line item',
+                  template: {
+                    kind: 'layout',
+                    type: 'flex',
+                    children: [
+                      {
+                        uid: 'qty',
+                        kind: 'input',
+                        type: 'textinput',
+                        path: `${LINE_ITEMS_PATH}.items.quantity`,
+                        label: 'Quantity',
+                      },
+                      {
+                        uid: 'rowTotal',
+                        kind: 'display',
+                        type: 'alert',
+                        props: {
+                          level: 'success',
+                          text: 'Row {{$index + 1}} total: {{($item.quantity ?? 0) * 2}}',
+                        },
+                        include: { when: '$item.quantity !== undefined' },
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+          });
+
+        mountFn({
+          data: { lineItems: [{ quantity: 2 }, { quantity: 5 }, {}] },
+          formDef: getItemScopeFormDefinition(),
+        });
+
+        // Each row reads its own $item and $index
+        cy.get('[id="rowTotal[0]"]').should('contain.text', 'Row 1 total: 4');
+        cy.get('[id="rowTotal[1]"]').should('contain.text', 'Row 2 total: 10');
+        // include.when with $item: quantity is undefined on the third item
+        cy.get('[id="rowTotal[2]"]').should('not.exist');
+
+        // Typing in row 1 must only affect row 1's total
+        cy.get('[data-cy="qty[1]_textinput"]').clear();
+        cy.get('[data-cy="qty[1]_textinput"]').type('7');
+        cy.get('[id="rowTotal[1]"]').should('contain.text', 'Row 2 total: 14');
+        cy.get('[id="rowTotal[0]"]').should('contain.text', 'Row 1 total: 4');
+
+        // Removing row 0 rebinds $item/$index: the old row 1 becomes row 0
+        cy.get('.gui-button').contains('Remove line item').first().click();
+        cy.get('[id="rowTotal[0]"]').should('contain.text', 'Row 1 total: 14');
+        cy.get('[id="rowTotal[1]"]').should('not.exist');
+      });
+
+      it('should render markdownText displays with $item interpolation inside repeater items', () => {
+        const LINE_ITEMS_PATH = 'invoiceLines';
+        const getMarkdownItemScopeFormDefinition = () =>
+          defineForm({
+            form: [
+              {
+                uid: 'invoiceLinesRepeater',
+                kind: 'input',
+                type: 'repeater',
+                path: LINE_ITEMS_PATH,
+                props: {
+                  addLabel: 'Add invoice line',
+                  removeLabel: 'Remove invoice line',
+                  template: {
+                    kind: 'layout',
+                    type: 'flex',
+                    children: [
+                      {
+                        uid: 'lineQty',
+                        kind: 'input',
+                        type: 'textinput',
+                        path: `${LINE_ITEMS_PATH}.items.quantity`,
+                        label: 'Quantity',
+                      },
+                      {
+                        uid: 'lineTotalMd',
+                        kind: 'display',
+                        type: 'markdownText',
+                        props: {
+                          md: 'Row {{$index + 1}} total: {{($item.quantity ?? 0) * 2}}',
+                        },
+                        include: { when: '$item.quantity !== undefined' },
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+          });
+
+        mountFn({
+          data: { invoiceLines: [{ quantity: 2 }, {}] },
+          formDef: getMarkdownItemScopeFormDefinition(),
+          // The markdown widget renders nothing without a parser; a passthrough
+          // parser keeps the test dependency-free while still proving the
+          // dependency reaches the component and the interpolated text renders.
+          dependencies: { markdown: { parse: (markdown) => markdown } },
+        });
+
+        // Interpolated $item/$index content must actually render in the DOM
+        cy.get('[id="lineTotalMd[0]"]').should('contain.text', 'Row 1 total: 4');
+        // include.when with $item: quantity is undefined on the second item
+        cy.get('[id="lineTotalMd[1]"]').should('not.exist');
+
+        // Editing the row updates the rendered markdown
+        cy.get('[data-cy="lineQty[0]_textinput"]').clear();
+        cy.get('[data-cy="lineQty[0]_textinput"]').type('5');
+        cy.get('[id="lineTotalMd[0]"]').should('contain.text', 'Row 1 total: 10');
+      });
+
+      it('should scope $item and $index to the innermost item in nested repeaters', () => {
+        const ORDERS_PATH = 'orders';
+        const LINES_PATH = `${ORDERS_PATH}.items.lines`;
+        const getNestedItemScopeFormDefinition = () =>
+          defineForm({
+            form: [
+              {
+                uid: 'orderRepeater',
+                kind: 'input',
+                type: 'repeater',
+                path: ORDERS_PATH,
+                props: {
+                  addLabel: 'Add order',
+                  removeLabel: 'Remove order',
+                  template: {
+                    kind: 'layout',
+                    type: 'flex',
+                    children: [
+                      {
+                        uid: 'customer',
+                        kind: 'input',
+                        type: 'textinput',
+                        path: `${ORDERS_PATH}.items.customer`,
+                        label: 'Customer',
+                      },
+                      {
+                        uid: 'lineRepeater',
+                        kind: 'input',
+                        type: 'repeater',
+                        path: LINES_PATH,
+                        props: {
+                          addLabel: 'Add line',
+                          removeLabel: 'Remove line',
+                          template: {
+                            kind: 'layout',
+                            type: 'flex',
+                            children: [
+                              {
+                                uid: 'qty',
+                                kind: 'input',
+                                type: 'textinput',
+                                path: `${LINES_PATH}.items.quantity`,
+                                label: 'Quantity',
+                              },
+                              {
+                                uid: 'lineSubtotal',
+                                kind: 'display',
+                                type: 'alert',
+                                props: {
+                                  level: 'success',
+                                  text: 'Line {{$index + 1}} subtotal: {{($item.quantity ?? 0) * ($item.price ?? 0)}}',
+                                },
+                                include: { when: '$item.quantity !== undefined' },
+                              },
+                            ],
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+          });
+
+        mountFn({
+          data: {
+            orders: [
+              {
+                customer: 'Acme',
+                lines: [{ quantity: 2, price: 10 }, { quantity: 1, price: 5 }, {}],
+              },
+              { customer: 'Globex', lines: [{ quantity: 3, price: 4 }] },
+            ],
+          },
+          formDef: getNestedItemScopeFormDefinition(),
+        });
+
+        // $item and $index are the innermost line, so each line reads its own values.
+        // $index restarts at 0 inside every order's line repeater.
+        cy.get('[id="lineSubtotal[0][0]"]').should('contain.text', 'Line 1 subtotal: 20');
+        cy.get('[id="lineSubtotal[0][1]"]').should('contain.text', 'Line 2 subtotal: 5');
+        // The first line of the second order is index 0 again and reads its own $item (3 * 4).
+        cy.get('[id="lineSubtotal[1][0]"]').should('contain.text', 'Line 1 subtotal: 12');
+        // include.when with $item: the third line of the first order has no quantity
+        cy.get('[id="lineSubtotal[0][2]"]').should('not.exist');
+
+        // Typing in the second order's line only affects that line's subtotal
+        cy.get('[data-cy="qty[1][0]_textinput"]').clear();
+        cy.get('[data-cy="qty[1][0]_textinput"]').type('10');
+        cy.get('[id="lineSubtotal[1][0]"]').should('contain.text', 'Line 1 subtotal: 40');
+        cy.get('[id="lineSubtotal[0][0]"]').should('contain.text', 'Line 1 subtotal: 20');
+      });
+
       it('should evaluate index-aware include.when expressions independently per repeater item', () => {
         mountFn({
           data: {


### PR DESCRIPTION
## Description

Widgets inside a repeater's `props.template` can now reference the row they render for through two scope variables:

- `$item`: the current array element
- `$index`: its zero-based position

They work everywhere expressions do: 
- reactive `when` conditions (`include` / `exclude` / `disabled` / `readonly`)
- `{{ }}` interpolation
- i18n params
- dx callback params

Nested repeaters are supported. `$item` / `$index` always mean the innermost enclosing row.

## Example

```ts
gui.inputs.repeater('lineItems', {
  template: [
    gui.inputs.numberInput('lineItems.items.quantity', { label: 'Quantity' }),
    gui.inputs.currency('lineItems.items.unitPrice', { label: 'Unit Price' }),

    // Each rendered row computes its own total from its own data.
    gui.displays.markdownText({
      md: '**Total**  \n{{ (($item.quantity ?? 0) * ($item.unitPrice ?? 0)).toFixed(2) }}',
      include: { when: '$item.quantity !== undefined' },
    }),
  ],
});
```

`$index` reads the same way, e.g. a row label `{{ $index + 1 }}`.
