### PR TITLE
fix(core): inputs added after form interaction no longer show errors before being touched

### DIFF
--- a/apps/apps-shared/src/lib/mocks/modular.dx.ts
+++ b/apps/apps-shared/src/lib/mocks/modular.dx.ts
@@ -42,4 +42,4 @@ export function buildModularDx(modules: DxModule[]): ModularDx {
   };
 }
 
-export const modularDx = buildModularDx([dxModularMocks.invoiceDxModular]);
+export const modularDx = buildModularDx([dxModularMocks.testsDxModular]);

--- a/apps/apps-shared/src/lib/mocks/tests.dx.ts
+++ b/apps/apps-shared/src/lib/mocks/tests.dx.ts
@@ -2,54 +2,114 @@ import type { DxDefinitionItem, DxFormConfig } from '@golemui/gui-shared';
 import { gui } from '@golemui/gui-shared';
 import { type DxModule } from './modular.dx';
 
-const data = { isVip: false };
+const data = {};
 
 const formDef: DxDefinitionItem[] = [
-  gui.inputs.textInput('userName', {
-    uid: 'user-name',
-    label: 'User Name',
-    hint: 'Your user name',
-    validator: { required: true, minLength: 3 },
+  gui.inputs.textInput('email', {
+    label: 'Email',
+    placeholder: 'name@company.com',
+    validator: {
+      required: true,
+      format: 'email',
+      messages: {
+        required: 'Please enter your email address',
+        format: "That doesn't look like an email — try name@company.com",
+      },
+    },
   }),
-  gui.inputs.checkbox('isVip', {
-    uid: 'is-vip',
-    label: 'Is VIP',
+  gui.inputs.password('password', {
+    label: 'Password',
+    validator: {
+      required: true,
+      minLength: 8,
+      pattern: '^(?=.*[A-Za-z])(?=.*\\d).+$',
+      messages: {
+        required: 'Please choose a password',
+        minLength: 'Password must be at least 8 characters',
+        pattern: 'Password must contain both letters and numbers',
+      },
+    },
+  }),
+  gui.inputs.radiogroup('tier', {
+    label: 'Account tier',
+    defaultValue: 'free',
+    options: [
+      { value: 'free', label: 'Free' },
+      { value: 'pro', label: 'Pro' },
+      { value: 'enterprise', label: 'Enterprise' },
+    ],
+    validator: { type: 'string', required: true },
   }),
   gui.displays.alert({
-    uid: 'vip-message',
-    text: 'Welcome VIP: {{$form.userName}}',
-    include: { in: ['vip'] },
+    text: 'Company details',
+    include: { in: ['paidPlan'] },
   }),
-  gui.displays.alert({
-    uid: 'alert1',
-    text: 'One Error: {{$errors.userName}}',
-    include: { when: '$errors.userName?.length === 1' },
+  gui.inputs.textInput('company.name', {
+    label: 'Company name',
+    include: { in: ['paidPlan'] },
+    validator: {
+      required: true,
+      minLength: 2,
+      messages: {
+        required: 'Please enter your company name',
+        minLength: 'Company name must be at least 2 characters',
+      },
+    },
   }),
-  gui.displays.alert({
-    uid: 'alert2',
-    text: 'Two Errors: {{$errors.userName}} becasue form is invalid: {{$formIsInvalid}}',
-    include: { when: '$errors.userName?.length === 2' },
+  gui.inputs.textInput('company.vatId', {
+    label: 'VAT / Tax ID (optional)',
+    include: { in: ['paidPlan'] },
+  }),
+  gui.inputs.numberInput('company.seats', {
+    label: 'Seats',
+    include: { in: ['paidPlan'] },
+    validator: {
+      required: true,
+      minimum: 5,
+      maximum: 1000,
+      multipleOf: 1,
+      messages: {
+        required: 'Tell us how many seats your team needs',
+        minimum: 'Paid plans start at 5 seats — enter 5 or more',
+        maximum: 'Paid plans max out at 1000 seats — contact sales for larger teams',
+        multipleOf: 'Seats must be a whole number',
+      },
+    },
+  }),
+  gui.inputs.checkbox('productUpdates', {
+    label: 'Send me product updates',
+    defaultValue: false,
+  }),
+  gui.inputs.radiogroup('updateFrequency', {
+    label: 'How often should we email you?',
+    defaultValue: 'monthly',
+    include: { when: '$form.productUpdates === true' },
+    options: [
+      { value: 'weekly', label: 'Weekly' },
+      { value: 'monthly', label: 'Monthly' },
+      { value: 'quarterly', label: 'Quarterly' },
+    ],
+    validator: { type: 'string', required: true },
+  }),
+  gui.inputs.checkbox('terms', {
+    label: 'I accept the Terms of Service and Privacy Policy',
+    defaultValue: false,
+    validator: {
+      const: true,
+      messages: {
+        const: 'You must accept the terms to create an account',
+      },
+    },
   }),
   gui.actions.button({
-    uid: 'dx-button-send',
-    label: 'Send Event',
-    onClick: () => 'testingEvens',
-  }),
-  gui.actions.button({
-    uid: 'dx-button-submit',
+    label: 'Create account',
     actionType: 'submit',
-    label: 'Submit',
     disabled: { when: '$formIsInvalid' },
-  }),
-  gui.displays.alert({
-    uid: 'send-result',
-    text: 'Press Submit to send the form',
-    level: 'info',
   }),
 ];
 
 const formConfig: DxFormConfig = {
-  states: { vip: '$form.isVip === true' },
+  states: { paidPlan: "$form.tier === 'pro' || $form.tier === 'enterprise'" },
 };
 
 export const testsDxModular: DxModule = {

--- a/libs/core/src/lib/store/model.ts
+++ b/libs/core/src/lib/store/model.ts
@@ -121,6 +121,12 @@ export type State = {
   touched: boolean;
 
   /**
+   * True once a VALIDATE_ALL pass has run (typically a submit attempt).
+   * Input widgets added afterwards are immediately marked as touched.
+   */
+  allControlsValidated: boolean;
+
+  /**
    * The BCP 47 language tag of the current locale (e.g., 'en-US', 'es', 'fr-CA').
    */
   lang: string;
@@ -150,6 +156,7 @@ export const createInitialState = (lang: string): State => ({
   meta: {},
   formHealth: { status: 'ok' },
   touched: false,
+  allControlsValidated: false,
   lang,
 });
 

--- a/libs/core/src/lib/store/reducer.ts
+++ b/libs/core/src/lib/store/reducer.ts
@@ -67,14 +67,31 @@ export const reducer = ({
       case 'SET_LANGUAGE':
         return pipe(setLanguage(state, action), applyWidgetProps);
 
-      case 'ADD_WIDGET':
-        return pipe(
+      case 'ADD_WIDGET': {
+        const stateAfterAdd = pipe(
           addWidget(state, action),
           reduceIf(formIsHealthy, applyCurrentState),
           reduceIf(formIsHealthy, materializeRepeaterItems),
           reduceIf(formIsHealthy, applyWidgetFlags),
           reduceIf(formIsHealthy, applyWidgetProps),
         );
+        // After a VALIDATE_ALL pass, a widget added later is touched but never validated, so validate
+        // here or its errors stay hidden until the next validation event.
+        // Must run after applyWidgetProps because validateAll reads the calculated `current` widget,
+        // which is empty until then.
+        if (formIsHealthy(stateAfterAdd) && stateAfterAdd.allControlsValidated) {
+          return pipe(
+            stateAfterAdd,
+            validateAll(validators, localization),
+            applyCurrentState,
+            materializeRepeaterItems,
+            applyWidgetFlags,
+            applyWidgetProps,
+            calculateIsFormValid,
+          );
+        }
+        return stateAfterAdd;
+      }
 
       case 'REMOVE_WIDGET':
         return pipe(
@@ -133,6 +150,7 @@ export const reducer = ({
           {
             ...state,
             touched: true,
+            allControlsValidated: true,
             touchedControls: Object.keys(state.calculatedWidgets).reduce(
               (touchedControls, key) => {
                 const widget = state.calculatedWidgets[key].source;

--- a/libs/core/src/lib/store/reducers/add-widget.ts
+++ b/libs/core/src/lib/store/reducers/add-widget.ts
@@ -10,11 +10,11 @@ export function addWidget(state: State, action: ADD_WIDGET): State {
 
   const widget = action.payload.widget;
 
-  // If the form has already been globally touched (e.g. submitted), immediately
-  // mark the incoming widget as touched so its validation errors are visible.
+  // Widgets added after a VALIDATE_ALL pass (a submit attempt) are marked as touched so
+  // their errors show immediately.
   const touchedControls =
-    state.touched && isInputWidget(widget)
-      ? { ...state.touchedControls, [(widget as any).path]: true }
+    state.allControlsValidated && isInputWidget(widget)
+      ? { ...state.touchedControls, [widget.path]: true }
       : state.touchedControls;
 
   return {

--- a/libs/ui-testing/src/lib/core-features/include-exclude.cy.ts
+++ b/libs/ui-testing/src/lib/core-features/include-exclude.cy.ts
@@ -486,4 +486,72 @@ export const runIncludeExcludeComponentTests = (mountFn: MountComponentFn) => {
       cy.get('[id="successMessage"]').should('exist');
     });
   });
+
+  describe('Error visibility of inputs revealed after form interaction', () => {
+    const revealFormDef = () =>
+      defineForm({
+        form: [
+          {
+            uid: 'firstName',
+            kind: 'input',
+            type: 'textinput',
+            path: 'firstName',
+            label: 'First Name',
+            validator: { type: 'string', required: true },
+          },
+          {
+            uid: 'toggle',
+            kind: 'input',
+            type: 'checkbox',
+            path: 'showDetails',
+            label: 'Show Details',
+          },
+          {
+            uid: 'details',
+            kind: 'input',
+            type: 'textinput',
+            path: 'details',
+            label: 'Details',
+            validator: { type: 'string', required: true },
+            include: { when: '$form.showDetails === true' },
+          },
+          {
+            uid: 'submitBtn',
+            kind: 'action',
+            type: 'button',
+            label: 'Submit',
+            actionType: 'submit',
+          },
+        ],
+      });
+
+    it('should not show errors on a revealed input when another control was touched before', () => {
+      mountFn({ formDef: revealFormDef() });
+
+      // Provoke a required error on firstName by typing and deleting a character
+      cy.get('[data-cy="firstName_textinput"]').type('a{backspace}');
+      cy.get('[data-cy="firstName_validator-errors"]').should('exist');
+
+      // Reveal the details input, it must appear without visible errors
+      cy.get('[data-cy="toggle_checkbox"]').click();
+      cy.get('[data-cy="details_textinput"]').should('exist');
+      cy.get('[data-cy="details_validator-errors"]').should('not.exist');
+
+      // Only after interacting with the revealed input do its errors show
+      cy.get('[data-cy="details_textinput"]').type('a{backspace}');
+      cy.get('[data-cy="details_validator-errors"]').should('exist');
+    });
+
+    it('should show errors immediately on a revealed input after a submit attempt', () => {
+      mountFn({ formDef: revealFormDef() });
+
+      cy.get('[data-cy="submitBtn_button"]').click();
+      cy.get('[data-cy="firstName_validator-errors"]').should('exist');
+
+      // After a submit attempt, a revealed input shows its errors without interaction
+      cy.get('[data-cy="toggle_checkbox"]').click();
+      cy.get('[data-cy="details_textinput"]').should('exist');
+      cy.get('[data-cy="details_validator-errors"]').should('exist');
+    });
+  });
 };


### PR DESCRIPTION
## Problem

In a form where the user has already blurred or changed any field, widgets added later (via `include: {in: ...}` or `include: {when: ...}`) mounted marked as touched already, so their validation errors rendered before the user ever interacted with them.

## Fix

- New `State.allControlsValidated` flag, set only by `VALIDATE_ALL` and reset on `INITIALIZE`. `addWidget` now uses this flag instead of `touched`.
- The `ADD_WIDGET` action now also runs a validation pass when `allControlsValidated` is true. Without it, a widget first mounted after submit was marked touched but had no computed validation status, so its errors stayed hidden until the next validation event.
