### PR TITLE
fix(dx): type the dependency shape per widget set implementation

### DIFF
--- a/libs/dx/src/lib/core/dx.domain.ts
+++ b/libs/dx/src/lib/core/dx.domain.ts
@@ -108,9 +108,17 @@ export interface GslLeafSelector {
 // Aggregated Selectors
 // ===================================================
 
-export interface FormConfig {
+/**
+ * Form-level behavioral settings.
+ *
+ * Generic over the dependency shape so a widget set implementation can expose
+ * its own narrowed dependency keys to form authors. The default is the open
+ * {@link Dependencies} record, which is what a caller that does not care about
+ * a specific widget set gets.
+ */
+export interface FormConfig<TDependencies extends Dependencies = Dependencies> {
   suppressAutomaticStack?: boolean;
-  dependencies?: Dependencies;
+  dependencies?: TDependencies;
   /**
    * Pure functions callable from reactive expressions under the `$fn` namespace.
    * Functions passed in the wrapper's `config.functions` win on name collisions.
@@ -130,11 +138,15 @@ export interface FormConfig {
 /**
  * Public-facing form config type for `processDxFacade`'s third argument.
  * Generic over state keys - TypeScript enforces that every declared state name
- * has a corresponding expression.
+ * has a corresponding expression - and over the dependency shape, which a
+ * widget set implementation narrows to the keys its components read.
  *
  * Usage: `processDxFacade<typeof states[number], FormData>(defs, selectors, formConfig)`
  */
-export type DxFormConfig<S extends string = string> = Omit<FormConfig, 'states'> & {
+export type DxFormConfig<
+  S extends string = string,
+  TDependencies extends Dependencies = Dependencies,
+> = Omit<FormConfig<TDependencies>, 'states'> & {
   states?: Record<S, string>;
 };
 

--- a/libs/dx/src/lib/core/selectorNormalizer.service.ts
+++ b/libs/dx/src/lib/core/selectorNormalizer.service.ts
@@ -4,6 +4,7 @@ import {
   type GslSelector,
   type GslSelectorsInput,
 } from './dx.domain';
+import { type Dependencies } from '../shared';
 
 export class SelectorNormalizer {
   /**
@@ -30,7 +31,7 @@ export class SelectorNormalizer {
     }
 
     // Wrap bare leaves in a catch-all aggregated selector (matcher: () => true)
-    // and prepend them so they act as lowest-precedence defaults — explicit
+    // and prepend them so they act as lowest-precedence defaults - explicit
     // aggregated selectors that come later will override them during merging.
     if (bareLeafSelectors.length > 0) {
       gslSelectors.unshift({
@@ -43,7 +44,15 @@ export class SelectorNormalizer {
     return gslSelectors;
   }
 
-  extractFormConfig(): FormConfig {
+  /**
+   * The form-level defaults every form starts from, before the caller's own
+   * `formConfig` is merged over them. Generic over the dependency shape only so
+   * the result slots into a caller working with a narrowed shape - no default
+   * declares a dependency.
+   */
+  extractFormConfig<
+    TDependencies extends Dependencies = Dependencies,
+  >(): FormConfig<TDependencies> {
     return {
       suppressAutomaticStack: false,
     };

--- a/libs/dx/src/lib/createImplementation.spec.ts
+++ b/libs/dx/src/lib/createImplementation.spec.ts
@@ -14,9 +14,9 @@ import {
 
 // ===================================================
 // A minimal second widget set ("demo") with its own vocabulary. This is the
-// counterpart of the gui wiring: it pins that the pipeline seams
-// (registry, adapter, umbrella kinds, facade, bridge) work for an
-// implementation other than gui.
+// counterpart of the gui wiring: it checks that every shared part of the
+// pipeline (registry, adapter, umbrella kinds, exact item type matching,
+// facade, bridge) works for an implementation other than gui.
 // ===================================================
 
 interface DemoFieldDecorator extends DxCommonFields {
@@ -201,6 +201,29 @@ describe('createImplementation', () => {
 
     const field = rootLayoutOf(result).children[0];
     expect(field.label).toBe('From umbrella');
+  });
+
+  it('applies a selector that matches the second vocabulary item type exactly', () => {
+    const demo = buildDemoImplementation();
+    const result = demo.formDefs.processDxFacade(
+      [demoText('email')],
+      [demo.namespace.selectors.fields({ override: { label: 'From DEMO_FIELD' } })],
+    );
+
+    const field = rootLayoutOf(result).children[0];
+    expect(field.label).toBe('From DEMO_FIELD');
+  });
+
+  it('targets one widget of the second vocabulary by its declared uid', () => {
+    const demo = buildDemoImplementation();
+    const result = demo.formDefs.processDxFacade(
+      [demoText('email', { uid: 'email-field' }), demoText('name', { uid: 'name-field' })],
+      [demo.namespace.selectors.fieldByUid('email-field', { override: { label: 'Only email' } })],
+    );
+
+    const [email, name] = rootLayoutOf(result).children;
+    expect(email.label).toBe('Only email');
+    expect(name.label).toBeUndefined();
   });
 
   it('maps bare functions through the adapter', () => {

--- a/libs/dx/src/lib/createImplementation.ts
+++ b/libs/dx/src/lib/createImplementation.ts
@@ -10,6 +10,7 @@
 import { type ItemTypeRegistry } from './core/itemTypeRegistry';
 import { createDxService, type DxAdapter, type DxService } from './dx.service';
 import { createResolveFormInput, type ResolveFormInputFn } from './resolveFormInput';
+import { type Dependencies } from './shared';
 
 export interface ImplementationConfig<TFacade extends Record<string, unknown>, TSelectors> {
   /** The implementation's name, e.g. 'gui' or 'kendo'. Used in error messages. */
@@ -29,8 +30,22 @@ export interface ImplementationConfig<TFacade extends Record<string, unknown>, T
   adapter: DxAdapter;
 }
 
-export interface WidgetSetImplementation<TFacade extends Record<string, unknown>, TSelectors> {
+/**
+ * Everything a widget set implementation package exports, assembled by
+ * {@link createImplementation}.
+ *
+ * `TDependencies` is the dependency shape this widget set's components read.
+ * It is carried by the form config and the resolved form input, so the
+ * implementation's form authors get those keys typed.
+ */
+export interface WidgetSetImplementation<
+  TFacade extends Record<string, unknown>,
+  TSelectors,
+  TDependencies extends Dependencies = Dependencies,
+> {
+  /** The implementation's name, as passed to {@link createImplementation}. */
   name: string;
+  /** The registry holding one handler per shortcut type of this widget set. */
   registry: ItemTypeRegistry;
   /**
    * The public authoring namespace: the facade groups plus `selectors`.
@@ -40,14 +55,14 @@ export interface WidgetSetImplementation<TFacade extends Record<string, unknown>
   namespace: TFacade & { selectors: TSelectors };
   /**
    * The DX form-definition service bound to the registry and adapter:
-   * transforms builder-style definitions into fully-fledged core forms.
+   * transforms builder-style definitions into complete core forms.
    */
-  formDefs: DxService;
+  formDefs: DxService<TDependencies>;
   /**
    * The memoized framework bridge bound to `formDefs`. The implementation's
    * framework Form wrappers use it to resolve their form input.
    */
-  resolveFormInput: ResolveFormInputFn;
+  resolveFormInput: ResolveFormInputFn<TDependencies>;
 }
 
 /**
@@ -71,10 +86,26 @@ export interface WidgetSetImplementation<TFacade extends Record<string, unknown>
  *   },
  * });
  * export const kendo = kendoImplementation.namespace;
+ *
+ * @example
+ * // A widget set whose components read third party services: declare the
+ * // dependency shape so form authors get those keys typed on `formConfig`
+ * // and on the resolved form input. All three type arguments must be given
+ * // together, so name the facade and the selector chain first.
+ * const kendoFacade = { inputs: { grid: _kendoGrid } };
+ * export const kendoImplementation = createImplementation<
+ *   typeof kendoFacade,
+ *   typeof kendoSelectors,
+ *   KendoDependencies
+ * >({ name: 'kendo', registry, facade: kendoFacade, selectors: kendoSelectors, adapter });
  */
-export function createImplementation<TFacade extends Record<string, unknown>, TSelectors>(
+export function createImplementation<
+  TFacade extends Record<string, unknown>,
+  TSelectors,
+  TDependencies extends Dependencies = Dependencies,
+>(
   config: ImplementationConfig<TFacade, TSelectors>,
-): WidgetSetImplementation<TFacade, TSelectors> {
+): WidgetSetImplementation<TFacade, TSelectors, TDependencies> {
   if ('selectors' in config.facade) {
     throw new Error(
       `The "${config.name}" implementation facade must not contain a "selectors" ` +
@@ -82,7 +113,10 @@ export function createImplementation<TFacade extends Record<string, unknown>, TS
     );
   }
 
-  const formDefs = createDxService({ registry: config.registry, adapter: config.adapter });
+  const formDefs = createDxService<TDependencies>({
+    registry: config.registry,
+    adapter: config.adapter,
+  });
 
   return {
     name: config.name,

--- a/libs/dx/src/lib/dx.service.ts
+++ b/libs/dx/src/lib/dx.service.ts
@@ -13,6 +13,7 @@ import {
   type GslSelectorsInput,
   type ValidGuiShortcut,
 } from './core/dx.domain';
+import { type Dependencies } from './shared';
 import { SelectorResolver } from './core/selectorResolver.service';
 import { WidgetMerger } from './core/widgetMerger.service';
 import { WidgetMapper } from './core/widgetMapper.service';
@@ -30,7 +31,7 @@ import { objectUtils } from './utils/objectUtils.service';
  */
 export interface DxAdapter {
   /**
-   * What a bare function in a form definition becomes — typically the
+   * What a bare function in a form definition becomes - typically the
    * implementation's display shortcut wrapping the render function.
    */
   bareItemToWidget(renderFn: DxDisplayRenderFn): ValidGuiShortcut;
@@ -46,26 +47,29 @@ export interface DxAdapter {
  * The output of {@link DxService.prepareForm}: a fully normalized form
  * ready for the walk-and-map phase.
  *
- * - `defs` — widget definitions, possibly wrapped in a synthetic root layout
- * - `gslSelectors` — normalized selectors (always aggregated shape)
- * - `formConfig` — form-level behavioral settings (auto-stack, onSubmit, etc.)
+ * - `defs` - widget definitions, possibly wrapped in a synthetic root layout
+ * - `gslSelectors` - normalized selectors (always aggregated shape)
+ * - `formConfig` - form-level behavioral settings (auto-stack, onSubmit, etc.)
  */
-interface PreparedForm {
+interface PreparedForm<TDependencies extends Dependencies = Dependencies> {
   defs: ValidGuiShortcut[];
   gslSelectors: GslSelector[];
-  formConfig: FormConfig;
+  formConfig: FormConfig<TDependencies>;
 }
 
 /**
  * Transforms a developer-friendly form definition into a fully-fledged form definition
  * usable by the framework ({@link Form}<STATE_KEYS, FORM_DATA>).
  *
- * Orchestrates: prepareForm → walkAndMap → buildResult.
+ * Orchestrates: prepareForm -> walkAndMap -> buildResult.
  *
- * One instance exists per widget set implementation; build it with
- * {@link createDxService}.
+ * One instance exists per widget set implementation, build it with
+ * {@link createDxService}. The `TDependencies` parameter is the dependency
+ * shape the implementation exposes to its form authors (see
+ * {@link Dependencies}), and it flows from the form config through to the
+ * result.
  */
-export class DxService {
+export class DxService<TDependencies extends Dependencies = Dependencies> {
   constructor(
     private readonly selectorNormalizer: SelectorNormalizer,
     private readonly walker: ItemWalker,
@@ -75,23 +79,23 @@ export class DxService {
   processDxFacade<STATE_KEYS extends UiState = never, FORM_DATA extends Record<string, any> = any>(
     dxDefinitionsRaw: DxDefinitions,
     gslSelectorsInput: GslSelectorsInput = [],
-    formConfigInput?: DxFormConfig<STATE_KEYS>,
-  ): DxResult<STATE_KEYS, FORM_DATA> {
-    // ── 1. Prepare: normalize, auto-stack ──
+    formConfigInput?: DxFormConfig<STATE_KEYS, TDependencies>,
+  ): DxResult<STATE_KEYS, FORM_DATA, TDependencies> {
+    // -- 1. Prepare: normalize, auto-stack --
     const { defs, gslSelectors, formConfig } = this.prepareForm(
       dxDefinitionsRaw,
       gslSelectorsInput,
       formConfigInput,
     );
 
-    // ── 2. Walk the shortcut tree and map each widget ──
+    // -- 2. Walk the shortcut tree and map each widget --
     const { widgets, eventRegistry } = this.walker.walkAndMap<STATE_KEYS, FORM_DATA>(
       defs,
       gslSelectors,
       formConfig,
     );
 
-    // ── 3. Build result ──
+    // -- 3. Build result --
     const rootLayout = widgets[0] as LayoutWidget<STATE_KEYS, FORM_DATA>;
     return this.buildResult<STATE_KEYS, FORM_DATA>({ form: rootLayout }, eventRegistry, formConfig);
   }
@@ -100,17 +104,17 @@ export class DxService {
    * Normalizes raw form definitions and applies form-level defaults.
    *
    * Steps:
-   *  1. Normalize definitions — ensure a flat array; convert bare functions to display widgets.
-   *  2. Normalize selectors — convert mixed leaf/aggregated selectors into a uniform
+   *  1. Normalize definitions - ensure a flat array; convert bare functions to display widgets.
+   *  2. Normalize selectors - convert mixed leaf/aggregated selectors into a uniform
    *     aggregated shape, and extract form-level config (see {@link FormConfig}).
-   *  3. Auto-stack — unless suppressed, wrap all definitions in a synthetic root
+   *  3. Auto-stack - unless suppressed, wrap all definitions in a synthetic root
    *     flex column layout so the form renders as a single vertical container.
    */
   private prepareForm(
     dxDefinitionsRaw: DxDefinitions,
     gslSelectorsInput: GslSelectorsInput,
-    formConfigInput?: FormConfig,
-  ): PreparedForm {
+    formConfigInput?: FormConfig<TDependencies>,
+  ): PreparedForm<TDependencies> {
     // 1. Normalize definitions
     const rawItems: DxDefinitionItem[] = Array.isArray(dxDefinitionsRaw)
       ? [...dxDefinitionsRaw]
@@ -122,8 +126,8 @@ export class DxService {
     // 2. Normalize selectors + extract form config
     //    Defaults come from extractFormConfig(); third-arg overrides them.
     const gslSelectors = this.selectorNormalizer.normalizeSelectors(gslSelectorsInput);
-    const formConfig = {
-      ...this.selectorNormalizer.extractFormConfig(),
+    const formConfig: FormConfig<TDependencies> = {
+      ...this.selectorNormalizer.extractFormConfig<TDependencies>(),
       ...formConfigInput,
     };
 
@@ -141,7 +145,7 @@ export class DxService {
 
   /**
    * Converts DX `$`-separated state names to core's `:`-separated names.
-   * E.g. `{ register$adult: 'expr' }` → `{ 'register:adult': 'expr' }`.
+   * E.g. `{ register$adult: 'expr' }` becomes `{ 'register:adult': 'expr' }`.
    */
   private convertStateNames(states: Record<string, string>): Record<string, string> {
     const converted: Record<string, string> = {};
@@ -157,8 +161,8 @@ export class DxService {
   >(
     form: Form<StateKeys, FormData>,
     eventRegistry: EventRegistry,
-    formConfig: FormConfig,
-  ): DxResult<StateKeys, FormData> {
+    formConfig: FormConfig<TDependencies>,
+  ): DxResult<StateKeys, FormData, TDependencies> {
     // Inject states into the core form if provided
     if (formConfig.states && Object.keys(formConfig.states).length > 0) {
       form = {
@@ -167,7 +171,7 @@ export class DxService {
       };
     }
 
-    const result: DxResult<StateKeys, FormData> = { form };
+    const result: DxResult<StateKeys, FormData, TDependencies> = { form };
 
     if (eventRegistry.size > 0) {
       result.events = (event: FormEvent) => {
@@ -233,14 +237,23 @@ export class DxService {
  * the full walk-and-map pipeline bound to the implementation's item type
  * registry and adapter.
  *
+ * Pass `TDependencies` to declare the dependency shape this widget set's
+ * components read, so its form authors get those keys typed on both the form
+ * config and the result. Omit it for the open {@link Dependencies} record.
+ *
  * @example
  * const formDefs = createDxService({ registry: guiRegistry, adapter: guiAdapter });
  * const result = formDefs.processDxFacade(definitions, selectors, config);
+ *
+ * @example
+ * // A widget set that documents its own dependency keys.
+ * type KendoDependencies = { icons?: IconPack };
+ * const formDefs = createDxService<KendoDependencies>({ registry, adapter });
  */
-export function createDxService(options: {
+export function createDxService<TDependencies extends Dependencies = Dependencies>(options: {
   registry: ItemTypeRegistry;
   adapter: DxAdapter;
-}): DxService {
+}): DxService<TDependencies> {
   const { registry, adapter } = options;
   const walker = new ItemWalker(
     registry,
@@ -250,5 +263,5 @@ export function createDxService(options: {
     eventWiringService,
     stateExpansionService,
   );
-  return new DxService(new SelectorNormalizer(), walker, adapter);
+  return new DxService<TDependencies>(new SelectorNormalizer(), walker, adapter);
 }

--- a/libs/dx/src/lib/formDef.domain.ts
+++ b/libs/dx/src/lib/formDef.domain.ts
@@ -5,9 +5,9 @@ import { type DxCommonFields, type DxInternalFields } from './core/dxBase.types'
 import { type DxRuntimeParams } from './core/dxUtilityTypes';
 import { type Dependencies } from './shared';
 
-// ═══════════════════════════════════════════════════
+// ===================================================
 // Base Types (owned here)
-// ═══════════════════════════════════════════════════
+// ===================================================
 
 export type GslItemType = string;
 
@@ -20,9 +20,9 @@ export type GslItemType = string;
  */
 export type WidgetItemDecorator = DxInternalFields & DxCommonFields;
 
-// ═══════════════════════════════════════════════════
+// ===================================================
 // DX-level aggregate types
-// ═══════════════════════════════════════════════════
+// ===================================================
 
 export type DxDisplayRenderFn = (params: DxRuntimeParams) => any;
 export type DxDefinitionItem = ValidGuiShortcut | DxDisplayRenderFn;
@@ -30,10 +30,19 @@ export type DxDefinitions = DxDefinitionItem | DxDefinitionItem[];
 
 export type FormEvents = (event: FormEvent) => void;
 
-export interface DxResult<S extends UiState = never, F extends Record<string, any> = any> {
+/**
+ * The output of the DX pipeline. Generic over the dependency shape so a widget
+ * set implementation can hand its form authors the narrowed dependency keys its
+ * components read (the default is the open {@link Dependencies} record).
+ */
+export interface DxResult<
+  S extends UiState = never,
+  F extends Record<string, any> = any,
+  TDependencies extends Dependencies = Dependencies,
+> {
   form: Form<S, F>;
   events?: FormEvents;
-  dependencies?: Dependencies;
+  dependencies?: TDependencies;
   functions?: ExpressionFunctions;
   widgetLoaders?: Record<string, () => Promise<unknown>>;
   validateOn?: ValidateOn;

--- a/libs/dx/src/lib/resolveFormInput.ts
+++ b/libs/dx/src/lib/resolveFormInput.ts
@@ -5,8 +5,8 @@ import type { DxFormConfig, GslSelectorsInput } from './core/dx.domain';
 import { type DxService } from './dx.service';
 import type { DxDefinitions, FormEvents } from './formDef.domain';
 
-// ═══════════════════════════════════════════════════
-// resolveFormInput — shared bridge used by every framework's <Form> wrapper.
+// ===================================================
+// resolveFormInput - shared bridge used by every framework's <Form> wrapper.
 //
 // Accepts either a JSON form definition (string | Record<string, any>) or a
 // DX bundle (DxDefinitions + optional selectors/config) and returns a
@@ -17,16 +17,25 @@ import type { DxDefinitions, FormEvents } from './formDef.domain';
 //
 // Memoization: `processDxFacade` walks the entire form tree, so the result is
 // cached by reference identity of the (defs, selectors, config) triple. Each
-// framework wrapper calls this on every render — without memoization a typical
+// framework wrapper calls this on every render - without memoization a typical
 // kitchen-sink form would re-walk hundreds of nodes per keystroke.
-// ═══════════════════════════════════════════════════
+// ===================================================
 
 export type FormInput = string | Record<string, any> | DxDefinitions;
 
-export interface ResolvedFormInput<FormData extends Record<string, any> = any> {
+/**
+ * The uniform shape every framework Form wrapper consumes. Generic over the
+ * dependency shape so a widget set implementation hands its form authors the
+ * dependency keys its components read (the default is the open
+ * {@link Dependencies} record).
+ */
+export interface ResolvedFormInput<
+  FormData extends Record<string, any> = any,
+  TDependencies extends Dependencies = Dependencies,
+> {
   formDef: string | Record<string, any> | Form<any, FormData>;
   formEvent?: FormEvents;
-  dependencies?: Dependencies;
+  dependencies?: TDependencies;
   functions?: ExpressionFunctions;
   widgetLoaders?: Record<string, () => Promise<unknown>>;
   validateOn?: ValidateOn;
@@ -34,13 +43,16 @@ export interface ResolvedFormInput<FormData extends Record<string, any> = any> {
 }
 
 /**
- * The bound resolver returned by {@link createResolveFormInput}.
+ * The bound resolver returned by {@link createResolveFormInput}, carrying the
+ * dependency shape of the widget set it was bound to.
  */
-export type ResolveFormInputFn = <FormData extends Record<string, any> = any>(
+export type ResolveFormInputFn<TDependencies extends Dependencies = Dependencies> = <
+  FormData extends Record<string, any> = any,
+>(
   formDef: FormInput | undefined,
   formSelectors?: GslSelectorsInput,
-  formConfig?: DxFormConfig,
-) => ResolvedFormInput<FormData>;
+  formConfig?: DxFormConfig<string, TDependencies>,
+) => ResolvedFormInput<FormData, TDependencies>;
 
 /**
  * Heuristic discriminator: a DX bundle is an array of builder shortcuts (each
@@ -89,14 +101,16 @@ function assertNotWrappedDx(formDef: unknown): void {
  * @internal Used by widget set packages to build the `resolveFormInput` their
  * framework Form wrappers consume; not part of the end-user public API.
  */
-export function createResolveFormInput(dxService: DxService): ResolveFormInputFn {
-  // ─── Memoization ───
+export function createResolveFormInput<TDependencies extends Dependencies = Dependencies>(
+  dxService: DxService<TDependencies>,
+): ResolveFormInputFn<TDependencies> {
+  // --- Memoization ---
   // Three-level WeakMap keyed by (defs, selectors, config). Falls back to a
   // sentinel for the "selectors omitted" / "config omitted" cases so undefined
   // arguments still hit the cache.
   const NO_SELECTORS = Object.freeze({}) as object;
   const NO_CONFIG = Object.freeze({}) as object;
-  type Triple = WeakMap<object, WeakMap<object, ResolvedFormInput<any>>>;
+  type Triple = WeakMap<object, WeakMap<object, ResolvedFormInput<any, TDependencies>>>;
   const cache = new WeakMap<object, Triple>();
 
   function cacheKey(value: unknown, sentinel: object): object {
@@ -109,8 +123,8 @@ export function createResolveFormInput(dxService: DxService): ResolveFormInputFn
   return function resolveFormInput<FormData extends Record<string, any> = any>(
     formDef: FormInput | undefined,
     formSelectors?: GslSelectorsInput,
-    formConfig?: DxFormConfig,
-  ): ResolvedFormInput<FormData> {
+    formConfig?: DxFormConfig<string, TDependencies>,
+  ): ResolvedFormInput<FormData, TDependencies> {
     if (!isDxDefinitions(formDef)) {
       assertNotWrappedDx(formDef);
       return { formDef: formDef as string | Record<string, any> };
@@ -130,7 +144,9 @@ export function createResolveFormInput(dxService: DxService): ResolveFormInputFn
       byConfig = new WeakMap();
       bySelectors.set(selectorsKey, byConfig);
     }
-    const cached = byConfig.get(configKey) as ResolvedFormInput<FormData> | undefined;
+    const cached = byConfig.get(configKey) as
+      | ResolvedFormInput<FormData, TDependencies>
+      | undefined;
     if (cached) return cached;
 
     const result = dxService.processDxFacade<never, FormData>(
@@ -138,7 +154,7 @@ export function createResolveFormInput(dxService: DxService): ResolveFormInputFn
       formSelectors,
       formConfig,
     );
-    const resolved: ResolvedFormInput<FormData> = {
+    const resolved: ResolvedFormInput<FormData, TDependencies> = {
       formDef: result.form,
       formEvent: result.events,
       dependencies: result.dependencies,

--- a/libs/gui/shared/src/legacy-imports.spec.ts
+++ b/libs/gui/shared/src/legacy-imports.spec.ts
@@ -665,3 +665,67 @@ export type LegacyWidgetPropsTypeSurface = [
   ToggleProps,
   GolemWidget,
 ];
+
+// --- Dependency shape (compile-time coverage) -----------------------------
+// `@golemui/dx` declares the dependency-carrying types generic over the
+// dependency shape, defaulted to an open record, so a second widget set can
+// bring its own keys. gui-shared binds them to the gui `Dependencies` (see
+// `lib/dx/guiDependencyTypes.ts`). These probes fail the typecheck pass if
+// that binding is ever lost: reading a documented key must keep compiling,
+// and a wrong dependency value must keep failing.
+
+import type { DxFormConfig as GuiDxFormConfig, GuiFormInitConfig as GuiInitConfig } from './index';
+
+/**
+ * Never called. Its body is the assertion: every read path that compiled
+ * before `@golemui/dx` was extracted must still compile.
+ */
+export function legacyDependencyReadProbes(
+  resolved: ResolvedFormInput,
+  result: DxResult,
+  resolve: typeof resolveFormInput,
+  service: typeof formDefs,
+): (string | undefined)[] {
+  return [
+    resolved.dependencies?.markdown?.parse('# heading'),
+    result.dependencies?.markdown?.parse('# heading'),
+    resolve([]).dependencies?.markdown?.parse('# heading'),
+    service.processDxFacade([]).dependencies?.markdown?.parse('# heading'),
+  ];
+}
+
+export const legacyFormConfigDependencyProbe: FormConfig = {
+  dependencies: {
+    markdown: {
+      // @ts-expect-error the gui markdown dependency must declare a parse function
+      parse: 42,
+    },
+  },
+};
+
+export const legacyDxFormConfigDependencyProbe: GuiDxFormConfig = {
+  dependencies: {
+    markdown: {
+      // @ts-expect-error the gui markdown dependency must declare a parse function
+      parse: 42,
+    },
+  },
+};
+
+export const legacyInitConfigDependencyProbe: GuiInitConfig = {
+  formDef: [],
+  dependencies: {
+    markdown: {
+      // @ts-expect-error the gui markdown dependency must declare a parse function
+      parse: 42,
+    },
+  },
+  formConfig: {
+    dependencies: {
+      markdown: {
+        // @ts-expect-error the gui markdown dependency must declare a parse function
+        parse: 42,
+      },
+    },
+  },
+};

--- a/libs/gui/shared/src/lib/dx/SHORTCUTS.md
+++ b/libs/gui/shared/src/lib/dx/SHORTCUTS.md
@@ -259,10 +259,17 @@ It does **not** accept object literals or callbacks. For any per-field customiza
 
 ## Demo Requirement for New Shortcut Types
 
-Every new shortcut type must ship with at least one demo under `src/app/demos/` and be registered in:
+Every new shortcut type must be visible in the kitchen sink demo, which the four
+playground apps render at `/dx/kitchen-sink` and `/json/kitchen-sink`. Add a tab
+pair under `apps/apps-shared/src/lib/mocks/tabs/`:
 
-- `src/app/demos/index.ts`
-- `src/app/app.tsx` (`formRegistry.registerAll([...])`)
+- `<widget>.dx.ts` (the builder version) wired into
+  `apps/apps-shared/src/lib/mocks/kitchen-sink.dx.ts`
+- `<widget>.form-chunk.json` (the JSON version) wired into
+  `apps/apps-shared/src/lib/mocks/kitchen-sink.form.json`
+
+`kitchen-sink.equivalence.spec.ts` compares the two versions tab by tab, so both
+must produce the same form.
 
 If a shortcut has no visible demo, it is not considered complete.
 
@@ -303,17 +310,29 @@ lib/dx/
 │   │   ├── guiDisplay.impl.ts         ← _guiDisplay()
 │   │   └── register.ts                ← _gslDisplays(), _gslDisplayByUid()
 │   │
-│   └── scopes/                        ← Scope chain + legacy primitives
-│       ├── scopeChain.ts              ← ScopeChain class — `gui.selectors` root
+│   └── scopes/                        ← Legacy scope primitives
 │       ├── gslTag.impl.ts             ← _gslTag()  (internal, focus-closeout removal)
 │       └── gslStates.impl.ts          ← _gslStates() (internal, focus-closeout removal)
 │
+├── gui.ts                             ← The assembly point: the selector map passed to
+│                                        createSelectors, the gui adapter, the one
+│                                        createImplementation call, and the `gui` namespace
 ├── registry.ts                        ← guiRegistry: registers every shortcut type definition
-├── formDefs.ts                        ← formDefs: the DX service bound to guiRegistry + gui adapter
+├── guiDependencyTypes.ts              ← The DX types bound to the gui `Dependencies` shape
+├── formDefs.ts                        ← formDefs: re-exported from the implementation object
 ├── resolveFormInput.ts                ← gui-bound resolveFormInput + GuiFormInitConfig
 ├── formDef.domain.ts                  ← Compatibility re-exports + gui decorator re-exports
+├── __tests__/selectorChain.spec.ts    ← Pinned list of every `gui.selectors` method
 └── SHORTCUTS.md                       ← This file
 ```
+
+A new widget type needs three edits outside its own folder: register the
+definition in `registry.ts`, add the factory to the facade in `gui.ts`, and add
+its selector pair (`<widget>s` and `<widget>ByUid`) to the selector map in
+`gui.ts`. The selector map is the replacement for the hand-written selector
+class that used to live in `shortcuts/scopes/`: `createSelectors` builds the
+chain from that flat map. `selectorChain.spec.ts` pins the resulting method
+list, so it fails until the new pair is added there too.
 
 ## Existing Shortcuts — Reference Implementation Map
 

--- a/libs/gui/shared/src/lib/dx/formDef.domain.ts
+++ b/libs/gui/shared/src/lib/dx/formDef.domain.ts
@@ -1,8 +1,8 @@
-// ═══════════════════════════════════════════════════
+// ===================================================
 // The generic DX base types moved to `@golemui/dx`; they stay re-exported
 // here permanently so existing import paths keep working. The gui shortcut
 // type re-exports below are owned by this package.
-// ═══════════════════════════════════════════════════
+// ===================================================
 
 export type {
   GslItemType,
@@ -11,12 +11,14 @@ export type {
   DxDefinitionItem,
   DxDefinitions,
   FormEvents,
-  DxResult,
 } from '@golemui/dx';
 
-// ═══════════════════════════════════════════════════
+// DxResult carries the gui dependency shape, see guiDependencyTypes.ts.
+export type { DxResult } from './guiDependencyTypes';
+
+// ===================================================
 // Re-exports from shortcut folders (backward compat)
-// ═══════════════════════════════════════════════════
+// ===================================================
 
 export type {
   DxEventHandler,

--- a/libs/gui/shared/src/lib/dx/gui.ts
+++ b/libs/gui/shared/src/lib/dx/gui.ts
@@ -17,6 +17,7 @@ import {
 } from '@golemui/dx';
 
 import { guiRegistry } from './registry';
+import type { Dependencies } from '../shared';
 
 // --- Inputs ---
 import { _guiTextInput } from './shortcuts/inputs/guiTextInput.impl';
@@ -254,70 +255,81 @@ const guiAdapter: DxAdapter = {
   },
 };
 
+// The shortcut factory groups of the public namespace. Named so the
+// dependency shape can be passed to createImplementation explicitly: giving
+// any type argument means giving all of them.
+const guiFacade = {
+  inputs: {
+    textInput: _guiTextInput,
+    numberInput: _guiNumberInput,
+    booleanInput: _guiBooleanInput,
+    select: _guiSelect,
+    dropdown: _guiDropdown,
+    radiogroup: _guiRadiogroup,
+    checkbox: _guiCheckbox,
+    textarea: _guiTextarea,
+    password: _guiPassword,
+    currency: _guiCurrency,
+    markdown: _guiMarkdown,
+    list: _guiList,
+    calendar: _guiCalendar,
+    dateTimeCalendar: _guiDateTimeCalendar,
+    dateInput: _guiDateInput,
+    datePicker: _guiDatePicker,
+    dateTimePicker: _guiDateTimePicker,
+    timeInput: _guiTimeInput,
+    timePicker: _guiTimePicker,
+    dateTimeInput: _guiDateTimeInput,
+    rangeCalendar: _guiRangeCalendar,
+    rangeDateInput: _guiRangeDateInput,
+    rangeDateTimeInput: _guiRangeDateTimeInput,
+    rangeDateTimeCalendar: _guiRangeDateTimeCalendar,
+    rangeDateTimePicker: _guiRangeDateTimePicker,
+    rangeTimeInput: _guiRangeTimeInput,
+    rangeDatePicker: _guiRangeDatePicker,
+    rangeTimePicker: _guiRangeTimePicker,
+    repeater: _guiRepeater,
+    tags: _guiTags,
+    custom: _guiCustomInput,
+  },
+  actions: {
+    button: _guiButton,
+    custom: _guiCustomAction,
+  },
+  displays: {
+    display: _guiDisplay,
+    alert: _guiAlert,
+    markdownText: _guiMarkdownText,
+    custom: _guiCustomDisplay,
+  },
+  layouts: {
+    flex: _guiFlex,
+    horizontalFlex: _guiHorizontalFlex,
+    verticalFlex: _guiVerticalFlex,
+    grid: _guiGrid,
+    horizontalGrid: _guiHorizontalGrid,
+    verticalGrid: _guiVerticalGrid,
+    tabs: _guiTabs,
+    accordion: _guiAccordion,
+    custom: _guiCustomLayout,
+  },
+};
+
 /**
  * The assembled gui widget set: the authoring namespace plus the DX
  * form-definition service and the framework bridge, all bound to the gui
- * registry and adapter.
+ * registry and adapter. `Dependencies` is the gui widget set's dependency
+ * shape, so form authors get its keys typed on `formConfig.dependencies` and
+ * on the resolved form input.
  */
-export const guiImplementation = createImplementation({
+export const guiImplementation = createImplementation<
+  typeof guiFacade,
+  typeof guiSelectors,
+  Dependencies
+>({
   name: 'gui',
   registry: guiRegistry,
-  facade: {
-    inputs: {
-      textInput: _guiTextInput,
-      numberInput: _guiNumberInput,
-      booleanInput: _guiBooleanInput,
-      select: _guiSelect,
-      dropdown: _guiDropdown,
-      radiogroup: _guiRadiogroup,
-      checkbox: _guiCheckbox,
-      textarea: _guiTextarea,
-      password: _guiPassword,
-      currency: _guiCurrency,
-      markdown: _guiMarkdown,
-      list: _guiList,
-      calendar: _guiCalendar,
-      dateTimeCalendar: _guiDateTimeCalendar,
-      dateInput: _guiDateInput,
-      datePicker: _guiDatePicker,
-      dateTimePicker: _guiDateTimePicker,
-      timeInput: _guiTimeInput,
-      timePicker: _guiTimePicker,
-      dateTimeInput: _guiDateTimeInput,
-      rangeCalendar: _guiRangeCalendar,
-      rangeDateInput: _guiRangeDateInput,
-      rangeDateTimeInput: _guiRangeDateTimeInput,
-      rangeDateTimeCalendar: _guiRangeDateTimeCalendar,
-      rangeDateTimePicker: _guiRangeDateTimePicker,
-      rangeTimeInput: _guiRangeTimeInput,
-      rangeDatePicker: _guiRangeDatePicker,
-      rangeTimePicker: _guiRangeTimePicker,
-      repeater: _guiRepeater,
-      tags: _guiTags,
-      custom: _guiCustomInput,
-    },
-    actions: {
-      button: _guiButton,
-      custom: _guiCustomAction,
-    },
-    displays: {
-      display: _guiDisplay,
-      alert: _guiAlert,
-      markdownText: _guiMarkdownText,
-      custom: _guiCustomDisplay,
-    },
-    layouts: {
-      flex: _guiFlex,
-      horizontalFlex: _guiHorizontalFlex,
-      verticalFlex: _guiVerticalFlex,
-      grid: _guiGrid,
-      horizontalGrid: _guiHorizontalGrid,
-      verticalGrid: _guiVerticalGrid,
-      tabs: _guiTabs,
-      accordion: _guiAccordion,
-      custom: _guiCustomLayout,
-    },
-  },
+  facade: guiFacade,
   selectors: guiSelectors,
   adapter: guiAdapter,
 });

--- a/libs/gui/shared/src/lib/dx/guiDependencyTypes.ts
+++ b/libs/gui/shared/src/lib/dx/guiDependencyTypes.ts
@@ -1,0 +1,44 @@
+// ===================================================
+// The DX types that carry a dependency shape, bound to the gui widget set's
+// own `Dependencies`.
+//
+// `@golemui/dx` declares these types generic over the dependency shape and
+// defaults them to the open `Record<string, unknown>`, because the pipeline
+// itself does not care what a widget set injects. gui-shared re-exports them
+// under their original names bound to the gui shape, so gui form authors keep
+// the documented keys (`dependencies.markdown`) typed on both entry points.
+//
+// A second widget set does the same with its own dependency type. Nothing here
+// is gui-specific except the `Dependencies` import.
+// ===================================================
+
+import type { UiState } from '@golemui/core';
+import type {
+  DxFormConfig as DxFormConfigOf,
+  DxResult as DxResultOf,
+  FormConfig as FormConfigOf,
+  ResolvedFormInput as ResolvedFormInputOf,
+} from '@golemui/dx';
+import type { Dependencies } from '../shared';
+
+/** Form-level settings, with the gui dependency keys typed. */
+export type FormConfig = FormConfigOf<Dependencies>;
+
+/**
+ * Form-level settings for `processDxFacade`'s third argument, generic over the
+ * declared state names, with the gui dependency keys typed.
+ */
+export type DxFormConfig<S extends string = string> = DxFormConfigOf<S, Dependencies>;
+
+/** The DX pipeline output, with the gui dependency keys typed. */
+export type DxResult<S extends UiState = never, F extends Record<string, any> = any> = DxResultOf<
+  S,
+  F,
+  Dependencies
+>;
+
+/** The resolved framework form input, with the gui dependency keys typed. */
+export type ResolvedFormInput<FormData extends Record<string, any> = any> = ResolvedFormInputOf<
+  FormData,
+  Dependencies
+>;

--- a/libs/gui/shared/src/lib/dx/index.ts
+++ b/libs/gui/shared/src/lib/dx/index.ts
@@ -1,12 +1,12 @@
-// ═══════════════════════════════════════════════════
-// FormForge DX — Public API
-// ═══════════════════════════════════════════════════
+// ===================================================
+// FormForge DX - Public API
+// ===================================================
 
-// ─── Public namespace ───
+// --- Public namespace ---
 
 export { gui } from './gui';
 
-// ─── GUI factories (structure) ───
+// --- GUI factories (structure) ---
 
 export { _guiAccordion } from './shortcuts/accordion/guiAccordion.impl';
 export { _guiButton } from './shortcuts/actions/guiActions.impl';
@@ -57,7 +57,7 @@ export { _guiTextarea } from './shortcuts/textarea/guiTextarea.impl';
 export { _guiTimeInput } from './shortcuts/time-input/guiTimeInput.impl';
 export { _guiTimePicker } from './shortcuts/time-picker/guiTimePicker.impl';
 
-// ─── GSL selectors (behavior) ───
+// --- GSL selectors (behavior) ---
 
 export { _gslAccordionByUid, _gslAccordions } from './shortcuts/accordion/register';
 export { _gslActionByUid, _gslActions } from './shortcuts/actions/register';
@@ -131,19 +131,20 @@ export { _gslTextareaByUid, _gslTextareas } from './shortcuts/textarea/register'
 export { _gslTimeInputByUid, _gslTimeInputs } from './shortcuts/time-input/register';
 export { _gslTimePickerByUid, _gslTimePickers } from './shortcuts/time-picker/register';
 
-// ─── Scope selectors ───
+// --- Scope selectors ---
 //
 // `_gslTag` and `_gslStates` are kept as internal underscore-era primitives
 // pending focus-closeout removal. They are not part of the spec entrance
 // (`gui.selectors.tag(...)` / `.state(...)` are). `_gslRoot` retired in
-// Phase 15 — the chain emits combined-matcher leaves directly, no wrap step.
+// Phase 15 - the chain emits combined-matcher leaves directly, no wrap step.
 
 export { _gslStates } from './shortcuts/scopes/gslStates.impl';
 export { _gslTag } from './shortcuts/scopes/gslTag.impl';
 
-// ─── Public types ───
+// --- Public types ---
 
-export type { DxFormConfig, FormConfig, GslSelectorsInput } from '@golemui/dx';
+export type { GslSelectorsInput } from '@golemui/dx';
+export type { DxFormConfig, FormConfig } from './guiDependencyTypes';
 export type { DxRuntimeParams } from '@golemui/dx';
 export type { DxValidator } from '@golemui/dx';
 export { formDefs } from './formDefs';
@@ -267,7 +268,7 @@ export type {
   TimePickerDecorator,
 } from './shortcuts/time-picker/timePicker.domain';
 
-// ─── Extension API (for adding custom shortcut types) ───
+// --- Extension API (for adding custom shortcut types) ---
 
 export { defineShortcutType, guiRegistry } from './registry';
 export type { ShortcutTypeSelectors } from '@golemui/dx';

--- a/libs/gui/shared/src/lib/dx/resolveFormInput.ts
+++ b/libs/gui/shared/src/lib/dx/resolveFormInput.ts
@@ -1,8 +1,9 @@
 import type { ExpressionFunctions, ValidateOn } from '@golemui/core';
 import type { Action, I18nTranslator, Middleware, State } from '@golemui/core';
 import type { CustomValidatorSchemas } from '@golemui/gui-validators';
-import type { DxFormConfig, GslSelectorsInput, FormInput } from '@golemui/dx';
+import type { GslSelectorsInput, FormInput } from '@golemui/dx';
 import type { Dependencies } from '../shared';
+import type { DxFormConfig } from './guiDependencyTypes';
 import { guiImplementation } from './gui';
 
 // ===================================================
@@ -14,7 +15,9 @@ import { guiImplementation } from './gui';
 // ===================================================
 
 export { isDxDefinitions } from '@golemui/dx';
-export type { FormInput, ResolvedFormInput } from '@golemui/dx';
+export type { FormInput } from '@golemui/dx';
+// ResolvedFormInput carries the gui dependency shape, see guiDependencyTypes.ts.
+export type { ResolvedFormInput } from './guiDependencyTypes';
 
 export interface GuiFormInitConfig {
   formDef: FormInput;


### PR DESCRIPTION
## Description

`@golemui/dx` declared `dependencies` as an open `Record<string, unknown>`, and the types re-exported through `@golemui/gui-shared` inherited it. Reading `resolved.dependencies?.markdown?.parse(text)` stopped compiling, and a wrong `markdown` value stopped failing.

The shape is now a type parameter defaulted to the open record, declared on the config, result, resolver, and service types. A widget set states its own shape once in its `createImplementation` call. No casts, no runtime change.

Also tests and docs tweaks.