### PR TITLE
chore: harden compatibility guards after the @golemui/dx extraction

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,12 +22,12 @@ export default [
       //  scope:app ----> scope:framework ------> scope:gui -----> scope:core
       //  apps/           react/lit/angular       gui-shared       core
       //  docs/           gui-react/lit/angular   gui-components   gui-validators
-      //                  ui-testing
+      //                  ui-testing                               dx
       //
       // |------------------------------------------------------------------------------------------------|
       // | Tag             | Projects                                                                     |
       // |------------------------------------------------------------------------------------------------|
-      // | scope:core      | @golemui/core, gui-validators                                                |
+      // | scope:core      | @golemui/core, @golemui/dx, gui-validators                                   |
       // | scope:gui       | @golemui/gui-shared, gui-components                                          |
       // | scope:framework | @golemui/react/lit/angular, gui-react/lit/angular, ui-testing                |
       // | scope:app       | everything under apps/ and docs/                                             |

--- a/libs/dx/src/lib/core/defineShortcutType.ts
+++ b/libs/dx/src/lib/core/defineShortcutType.ts
@@ -38,7 +38,7 @@ export interface ShortcutTypeSelectors<TDecorator, TConfig extends GslConfigBase
 
 /**
  * A fully assembled widget type: the handler for the DX pipeline, the GSL
- * selector factories, and the registration metadata. Pure data — building one
+ * selector factories, and the registration metadata. Pure data - building one
  * has no side effects, registration happens separately through
  * {@link registerShortcutType} (or in one step through {@link defineShortcutType}).
  */
@@ -48,14 +48,20 @@ export interface ShortcutTypeDefinition<
   TConfig extends GslConfigBase<TDecorator>,
 > extends ShortcutTypeSelectors<TDecorator, TConfig> {
   itemType: string;
-  kind: ShortcutItemKind;
+  /**
+   * The widget kind used for umbrella selector matching. The dx config
+   * requires a kind, but the gui compat `defineShortcutType` keeps it
+   * optional, so a definition built through that path can carry no kind.
+   * A kindless type never matches umbrella selectors.
+   */
+  kind?: ShortcutItemKind;
   handler: ItemTypeHandler<TEntry, TDecorator, TConfig>;
 }
 
 /**
  * Assembles a full widget type definition from a simple config object
- * (entry shape, mapToWidget, optional hooks) — generating `parseEntry`,
- * `rollUpSensibleDefaults`, and `applySensibleDefaults` automatically —
+ * (entry shape, mapToWidget, optional hooks) - generating `parseEntry`,
+ * `rollUpSensibleDefaults`, and `applySensibleDefaults` automatically -
  * plus the GSL selector factories (`gsl`, `gslByUid`) for styling/configuring
  * widgets of this type.
  *
@@ -104,7 +110,7 @@ export function createShortcutType<
   /**
    * Generated parseEntry for the '${config.entryShape}' entry shape.
    *
-   * ⚠️ AUDIT BOUNDARY: Uses `as any` for entry shape coercion.
+   * AUDIT BOUNDARY: Uses `as any` for entry shape coercion.
    * Type safety relies on the generic constraints at the
    * `createShortcutType<TEntry, TDecorator>` call site.
    * Do NOT replicate this pattern elsewhere.

--- a/libs/dx/src/lib/core/itemTypeRegistry.ts
+++ b/libs/dx/src/lib/core/itemTypeRegistry.ts
@@ -9,9 +9,9 @@ import {
 import type { DxCommonFields } from './dxBase.types';
 import type { GslItemType } from './dx.domain';
 
-// ═══════════════════════════════════════════════════
-// Item Type Handler — each shortcut folder implements this
-// ═══════════════════════════════════════════════════
+// ===================================================
+// Item Type Handler - each shortcut folder implements this
+// ===================================================
 
 export interface ParsedEntry<TDecorator extends DxCommonFields = DxCommonFields> {
   baseDef: TDecorator | ((params: DxRuntimeParams) => Partial<TDecorator>);
@@ -42,18 +42,18 @@ export interface BuildWidgetContext {
 /**
  * Strategy interface for a widget type (inputs, actions, layouts, calendars, etc.).
  *
- * The DX pipeline (`ItemWalker.processItem`) is generic — it walks the widget tree,
+ * The DX pipeline (`ItemWalker.processItem`) is generic - it walks the widget tree,
  * resolves selectors, merges definitions, and maps to framework widgets. But each
  * widget type has its own entry shape, its own sensible defaults, and sometimes
  * custom post-merge or widget-building logic. The handler provides these type-specific
  * behaviors at well-defined extension points in the pipeline:
  *
- *   1. `parseEntry`             — parse raw entry into a normalized `ParsedEntry`
- *   2. `rollUpSensibleDefaults` — aggregate config from matching leaf selectors
- *   3. `applySensibleDefaults`  — apply aggregated config to a merged decorator
- *   4. `mapToWidget`            — map a decorator to a core `FormWidget`
- *   5. `afterMerge` (optional)  — post-merge hook (e.g. actions use this to wire onClick)
- *   6. `buildCustomWidget` (optional) — custom widget building for compound types (e.g. layouts
+ *   1. `parseEntry`             - parse raw entry into a normalized `ParsedEntry`
+ *   2. `rollUpSensibleDefaults` - aggregate config from matching leaf selectors
+ *   3. `applySensibleDefaults`  - apply aggregated config to a merged decorator
+ *   4. `mapToWidget`            - map a decorator to a core `FormWidget`
+ *   5. `afterMerge` (optional)  - post-merge hook (e.g. actions use this to wire onClick)
+ *   6. `buildCustomWidget` (optional) - custom widget building for compound types (e.g. layouts
  *                                  that need to recursively walk children)
  *
  * Shortcut authors do NOT implement this interface directly. Instead, they call
@@ -62,17 +62,17 @@ export interface BuildWidgetContext {
  *
  * Entry shape taxonomy:
  *
- * 1. Keyed entries — { key, def } — path derived from key
+ * 1. Keyed entries - { key, def } - path derived from key
  *    Used by: inputs, future select/radiogroup
  *
- * 2. Bare entries — decorator | callback directly
+ * 2. Bare entries - decorator | callback directly
  *    Used by: actions, calendar, displays
  *
- * 3. Compound entries — { def, children } — container with nested shortcuts
+ * 3. Compound entries - { def, children } - container with nested shortcuts
  *    Used by: layouts, future tabs/accordion
  *
  * Each handler declares TEntry to match its shape.
- * There is no shared base type — the shapes are intentionally different.
+ * There is no shared base type - the shapes are intentionally different.
  * parseEntry(entry: TEntry) is the type-safe boundary.
  */
 export interface ItemTypeHandler<
@@ -86,7 +86,7 @@ export interface ItemTypeHandler<
   // Used by widgetMerger: apply sensible defaults to a merged decorator
   applySensibleDefaults(def: TDecorator, config: TConfig): TDecorator;
 
-  // Used by widgetMapper: map a decorator → core FormWidget
+  // Used by widgetMapper: map a decorator -> core FormWidget
   mapToWidget<StateKeys extends UiState = never, FormData extends Record<string, any> = any>(
     def: TDecorator,
   ): NonFunctionWidget<StateKeys, FormData>;
@@ -113,9 +113,9 @@ export interface ItemTypeHandler<
   getChildren?(entry: TEntry): ValidGuiShortcut[] | undefined;
 }
 
-// ═══════════════════════════════════════════════════
-// Registry — one instance per widget set implementation
-// ═══════════════════════════════════════════════════
+// ===================================================
+// Registry - one instance per widget set implementation
+// ===================================================
 
 /**
  * The widget kind an item type belongs to. Matches the `kind` discriminator of core widgets
@@ -183,7 +183,9 @@ export class ItemTypeRegistry {
     if (!handler) {
       throw new Error(
         `No handler registered for item type "${itemType}". ` +
-          `Did you forget to import the registration module?`,
+          `Register its definition in the widget set's registry with ` +
+          `registerShortcutType (for the gui widget set: add it to ` +
+          `guiShortcutTypes in registry.ts).`,
       );
     }
     return handler;

--- a/libs/dx/src/lib/core/itemWalker.service.ts
+++ b/libs/dx/src/lib/core/itemWalker.service.ts
@@ -86,7 +86,7 @@ export class ItemWalker {
   ): FormWidget<StateKeys, FormData>[] {
     return guiShortcuts.flatMap((shortcut) => {
       if (shortcut.type !== 'ITEMS') {
-        throw new Error('Unexpected gui shortcut type');
+        throw new Error(`Unexpected shortcut type "${(shortcut as { type?: string }).type}"`);
       }
 
       return shortcut.items.map((entry) => {
@@ -145,7 +145,7 @@ export class ItemWalker {
       });
     }
 
-    // Universal event wiring: onLoad, onChange, onFilter → core on: { ... }
+    // Universal event wiring: onLoad, onChange, onFilter -> core on: { ... }
     mergeResult = this.eventWiring.wireInputLayoutEvents(
       mergeResult,
       eventRegistry,
@@ -176,7 +176,7 @@ export class ItemWalker {
 
     // Assign deterministic uids to widgets that don't have one.
     // First widget at a given path keeps `uid = path` (preserves the INITIALIZE
-    // decode invariant — flatForm and rendered tree match for stable paths).
+    // decode invariant - flatForm and rendered tree match for stable paths).
     // Subsequent widgets at the same path (legitimate when paths repeat across
     // tabs, e.g., a checkbox and a toggle both binding `isNewUser`) fall back
     // to the counter to avoid duplicate-uid errors from core.

--- a/libs/gui/shared/src/legacy-imports.spec.ts
+++ b/libs/gui/shared/src/legacy-imports.spec.ts
@@ -155,8 +155,9 @@ import {
 // A dropped value export fails this file at module-link time (the named import
 // above no longer resolves); the runtime assertions below give a readable
 // per-name report on top. Type exports are covered by the `import type` blocks
-// at the bottom, which fail `tsc -p tsconfig.spec.json` when a type re-export
-// is dropped.
+// at the bottom, which fail the vitest typecheck pass configured in
+// vite.config.ts (`test.typecheck`, using tsconfig.legacy-imports.json) when a
+// type re-export is dropped.
 
 const publicValueExports = { gui, resolveChunkRefs };
 
@@ -334,8 +335,9 @@ describe('legacy import surface', () => {
 });
 
 // ─── Type exports (compile-time coverage) ─────────────────────────────────
-// A dropped type re-export breaks these imports under
-// `tsc -p libs/gui/shared/tsconfig.spec.json`.
+// A dropped type re-export breaks these imports under the vitest typecheck
+// pass (see `test.typecheck` in vite.config.ts), which CI runs as part of
+// the vite:test target.
 
 import type {
   DxDefinitionItem as _T1,

--- a/libs/gui/shared/src/lib/dx/__tests__/extensionApi.spec.ts
+++ b/libs/gui/shared/src/lib/dx/__tests__/extensionApi.spec.ts
@@ -80,7 +80,7 @@ describe('Extension API — defineShortcutType', () => {
     // TEST_CUSTOM_WIDGET is registered without a kind, so the INPUTS umbrella
     // selector must skip it entirely: no umbrella override and no umbrella
     // sensible defaults (label suppression). The auto-label stays in place.
-    // This pins the legacy behavior for custom widget authors; if the compat
+    // This pins the legacy behavior for custom widget authors. If the compat
     // wrapper ever defaults `kind` or the resolver treats a missing kind as a
     // match, the label changes and this test fails.
     const result = processDx(_guiCustom('field'), [

--- a/libs/gui/shared/src/lib/dx/__tests__/extensionApi.spec.ts
+++ b/libs/gui/shared/src/lib/dx/__tests__/extensionApi.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { defineShortcutType } from '../registry';
+import { _gslInputs } from '../shortcuts/inputs/register';
 import { processAutoLabel } from '@golemui/dx';
 import { type DxCommonFields, type DxInputBase } from '@golemui/dx';
 import { type DefOrCallback, type GslConfigBase, type GuiShortcutOf } from '@golemui/dx';
@@ -73,5 +74,20 @@ describe('Extension API — defineShortcutType', () => {
     };
 
     expect(widget.props?.customField).toBe('from-gsl');
+  });
+
+  it('never matches umbrella selectors for a type registered without a kind', () => {
+    // TEST_CUSTOM_WIDGET is registered without a kind, so the INPUTS umbrella
+    // selector must skip it entirely: no umbrella override and no umbrella
+    // sensible defaults (label suppression). The auto-label stays in place.
+    // This pins the legacy behavior for custom widget authors; if the compat
+    // wrapper ever defaults `kind` or the resolver treats a missing kind as a
+    // match, the label changes and this test fails.
+    const result = processDx(_guiCustom('field'), [
+      _gslInputs({ suppressAutomaticLabels: true, override: { label: 'From Umbrella' } }),
+    ]);
+    const widget = getStaticChild(result, 0) as { label?: string };
+
+    expect(widget.label).toBe('Field');
   });
 });

--- a/libs/gui/shared/src/lib/dx/__tests__/registryWiring.spec.ts
+++ b/libs/gui/shared/src/lib/dx/__tests__/registryWiring.spec.ts
@@ -72,8 +72,8 @@ describe('gui registry wiring', () => {
       for (const definition of definitions) {
         expect(
           guiRegistry.hasItemTypeHandler(definition.itemType),
-          `"${definition.itemType}" (from shortcuts/${name}) is not registered in guiRegistry; ` +
-            `add it to guiShortcutTypes in registry.ts`,
+          `"${definition.itemType}" (from shortcuts/${name}) is not registered in guiRegistry. ` +
+            `Add it to guiShortcutTypes in registry.ts`,
         ).toBe(true);
       }
     }

--- a/libs/gui/shared/src/lib/dx/__tests__/registryWiring.spec.ts
+++ b/libs/gui/shared/src/lib/dx/__tests__/registryWiring.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { guiRegistry } from '../registry';
 
 // Each shortcut folder exports a pure shortcut type definition from its
 // `register.ts`; `registry.ts` is the single place that registers them all
@@ -41,5 +42,40 @@ describe('gui registry wiring', () => {
         missing.map((name) => `'./shortcuts/${name}/register'`).join(', ') +
         ` and add it to guiShortcutTypes`,
     ).toEqual([]);
+  });
+
+  it('registers every exported shortcut type definition in guiRegistry', async () => {
+    // The import check above only proves registry.ts references each folder.
+    // Registration additionally requires the definition to be listed in the
+    // guiShortcutTypes array, so this test asserts actual registration: a
+    // definition that is imported but not listed fails here.
+    for (const name of shortcutsWithRegister) {
+      const registerModule: Record<string, unknown> = await import(
+        `../shortcuts/${name}/register.ts`
+      );
+
+      const definitions = Object.values(registerModule).filter(
+        (candidate): candidate is { itemType: string } => {
+          if (typeof candidate !== 'object' || candidate === null) {
+            return false;
+          }
+          const shape = candidate as { itemType?: unknown; handler?: unknown };
+          return typeof shape.itemType === 'string' && typeof shape.handler === 'object';
+        },
+      );
+
+      expect(
+        definitions.length,
+        `shortcuts/${name}/register.ts exports no shortcut type definition`,
+      ).toBeGreaterThan(0);
+
+      for (const definition of definitions) {
+        expect(
+          guiRegistry.hasItemTypeHandler(definition.itemType),
+          `"${definition.itemType}" (from shortcuts/${name}) is not registered in guiRegistry; ` +
+            `add it to guiShortcutTypes in registry.ts`,
+        ).toBe(true);
+      }
+    }
   });
 });

--- a/libs/gui/shared/src/lib/dx/registry.ts
+++ b/libs/gui/shared/src/lib/dx/registry.ts
@@ -147,7 +147,7 @@ export function defineShortcutType<
   // AUDIT BOUNDARY: The cast presents a possibly-kindless config as the
   // kind-required dx config. Safe because `ShortcutTypeDefinition.kind` is
   // optional and its only runtime consumer (`registerItemType`) accepts an
-  // absent kind; a kindless type simply never matches umbrella selectors.
+  // absent kind, in which case the type never matches umbrella selectors.
   // Do NOT replicate this pattern elsewhere.
   return dxDefineShortcutType(
     guiRegistry,

--- a/libs/gui/shared/src/lib/dx/registry.ts
+++ b/libs/gui/shared/src/lib/dx/registry.ts
@@ -1,15 +1,15 @@
-// ═══════════════════════════════════════════════════
+// ===================================================
 // The gui widget set registry.
 //
 // Every shortcut folder exports a pure shortcut type definition
 // (`createShortcutType` in its register.ts); this module is the single
 // explicit place where they are registered. Registration rides on the
-// value-dependency chain (registry → formDefs → resolveFormInput), so no
+// value-dependency chain (registry -> formDefs -> resolveFormInput), so no
 // side-effect import is needed and bundlers cannot drop it.
 //
 // Adding a shortcut: export its `<name>ShortcutType` from the folder's
 // register.ts and add it to `guiShortcutTypes` below. See SHORTCUTS.md.
-// ═══════════════════════════════════════════════════
+// ===================================================
 
 import {
   createItemTypeRegistry,
@@ -144,6 +144,11 @@ export function defineShortcutType<
 >(
   config: GuiShortcutTypeConfig<TEntry, TDecorator, TConfig>,
 ): ShortcutTypeSelectors<TDecorator, TConfig> {
+  // AUDIT BOUNDARY: The cast presents a possibly-kindless config as the
+  // kind-required dx config. Safe because `ShortcutTypeDefinition.kind` is
+  // optional and its only runtime consumer (`registerItemType`) accepts an
+  // absent kind; a kindless type simply never matches umbrella selectors.
+  // Do NOT replicate this pattern elsewhere.
   return dxDefineShortcutType(
     guiRegistry,
     config as ShortcutTypeConfig<TEntry, TDecorator, TConfig>,

--- a/libs/gui/shared/tsconfig.legacy-imports.json
+++ b/libs/gui/shared/tsconfig.legacy-imports.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.spec.json",
+  "include": ["src/legacy-imports.spec.ts", "src/**/*.d.ts"]
+}

--- a/libs/gui/shared/vite.config.ts
+++ b/libs/gui/shared/vite.config.ts
@@ -42,6 +42,17 @@ export default defineConfig(() => ({
     globals: true,
     environment: 'node',
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    // Runs `tsc --noEmit` over legacy-imports.spec.ts so a dropped TYPE
+    // re-export fails the vite:test CI step. Value exports already fail at
+    // module link time; without this, esbuild erases the `import type` lines
+    // and the type half of the compatibility guard asserts nothing.
+    // The dedicated tsconfig keeps the checked program down to that one spec
+    // plus the entry points it imports.
+    typecheck: {
+      enabled: true,
+      include: ['src/legacy-imports.spec.ts'],
+      tsconfig: 'tsconfig.legacy-imports.json',
+    },
     reporters: ['default'],
     coverage: {
       reportsDirectory: '../../../coverage/libs/gui/shared',

--- a/libs/gui/shared/vite.config.ts
+++ b/libs/gui/shared/vite.config.ts
@@ -44,10 +44,10 @@ export default defineConfig(() => ({
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     // Runs `tsc --noEmit` over legacy-imports.spec.ts so a dropped TYPE
     // re-export fails the vite:test CI step. Value exports already fail at
-    // module link time; without this, esbuild erases the `import type` lines
-    // and the type half of the compatibility guard asserts nothing.
-    // The dedicated tsconfig keeps the checked program down to that one spec
-    // plus the entry points it imports.
+    // module link time, but without this check esbuild erases the
+    // `import type` lines and the type half of the compatibility guard
+    // asserts nothing. The dedicated tsconfig keeps the checked program down
+    // to that one spec plus the entry points it imports.
     typecheck: {
       enabled: true,
       include: ['src/legacy-imports.spec.ts'],


### PR DESCRIPTION
Follow-up to the `@golemui/dx` extraction (#239). No runtime behavior changes, just more guards around the public gui-shared surface and cleanup of leftovers from the old registration model.

- CI now catches dropped **type** re-exports: a vitest typecheck pass runs `tsc` over `legacy-imports.spec.ts` inside the existing `vite:test` step. Previously only value exports could fail CI.
- New test pins that custom types registered without a `kind` never match umbrella selectors.
- The registry wiring spec now asserts each definition is actually registered in `guiRegistry`, not just imported by `registry.ts`.
- Registration error messages updated for the explicit registration model, and the item walker error is widget-set neutral.
- `ShortcutTypeDefinition.kind` is now typed optional to match runtime, with the compat wrapper's cast documented as an audit boundary.
