### PR TITLE
fix(gui-components): Fix select widget height

### DIFF
--- a/apps/apps-shared/src/lib/mocks/modular.dx.ts
+++ b/apps/apps-shared/src/lib/mocks/modular.dx.ts
@@ -8,7 +8,7 @@ import { gui } from '@golemui/gui-shared';
 import { testsDxModular, invoiceDxModular } from './index.dx';
 
 // Available Dx Modular mocks
-const dxModularMocks = {testsDxModular, invoiceDxModular};
+const dxModularMocks = { testsDxModular, invoiceDxModular };
 
 export interface DxModule {
   label: string;

--- a/libs/gui/components/src/styles/select.scss
+++ b/libs/gui/components/src/styles/select.scss
@@ -3,7 +3,12 @@ gui-select {
 
   .gui-widget {
     select {
-      height: 42px;
+      box-sizing: content-box;
+      appearance: none;
+
+      &.gui-select--icon {
+        padding-inline-start: 2.5rem;
+      }
     }
 
     .gui-select__arrow {
@@ -14,13 +19,6 @@ gui-select {
       inset-inline-end: var(--gui-space-3);
       transform-origin: 50% 40%;
       pointer-events: none;
-    }
-    select {
-      appearance: none;
-
-      &.gui-select--icon {
-        padding-inline-start: 2.5rem;
-      }
     }
   }
 }


### PR DESCRIPTION
Select tags box-sizing is border-box, we have to set content-box which is the default in other widgets, otherwise the height of select widgets is `40px` instead of `42px`.