### PR TITLE
fix(gui-components): mark rollup chunks as side-effectful

### DIFF
--- a/libs/gui/components/package.json
+++ b/libs/gui/components/package.json
@@ -10,6 +10,8 @@
   "module": "./index.js",
   "types": "./index.d.ts",
   "sideEffects": [
+    "./*.js",
+    "./*.cjs",
     "./lib/components/*.js",
     "./lib/components/*.umd.cjs",
     "./src/lib/components/*.ts",


### PR DESCRIPTION
Mark rollup chunks as side-effectful so custom element registration survives consumer tree-shaking.

This was happening with Angular and Vue production builids, that treeshacked the List component inside a Dropdown.