### PR TITLE
fix(gui-validators): make initValidators fail loudly on unknown configs

### DIFF
--- a/apps/apps-shared/src/lib/mocks/tabs/rangedatetimecalendar.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/rangedatetimecalendar.form-chunk.json
@@ -77,6 +77,7 @@
       "path": "rangeDateTimeCalendarValidation",
       "label": "Required (validation)",
       "validator": {
+        "type": "array",
         "required": true
       },
       "props": {

--- a/apps/apps-shared/src/lib/mocks/tabs/rangedatetimepicker.form-chunk.json
+++ b/apps/apps-shared/src/lib/mocks/tabs/rangedatetimepicker.form-chunk.json
@@ -77,6 +77,7 @@
       "path": "rangeDateTimePickerValidation",
       "label": "Required (validation)",
       "validator": {
+        "type": "array",
         "required": true
       },
       "props": {

--- a/libs/gui/mcp/tools/generate-skill-refs.ts
+++ b/libs/gui/mcp/tools/generate-skill-refs.ts
@@ -63,7 +63,9 @@ export function buildDxReference(): string {
     lines.push(`- ${setup[fw]}`);
   }
   lines.push('');
-  lines.push('Every example below is compile-checked against the real `@golemui` type declarations.');
+  lines.push(
+    'Every example below is compile-checked against the real `@golemui` type declarations.',
+  );
   lines.push('');
 
   // Factory index — the whole surface up front, so the reader knows every real name and
@@ -147,10 +149,17 @@ export function buildWidgetsIndex(): string {
     lines.push('');
     for (const [, factories] of [...rows.entries()].sort(([a], [b]) => a.localeCompare(b))) {
       const s = DX_SPECS[factories[0].split('.')[2]];
-      lines.push(`- ${factories.map((f) => `\`${f}\``).join(', ')} — ${dxDocUrl(s)} (json: ${dxDocUrl(s, 'json')})`);
+      lines.push(
+        `- ${factories.map((f) => `\`${f}\``).join(', ')} — ${dxDocUrl(s)} (json: ${dxDocUrl(s, 'json')})`,
+      );
     }
     const overview = `${DOCS_BASE}/dx/widgets-reference/${
-      { inputs: 'input-fields', actions: 'interactive-fields', displays: 'display-fields', layouts: 'layout-fields' }[ns]
+      {
+        inputs: 'input-fields',
+        actions: 'interactive-fields',
+        displays: 'display-fields',
+        layouts: 'layout-fields',
+      }[ns]
     }/overview.md`;
     lines.push(`- Category overview — ${overview}`);
     lines.push('');

--- a/libs/gui/validators/src/lib/validators.spec.ts
+++ b/libs/gui/validators/src/lib/validators.spec.ts
@@ -7,6 +7,7 @@ import {
   initValidators,
   type NumberValidator,
   type StringValidator,
+  type Validator,
 } from './validators';
 
 const validate = initValidators();
@@ -397,6 +398,13 @@ describe('Golem validators', () => {
 
     it('throws when no customValidators are provided', () => {
       expect(() => validate({ type: 'custom', minAge: 18 })).toThrow();
+    });
+  });
+
+  describe('unknown validator config', () => {
+    it('throws a descriptive error when the config has no known type', () => {
+      const typelessConfig = { required: true } as unknown as Validator;
+      expect(() => validate(typelessConfig)).toThrow(/Unknown validator config/);
     });
   });
 

--- a/libs/gui/validators/src/lib/validators.ts
+++ b/libs/gui/validators/src/lib/validators.ts
@@ -140,6 +140,13 @@ export const initValidators =
         }
         return fromCustomValidator(validator, customValidators);
       }
+
+      default: {
+        const unknownValidator: never = validator;
+        throw new Error(
+          `Unknown validator config: ${JSON.stringify(unknownValidator)}. The "type" property must be one of: "string", "number", "integer", "boolean", "array", "custom".`,
+        );
+      }
     }
   };
 

--- a/skills/golemui/SKILL.md
+++ b/skills/golemui/SKILL.md
@@ -19,7 +19,7 @@ TypeScript declarations in `node_modules` or search the filesystem for them.
 
 Two ways to author the same form. **HARD GATE — do not write a single line of form code until
 the user has told you which API they want.** If the current request doesn't already state it,
-you MUST stop and ask (use the AskUserQuestion tool when available): TS API (gui.*, coded
+you MUST stop and ask (use the AskUserQuestion tool when available): TS API (gui.\*, coded
 programmatically) or JSON API (a serializable document, e.g. stored or served at runtime). There
 is NO default — never pick one silently, even when operating autonomously, even if one seems
 obvious. Never mix their syntaxes in one artifact:
@@ -49,7 +49,7 @@ These are the silent failure modes. All of them compile/parse cleanly and then b
    `select`) REQUIRE an explicit `type` (`validator: { type: 'string', required: true }`);
    `repeater` auto-supplies `type: 'array'` — pass only rules (`{ required: true, minItems: 1 }`);
    everything else takes the loose validator with NO `type` (`{ required: true }`).
-4. **Markdown is an input, not a display.** `gui.inputs.markdown` is a markdown *editor*. For a
+4. **Markdown is an input, not a display.** `gui.inputs.markdown` is a markdown _editor_. For a
    heading or static block use `gui.displays.display(() => <h2>…</h2>)` returning your
    framework's own node.
 5. **Import `@golemui/gui-components/index.css` once** or the form renders unstyled.
@@ -73,25 +73,25 @@ Never present an unverified form. In order of preference:
      real `@golemui` types.
    - `npx -y @golemui/gui-mcp validate-json <file.json>` — validates a JSON definition
      against the bundled schemas.
-   Both print a JSON result; exit 0 = pass, 1 = fix the reported problems and re-run.
-   npx runs a project-local install when present and only fetches otherwise — see
-   [references/mcp.md](references/mcp.md) for restricted/corporate environments.
+     Both print a JSON result; exit 0 = pass, 1 = fix the reported problems and re-run.
+     npx runs a project-local install when present and only fetches otherwise — see
+     [references/mcp.md](references/mcp.md) for restricted/corporate environments.
 3. **Neither possible**: follow this skill's rules exactly, and offer the user the MCP
    install from [references/mcp.md](references/mcp.md).
 
 ## Where to look
 
-| Task | Read |
-| --- | --- |
-| Write a form in TypeScript (`gui.*`) | [references/forms-dx.md](references/forms-dx.md) — complete, compile-verified factory reference |
-| Write/validate a JSON form definition, generate from JSON Schema or OpenAPI | [references/forms-json.md](references/forms-json.md) |
-| Install packages, render the form, receive submits in a framework | [references/framework-setup.md](references/framework-setup.md) |
-| A widget's exhaustive props/options/CSS variables | [references/widgets-index.md](references/widgets-index.md) → fetch that page's URL |
-| Validators, states, events, i18n, interpolation, dependencies, host functions, loaders, item renderers, runtime methods, selectors | [references/features.md](references/features.md) |
-| Custom widgets, custom item renderers, custom validators, custom middlewares | [references/extending.md](references/extending.md) |
-| Theming, CSS customization, headless rendering | [references/styling.md](references/styling.md) |
-| Set up or use the GolemUI MCP server | [references/mcp.md](references/mcp.md) |
-| Anything else | Fetch `https://golemui.com/llms.txt` (full page index) |
+| Task                                                                                                                               | Read                                                                                            |
+| ---------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Write a form in TypeScript (`gui.*`)                                                                                               | [references/forms-dx.md](references/forms-dx.md) — complete, compile-verified factory reference |
+| Write/validate a JSON form definition, generate from JSON Schema or OpenAPI                                                        | [references/forms-json.md](references/forms-json.md)                                            |
+| Install packages, render the form, receive submits in a framework                                                                  | [references/framework-setup.md](references/framework-setup.md)                                  |
+| A widget's exhaustive props/options/CSS variables                                                                                  | [references/widgets-index.md](references/widgets-index.md) → fetch that page's URL              |
+| Validators, states, events, i18n, interpolation, dependencies, host functions, loaders, item renderers, runtime methods, selectors | [references/features.md](references/features.md)                                                |
+| Custom widgets, custom item renderers, custom validators, custom middlewares                                                       | [references/extending.md](references/extending.md)                                              |
+| Theming, CSS customization, headless rendering                                                                                     | [references/styling.md](references/styling.md)                                                  |
+| Set up or use the GolemUI MCP server                                                                                               | [references/mcp.md](references/mcp.md)                                                          |
+| Anything else                                                                                                                      | Fetch `https://golemui.com/llms.txt` (full page index)                                          |
 
 Fetch discipline: `forms-dx.md` is self-sufficient for almost every TS form — read it once, keep
 it in context, and write from it instead of making many small lookups.

--- a/skills/golemui/references/forms-dx.md
+++ b/skills/golemui/references/forms-dx.md
@@ -73,7 +73,9 @@ Every `gui.*` factory and its calling convention. Look up the detail below for t
 Call: `gui.layouts.accordion(sections)`
 
 ```ts
-gui.layouts.accordion([ { label: 'Billing', children: [ gui.inputs.textInput('card', { label: 'Card' }) ] } ])
+gui.layouts.accordion([
+  { label: 'Billing', children: [gui.inputs.textInput('card', { label: 'Card' })] },
+]);
 ```
 
 - Takes `sections: { label, children, uid? }[]` — same shape as `tabs`, rendered as collapsible panels.
@@ -85,7 +87,7 @@ Reference: https://golemui.com/dx/widgets-reference/layout-fields/accordion.md
 Call: `gui.displays.alert({ text })`
 
 ```ts
-gui.displays.alert({ text: 'Please review your details before submitting.' })
+gui.displays.alert({ text: 'Please review your details before submitting.' });
 ```
 
 - Static, non-input callout. Uses **`text`** (not `content`). Displays do not take a `path`.
@@ -97,7 +99,7 @@ Reference: https://golemui.com/dx/widgets-reference/display-fields/alert.md
 Call: `gui.inputs.booleanInput(path, { label, defaultValue? })`
 
 ```ts
-gui.inputs.booleanInput('newsletter', { label: 'Subscribe to newsletter', defaultValue: false })
+gui.inputs.booleanInput('newsletter', { label: 'Subscribe to newsletter', defaultValue: false });
 ```
 
 - The on/off toggle for a single boolean. Use `checkbox` for a checkbox presentation.
@@ -109,7 +111,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/toggle.md
 Call: `gui.actions.button({ label, actionType?: 'submit', onClick? })`
 
 ```ts
-gui.actions.button({ label: 'Sign up', actionType: 'submit' })
+gui.actions.button({ label: 'Sign up', actionType: 'submit' });
 ```
 
 - Submit button: `gui.actions.button({ label, actionType: 'submit' })`.
@@ -123,7 +125,7 @@ Reference: https://golemui.com/dx/widgets-reference/interactive-fields/button.md
 Call: `gui.inputs.calendar(path, { label, minDate?, maxDate? })`
 
 ```ts
-gui.inputs.calendar('day', { label: 'Pick a day', minDate: '2025-01-01' })
+gui.inputs.calendar('day', { label: 'Pick a day', minDate: '2025-01-01' });
 ```
 
 - An always-visible INLINE calendar (no popover) — use when the calendar should be shown on the page. For a compact single-date field use `datePicker` instead.
@@ -136,7 +138,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/calendar.md
 Call: `gui.inputs.checkbox(path, { label, defaultValue? })`
 
 ```ts
-gui.inputs.checkbox('terms', { label: 'I accept the terms', defaultValue: false })
+gui.inputs.checkbox('terms', { label: 'I accept the terms', defaultValue: false });
 ```
 
 - A single boolean rendered as a checkbox.
@@ -148,7 +150,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/checkbox.md
 Call: `gui.inputs.currency(path, { label, validator? })`
 
 ```ts
-gui.inputs.currency('price', { label: 'Price', validator: { required: true, minimum: 0 } })
+gui.inputs.currency('price', { label: 'Price', validator: { required: true, minimum: 0 } });
 ```
 
 - Numeric money input; number-style validator.
@@ -160,7 +162,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/currency.md
 Call: `gui.inputs.dateInput(path, { label, minDate?, maxDate?, validator? })`
 
 ```ts
-gui.inputs.dateInput('startDate', { label: 'Start date', validator: { required: true } })
+gui.inputs.dateInput('startDate', { label: 'Start date', validator: { required: true } });
 ```
 
 - Typed date entry, NO calendar UI — use only when keyboard-first entry is wanted. For most dates use `datePicker` (popover calendar) instead. Accepts the loose `{ required: true }`.
@@ -173,7 +175,11 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/dateinput.md
 Call: `gui.inputs.datePicker(path, { label, minDate?, maxDate?, validator? })`
 
 ```ts
-gui.inputs.datePicker('startDate', { label: 'Coverage start', minDate: '2025-01-01', validator: { required: true } })
+gui.inputs.datePicker('startDate', {
+  label: 'Coverage start',
+  minDate: '2025-01-01',
+  validator: { required: true },
+});
 ```
 
 - THE DEFAULT single-date field: a text field with a popover calendar (click to open). Prefer this for most dates. (`calendar` = always-visible inline calendar; `dateInput` = typed entry, no calendar UI.) Accepts the loose `{ required: true }` validator.
@@ -186,7 +192,11 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/date-picker.md
 Call: `gui.inputs.dateTimeCalendar(path, { label, minDate?, maxDate?, minTime?, maxTime?, minuteStep?, disabledTimeRanges?, allowCustomTime? })`
 
 ```ts
-gui.inputs.dateTimeCalendar('appointmentAt', { label: 'Appointment', minTime: '09:00', maxTime: '18:00' })
+gui.inputs.dateTimeCalendar('appointmentAt', {
+  label: 'Appointment',
+  minTime: '09:00',
+  maxTime: '18:00',
+});
 ```
 
 - An INLINE calendar with an embedded time picker: a segmented time input between the header and the days grid opens a time grid in place of the days (like the year selector).
@@ -200,7 +210,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/datetimecalenda
 Call: `gui.inputs.dateTimeInput(path, { label, hourFormat?, minuteStep?, validator? })`
 
 ```ts
-gui.inputs.dateTimeInput('meetingAt', { label: 'Meeting at' })
+gui.inputs.dateTimeInput('meetingAt', { label: 'Meeting at' });
 ```
 
 - Typed date+time entry in one locale-ordered row. Emits a local ISO date-time (`YYYY-MM-DDTHH:mm:ss`) — pair with the `{ format: 'date-time' }` validator. `hourFormat`/`minuteStep` as in `timeInput`.
@@ -212,7 +222,11 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/datetimeinput.m
 Call: `gui.inputs.dateTimePicker(path, { label, minDate?, maxDate?, minTime?, maxTime?, minuteStep?, disabledTimeRanges?, allowCustomTime? })`
 
 ```ts
-gui.inputs.dateTimePicker('appointmentAt', { label: 'Appointment', minTime: '09:00', maxTime: '18:00' })
+gui.inputs.dateTimePicker('appointmentAt', {
+  label: 'Appointment',
+  minTime: '09:00',
+  maxTime: '18:00',
+});
 ```
 
 - A compact date-time FIELD that opens a `dateTimeCalendar` POPOVER on focus — the space-saving counterpart to the inline `dateTimeCalendar`, like `datePicker` is to `calendar`.
@@ -226,7 +240,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/datetimepicker.
 Call: `gui.displays.display(render)`
 
 ```ts
-gui.displays.display(() => 'Order summary')
+gui.displays.display(() => 'Order summary');
 ```
 
 - **The go-to for a static heading or any standalone/formatted block.** Return your framework’s own content from the render function — React: `gui.displays.display(() => <h2>Member enrollment</h2>)`; Vue/Angular/Lit: return that framework’s node. It renders immediately with **zero registration and no parser dependency** — this is how you put a heading or any static block in a form (GolemUI itself never renders content for display).
@@ -239,7 +253,14 @@ Reference: https://golemui.com/dx/widgets-reference/display-fields/renderer.md
 Call: `gui.inputs.dropdown(path, { label, items, validator? })`
 
 ```ts
-gui.inputs.dropdown('country', { label: 'Country', items: [{ value: 'us', label: 'United States' }, { value: 'ca', label: 'Canada' }], validator: { type: 'string', required: true } })
+gui.inputs.dropdown('country', {
+  label: 'Country',
+  items: [
+    { value: 'us', label: 'United States' },
+    { value: 'ca', label: 'Canada' },
+  ],
+  validator: { type: 'string', required: true },
+});
 ```
 
 - Choice list uses **`items`** (`{ value, label }[]`).
@@ -252,7 +273,10 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/dropdown.md
 Call: `gui.layouts.flex(children, props?)`
 
 ```ts
-gui.layouts.flex([ gui.inputs.textInput('firstName', { label: 'First name' }), gui.inputs.textInput('lastName', { label: 'Last name' }) ])
+gui.layouts.flex([
+  gui.inputs.textInput('firstName', { label: 'First name' }),
+  gui.inputs.textInput('lastName', { label: 'Last name' }),
+]);
 ```
 
 - Layouts take the **children array first**, then optional props — unlike inputs (path first).
@@ -265,7 +289,10 @@ Reference: https://golemui.com/dx/widgets-reference/layout-fields/flex.md
 Call: `gui.layouts.grid(children, props?)`
 
 ```ts
-gui.layouts.grid([ gui.inputs.textInput('a', { label: 'A' }), gui.inputs.textInput('b', { label: 'B' }) ])
+gui.layouts.grid([
+  gui.inputs.textInput('a', { label: 'A' }),
+  gui.inputs.textInput('b', { label: 'B' }),
+]);
 ```
 
 - Grid layout; `horizontalGrid` / `verticalGrid` lock the direction.
@@ -277,7 +304,10 @@ Reference: https://golemui.com/dx/widgets-reference/layout-fields/grid.md
 Call: `gui.layouts.horizontalFlex(children, props?)`
 
 ```ts
-gui.layouts.horizontalFlex([ gui.inputs.textInput('a', { label: 'A' }), gui.inputs.textInput('b', { label: 'B' }) ])
+gui.layouts.horizontalFlex([
+  gui.inputs.textInput('a', { label: 'A' }),
+  gui.inputs.textInput('b', { label: 'B' }),
+]);
 ```
 
 - A `flex` with direction fixed to horizontal.
@@ -289,7 +319,10 @@ Reference: https://golemui.com/dx/widgets-reference/layout-fields/flex.md
 Call: `gui.layouts.horizontalGrid(children, props?)`
 
 ```ts
-gui.layouts.horizontalGrid([ gui.inputs.textInput('a', { label: 'A' }), gui.inputs.textInput('b', { label: 'B' }) ])
+gui.layouts.horizontalGrid([
+  gui.inputs.textInput('a', { label: 'A' }),
+  gui.inputs.textInput('b', { label: 'B' }),
+]);
 ```
 
 - A `grid` with direction fixed to horizontal.
@@ -301,7 +334,12 @@ Reference: https://golemui.com/dx/widgets-reference/layout-fields/grid.md
 Call: `gui.inputs.list(path, { label, items, height?, itemHeight? })`
 
 ```ts
-gui.inputs.list('selection', { label: 'Pick an option', items: ['Option 1', 'Option 2', 'Option 3'], height: 200, itemHeight: 40 })
+gui.inputs.list('selection', {
+  label: 'Pick an option',
+  items: ['Option 1', 'Option 2', 'Option 3'],
+  height: 200,
+  itemHeight: 40,
+});
 ```
 
 - A scrolling selection list. `items` is a string array (or `{ value, label }[]`).
@@ -314,10 +352,10 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/list.md
 Call: `gui.inputs.markdown(path, { label })`
 
 ```ts
-gui.inputs.markdown('notes', { label: 'Notes (markdown)' })
+gui.inputs.markdown('notes', { label: 'Notes (markdown)' });
 ```
 
-- A markdown *editor input* — the user types markdown and the value IS that markdown string. This is the ONLY use of markdown in GolemUI: there is no markdown-for-display. For a heading or static block, use `gui.displays.display(() => <node>)` (your host renders it), never a markdown widget.
+- A markdown _editor input_ — the user types markdown and the value IS that markdown string. This is the ONLY use of markdown in GolemUI: there is no markdown-for-display. For a heading or static block, use `gui.displays.display(() => <node>)` (your host renders it), never a markdown widget.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/markdown.md
 
@@ -326,7 +364,10 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/markdown.md
 Call: `gui.inputs.numberInput(path, { label, defaultValue?, validator? })`
 
 ```ts
-gui.inputs.numberInput('age', { label: 'Age', validator: { required: true, minimum: 0, maximum: 120 } })
+gui.inputs.numberInput('age', {
+  label: 'Age',
+  validator: { required: true, minimum: 0, maximum: 120 },
+});
 ```
 
 - Number validator: `{ required, minimum, maximum, exclusiveMinimum, exclusiveMaximum, multipleOf }`.
@@ -338,7 +379,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/number.md
 Call: `gui.inputs.password(path, { label, validator? })`
 
 ```ts
-gui.inputs.password('password', { label: 'Password', validator: { required: true, minLength: 8 } })
+gui.inputs.password('password', { label: 'Password', validator: { required: true, minLength: 8 } });
 ```
 
 - Masked text input; loose string validator.
@@ -350,7 +391,14 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/password.md
 Call: `gui.inputs.radiogroup(path, { label, options, defaultValue?, validator? })`
 
 ```ts
-gui.inputs.radiogroup('accountType', { label: 'Account type', defaultValue: 'personal', options: [{ value: 'personal', label: 'Personal' }, { value: 'business', label: 'Business' }] })
+gui.inputs.radiogroup('accountType', {
+  label: 'Account type',
+  defaultValue: 'personal',
+  options: [
+    { value: 'personal', label: 'Personal' },
+    { value: 'business', label: 'Business' },
+  ],
+});
 ```
 
 - Radio group uses **`options`** (`{ value, label }[]`) — note the asymmetry: `dropdown` uses `items`, `radiogroup` uses `options`.
@@ -363,7 +411,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/radiogroup.md
 Call: `gui.inputs.rangeCalendar(path, { label? })`
 
 ```ts
-gui.inputs.rangeCalendar('stayDates', { label: 'Stay dates' })
+gui.inputs.rangeCalendar('stayDates', { label: 'Stay dates' });
 ```
 
 - Inline calendar for a start–end date **range** (the value is a date range). For a single date use `calendar`.
@@ -375,7 +423,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/range-calendar.
 Call: `gui.inputs.rangeDateInput(path, { label? })`
 
 ```ts
-gui.inputs.rangeDateInput('stayDates', { label: 'Stay dates' })
+gui.inputs.rangeDateInput('stayDates', { label: 'Stay dates' });
 ```
 
 - Typed start–end date **range** entry (the range sibling of `dateInput`).
@@ -387,7 +435,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/range-date-inpu
 Call: `gui.inputs.rangeDatePicker(path, { label? })`
 
 ```ts
-gui.inputs.rangeDatePicker('stayDates', { label: 'Stay dates' })
+gui.inputs.rangeDatePicker('stayDates', { label: 'Stay dates' });
 ```
 
 - Popover calendar for a start–end date **range** (the range sibling of `datePicker`).
@@ -399,7 +447,11 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/range-date-pick
 Call: `gui.inputs.rangeDateTimeCalendar(path, { label?, minDateTime?, maxDateTime?, disabledRanges?, startTimeLabel?, endTimeLabel? })`
 
 ```ts
-gui.inputs.rangeDateTimeCalendar('stay', { label: 'Stay', startTimeLabel: 'Check-in', endTimeLabel: 'Check-out' })
+gui.inputs.rangeDateTimeCalendar('stay', {
+  label: 'Stay',
+  startTimeLabel: 'Check-in',
+  endTimeLabel: 'Check-out',
+});
 ```
 
 - INLINE range calendar with TWO embedded time pickers (start/end); value is `DateTimeRange[]`, rendered as pills. Pick a date range, then a start time (enables the end time), then an end time to commit a pill. A day holding more than one range shows a count badge.
@@ -412,7 +464,11 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/range-datetime-
 Call: `gui.inputs.rangeDateTimeInput(path, { label?, minDateTime?, maxDateTime? })`
 
 ```ts
-gui.inputs.rangeDateTimeInput('window', { label: 'Window', minDateTime: '2026-03-01T06:00:00', maxDateTime: '2026-03-31T22:00:00' })
+gui.inputs.rangeDateTimeInput('window', {
+  label: 'Window',
+  minDateTime: '2026-03-01T06:00:00',
+  maxDateTime: '2026-03-31T22:00:00',
+});
 ```
 
 - Typed start–end date-time **range** entry (the range sibling of `dateTimeInput`); value is `DateTimeRange[]`. A backward selection reorders (swaps) instead of erroring.
@@ -425,7 +481,11 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/range-datetime-
 Call: `gui.inputs.rangeDateTimePicker(path, { label?, minDateTime?, maxDateTime?, disabledRanges?, startTimeLabel?, endTimeLabel? })`
 
 ```ts
-gui.inputs.rangeDateTimePicker('stay', { label: 'Stay', startTimeLabel: 'Check-in', endTimeLabel: 'Check-out' })
+gui.inputs.rangeDateTimePicker('stay', {
+  label: 'Stay',
+  startTimeLabel: 'Check-in',
+  endTimeLabel: 'Check-out',
+});
 ```
 
 - POPOVER date-time range picker: the typed `rangeDateTimeInput` as the trigger (pills live there) with the `rangeDateTimeCalendar` in a dropdown. Value is `DateTimeRange[]`. Committing a pill keeps the popover open so several ranges can be added; it closes on outside-click, blur or Escape.
@@ -438,7 +498,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/range-datetime-
 Call: `gui.inputs.rangeTimeInput(path, { label?, minTime?, maxTime? })`
 
 ```ts
-gui.inputs.rangeTimeInput('shift', { label: 'Shift', minTime: '06:00:00', maxTime: '22:00:00' })
+gui.inputs.rangeTimeInput('shift', { label: 'Shift', minTime: '06:00:00', maxTime: '22:00:00' });
 ```
 
 - Typed start–end time **range** entry (the range sibling of `timeInput`); value is `TimeRange[]`. End time must be after start time.
@@ -450,7 +510,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/range-time-inpu
 Call: `gui.inputs.rangeTimePicker(path, { label?, minTime?, maxTime? })`
 
 ```ts
-gui.inputs.rangeTimePicker('shift', { label: 'Shift', minTime: '06:00:00', maxTime: '22:00:00' })
+gui.inputs.rangeTimePicker('shift', { label: 'Shift', minTime: '06:00:00', maxTime: '22:00:00' });
 ```
 
 - Two-list popover for a start–end time **range** (the range sibling of `timePicker`); value is `TimeRange[]`. The out list floors one slot after the chosen in so end is strictly after start.
@@ -462,7 +522,11 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/range-time-pick
 Call: `gui.inputs.repeater(path, { label?, addLabel?, removeLabel?, limit?, template })`
 
 ```ts
-gui.inputs.repeater('attendees', { label: 'Attendees', addLabel: 'Add attendee', template: [ gui.inputs.textInput('attendees.items.name', { label: 'Name' }) ] })
+gui.inputs.repeater('attendees', {
+  label: 'Attendees',
+  addLabel: 'Add attendee',
+  template: [gui.inputs.textInput('attendees.items.name', { label: 'Name' })],
+});
 ```
 
 - The variable-length array field: the user adds/removes rows at runtime, each rendering the `template`. This is the idiomatic way to collect an UNKNOWN number of items — do NOT hand-roll N pre-generated copies gated by `include.when` (a common but wrong workaround).
@@ -476,7 +540,14 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/repeater.md
 Call: `gui.inputs.select(path, { label, options, validator? })`
 
 ```ts
-gui.inputs.select('plan', { label: 'Plan', options: [{ value: 'free', label: 'Free' }, { value: 'pro', label: 'Pro' }], validator: { type: 'string', required: true } })
+gui.inputs.select('plan', {
+  label: 'Plan',
+  options: [
+    { value: 'free', label: 'Free' },
+    { value: 'pro', label: 'Pro' },
+  ],
+  validator: { type: 'string', required: true },
+});
 ```
 
 - Choice widget that uses **`options`** (like `radiogroup`) — NOT `items` (which `dropdown` uses).
@@ -489,7 +560,10 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/select.md
 Call: `gui.layouts.tabs(sections)`
 
 ```ts
-gui.layouts.tabs([ { label: 'Account', children: [ gui.inputs.textInput('email', { label: 'Email' }) ] }, { label: 'Profile', children: [ gui.inputs.textInput('name', { label: 'Name' }) ] } ])
+gui.layouts.tabs([
+  { label: 'Account', children: [gui.inputs.textInput('email', { label: 'Email' })] },
+  { label: 'Profile', children: [gui.inputs.textInput('name', { label: 'Name' })] },
+]);
 ```
 
 - Takes `sections: { label, children, uid? }[]` — each section is a tab with its own children.
@@ -501,7 +575,7 @@ Reference: https://golemui.com/dx/widgets-reference/layout-fields/tabs.md
 Call: `gui.inputs.tags(path, { label })`
 
 ```ts
-gui.inputs.tags('skills', { label: 'Skills' })
+gui.inputs.tags('skills', { label: 'Skills' });
 ```
 
 - Free-form multi-value tag input; the value is a string array.
@@ -513,7 +587,10 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/tags.md
 Call: `gui.inputs.textInput(path, { label, placeholder?, defaultValue?, validator? })`
 
 ```ts
-gui.inputs.textInput('fullName', { label: 'Full name', validator: { required: true, minLength: 2 } })
+gui.inputs.textInput('fullName', {
+  label: 'Full name',
+  validator: { required: true, minLength: 2 },
+});
 ```
 
 - Text fields accept a loose validator: `{ required, minLength, maxLength, pattern, format }` (no `type` needed).
@@ -526,7 +603,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/textinput.md
 Call: `gui.inputs.textarea(path, { label, placeholder?, validator? })`
 
 ```ts
-gui.inputs.textarea('bio', { label: 'Bio', validator: { maxLength: 500 } })
+gui.inputs.textarea('bio', { label: 'Bio', validator: { maxLength: 500 } });
 ```
 
 - Multi-line text; same loose string validator as `textInput`.
@@ -538,7 +615,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/textarea.md
 Call: `gui.inputs.timeInput(path, { label, hourFormat?, minuteStep?, validator? })`
 
 ```ts
-gui.inputs.timeInput('meetingTime', { label: 'Meeting time', minuteStep: 15 })
+gui.inputs.timeInput('meetingTime', { label: 'Meeting time', minuteStep: 15 });
 ```
 
 - Typed time entry (hh:mm segments). Emits an ISO time string (`HH:mm:ss`) — pair with the `{ format: 'time' }` validator. `hourFormat` forces '12'/'24' (default: locale); `minuteStep` sets the arrow-key minute increment.
@@ -550,7 +627,12 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/timeinput.md
 Call: `gui.inputs.timePicker(path, { label, minTime?, maxTime?, minuteStep?, disabledRanges?, allowCustomTime?, validator? })`
 
 ```ts
-gui.inputs.timePicker('meetingTime', { label: 'Meeting time', minTime: '09:00', maxTime: '18:00', minuteStep: 30 })
+gui.inputs.timePicker('meetingTime', {
+  label: 'Meeting time',
+  minTime: '09:00',
+  maxTime: '18:00',
+  minuteStep: 30,
+});
 ```
 
 - Time field with a popover list of slots built from `minTime`..`maxTime` stepping `minuteStep` (default 30). `disabledRanges` (`{ start, end }[]`, inclusive) greys slots out. Typing is off unless `allowCustomTime: true`. Emits `HH:mm:ss` — pair with the `{ format: 'time' }` validator.
@@ -562,7 +644,10 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/timepicker.md
 Call: `gui.layouts.verticalFlex(children, props?)`
 
 ```ts
-gui.layouts.verticalFlex([ gui.inputs.textInput('a', { label: 'A' }), gui.inputs.textInput('b', { label: 'B' }) ])
+gui.layouts.verticalFlex([
+  gui.inputs.textInput('a', { label: 'A' }),
+  gui.inputs.textInput('b', { label: 'B' }),
+]);
 ```
 
 - A `flex` with direction fixed to vertical.
@@ -574,7 +659,10 @@ Reference: https://golemui.com/dx/widgets-reference/layout-fields/flex.md
 Call: `gui.layouts.verticalGrid(children, props?)`
 
 ```ts
-gui.layouts.verticalGrid([ gui.inputs.textInput('a', { label: 'A' }), gui.inputs.textInput('b', { label: 'B' }) ])
+gui.layouts.verticalGrid([
+  gui.inputs.textInput('a', { label: 'A' }),
+  gui.inputs.textInput('b', { label: 'B' }),
+]);
 ```
 
 - A `grid` with direction fixed to vertical.
@@ -588,7 +676,10 @@ Cross-cutting patterns that apply to every factory (not a factory themselves).
 ## Show or hide a field conditionally (hide-when)
 
 ```ts
-gui.inputs.textInput('promoCode', { label: 'Promo code', include: { when: '$form.hasPromoCode === true' } })
+gui.inputs.textInput('promoCode', {
+  label: 'Promo code',
+  include: { when: '$form.hasPromoCode === true' },
+});
 ```
 
 - `include` and `exclude` are common config fields on EVERY `gui.*` item — pass them inside the factory's config argument (the same object as `label`): `gui.inputs.textInput('promoCode', { label, include: { when: '$form.hasPromoCode === true' } })`. `include` shows the field only while the expression is true; `exclude` hides it while true.
@@ -598,7 +689,7 @@ gui.inputs.textInput('promoCode', { label: 'Promo code', include: { when: '$form
 ## Declare named form-level states (and gate fields by them)
 
 ```ts
-gui.inputs.textInput('spouseName', { label: 'Spouse name', include: { in: ['familyCoverage'] } })
+gui.inputs.textInput('spouseName', { label: 'Spouse name', include: { in: ['familyCoverage'] } });
 ```
 
 - Named states are form-level: declare them in `formConfig.states`, a sibling of `formDef` on the `<GuiForm>` config — NOT a wrapper around the array. `formConfig.states` maps each state name to a `ReactiveExpression` string, e.g. `{ familyCoverage: '$form.coverageType === \'family\'' }`. Then any item references it by name: `include: { in: ['familyCoverage'] }` (show while true) / `exclude: { from: ['familyCoverage'] }` (hide while true).
@@ -608,10 +699,9 @@ gui.inputs.textInput('spouseName', { label: 'Spouse name', include: { in: ['fami
 ## Conditional & state-driven props (enable/disable, show/hide, readonly)
 
 ```ts
-gui.actions.button({ label: 'Submit', actionType: 'submit', disabled: { when: '$formIsInvalid' } })
+gui.actions.button({ label: 'Submit', actionType: 'submit', disabled: { when: '$formIsInvalid' } });
 ```
 
 - ENABLE/DISABLE & READONLY: `disabled` and `readonly` are typed `boolean | { when: <expr> }`. To gate the submit button on validity: `gui.actions.button({ label, actionType: 'submit', disabled: { when: '$formIsInvalid' } })`. `$formIsInvalid` is a built-in validity flag — do not declare it as a state.
 - SHOW/HIDE: `include` / `exclude` are typed `{ in: ['stateName'] }` / `{ from: ['stateName'] }` (state lists) or `{ when: <expr> }`. Every state name in `in`/`from` MUST be declared in `formConfig.states`; an undeclared name leaves the widget hidden forever (the engine logs an error to the console).
 - These are ALL typed config keys — pass them inside the factory’s config argument. NEVER reach a prop by casting the factory result and assigning a key (`(btn as any)['disabled.formValid'] = false`) or by spreading (`{ ...gui.actions.button(...), disabled }`): keys added that way are SILENTLY ignored and the behavior never fires. If a prop is not on the typed config, you are guessing — it is not a real field.
-

--- a/skills/golemui/references/framework-setup.md
+++ b/skills/golemui/references/framework-setup.md
@@ -28,13 +28,13 @@ Add `gui.actions.button({ label, actionType: 'submit' })` to the form, then list
 component. The handler receives a `FormSubmitEvent` (type from `@golemui/core`); `.data` is the
 collected form data. **Vue is the ONLY kebab-case event.**
 
-| Framework | Component | Submit wiring |
-| --- | --- | --- |
-| React | `<GuiForm>` from `@golemui/gui-react` | `formSubmit={(e: FormSubmitEvent) => e.data}` |
-| Angular | `<gui-form>` (`FormComponent` from `@golemui/gui-angular`) | `(formSubmit)="onSubmit($event)"` |
-| Vue | `<GuiForm>` from `@golemui/gui-vue` | `@form-submit="onSubmit"` |
-| Lit | `<gui-form>` (import `@golemui/gui-lit`) | `@formSubmit=${(e: CustomEvent) => e.detail.data}` |
-| Vanilla | `<gui-form>` (import `@golemui/gui-lit`) | `el.addEventListener('formSubmit', (e) => e.detail.data)` |
+| Framework | Component                                                  | Submit wiring                                             |
+| --------- | ---------------------------------------------------------- | --------------------------------------------------------- |
+| React     | `<GuiForm>` from `@golemui/gui-react`                      | `formSubmit={(e: FormSubmitEvent) => e.data}`             |
+| Angular   | `<gui-form>` (`FormComponent` from `@golemui/gui-angular`) | `(formSubmit)="onSubmit($event)"`                         |
+| Vue       | `<GuiForm>` from `@golemui/gui-vue`                        | `@form-submit="onSubmit"`                                 |
+| Lit       | `<gui-form>` (import `@golemui/gui-lit`)                   | `@formSubmit=${(e: CustomEvent) => e.detail.data}`        |
+| Vanilla   | `<gui-form>` (import `@golemui/gui-lit`)                   | `el.addEventListener('formSubmit', (e) => e.detail.data)` |
 
 ## Render snippets
 
@@ -65,7 +65,10 @@ import type { FormSubmitEvent } from '@golemui/core';
 **Lit** — `import '@golemui/gui-lit'` registers the `<gui-form>` custom element:
 
 ```ts
-html`<gui-form .config=${{ formDef: form }} @formSubmit=${(e: CustomEvent) => e.detail.data}></gui-form>`;
+html`<gui-form
+  .config=${{ formDef: form }}
+  @formSubmit=${(e: CustomEvent) => e.detail.data}
+></gui-form>`;
 ```
 
 **Vanilla JS**

--- a/skills/golemui/references/widgets-index.md
+++ b/skills/golemui/references/widgets-index.md
@@ -58,4 +58,3 @@ Every widget’s exhaustive reference page (props, per-prop examples, CSS variab
 - `gui.layouts.grid`, `gui.layouts.horizontalGrid`, `gui.layouts.verticalGrid` — https://golemui.com/dx/widgets-reference/layout-fields/grid.md (json: https://golemui.com/json/widgets-reference/layout-fields/grid.md)
 - `gui.layouts.tabs` — https://golemui.com/dx/widgets-reference/layout-fields/tabs.md (json: https://golemui.com/json/widgets-reference/layout-fields/tabs.md)
 - Category overview — https://golemui.com/dx/widgets-reference/layout-fields/overview.md
-


### PR DESCRIPTION
The kitchen-sink JSON page throws `Cannot read properties of undefined (reading '~standard')` on any change/blur because rangedatetimecalendar.form-chunk.json declares `"validator": { "required": true }` with no `type`, and initValidators has no `default` case, so it returns `undefined` into `standardValidate`.