### PR TITLE
fix(gui-components): fix dropdown caret arrow position

### DIFF
--- a/libs/gui/components/src/styles/dropdown.scss
+++ b/libs/gui/components/src/styles/dropdown.scss
@@ -19,6 +19,7 @@
       inset-inline-end: var(--gui-space-3);
       transform-origin: 50% 40%;
       pointer-events: none;
+      display: flex;
     }
 
     &:has(> input[aria-expanded='true']) .gui-dropdown__arrow {


### PR DESCRIPTION
Fix dropdown caret arrow position