### PR TITLE
fix: date time intermediate states and commit on blur

### DIFF
--- a/libs/core/src/lib/store/reducers/inject-validation-issues.ts
+++ b/libs/core/src/lib/store/reducers/inject-validation-issues.ts
@@ -2,11 +2,22 @@ import { type INJECT_VALIDATION_ISSUES } from '../actions';
 import { type State } from '../model';
 
 export function injectValidationIssues(state: State, action: INJECT_VALIDATION_ISSUES): State {
+  const { path, issues } = action.payload;
+
+  // Mark as touched any control that has injected validation issues
+  const touched = issues?.length
+    ? {
+        touched: true,
+        touchedControls: { ...state.touchedControls, [path]: true },
+      }
+    : {};
+
   return {
     ...state,
+    ...touched,
     injectedValidations: {
       ...state.injectedValidations,
-      [action.payload.path]: action.payload.issues,
+      [path]: issues,
     },
   };
 }

--- a/libs/gui/angular/src/lib/components/date-input/date.component.html
+++ b/libs/gui/angular/src/lib/components/date-input/date.component.html
@@ -20,6 +20,7 @@
   [maxDate]="templateData.maxDate"
   [minDateMessage]="templateData.minDateMessage"
   [maxDateMessage]="templateData.maxDateMessage"
+  [incompleteMessage]="templateData.incompleteMessage"
   (change)="onChangeDate($event)"
   (inputError)="onInputError($event)"
   (blur)="adapter.onBlur()"

--- a/libs/gui/angular/src/lib/components/date-picker/date-picker.component.html
+++ b/libs/gui/angular/src/lib/components/date-picker/date-picker.component.html
@@ -33,6 +33,7 @@
   [minDateMessage]="templateData.minDateMessage"
   [maxDateMessage]="templateData.maxDateMessage"
   [disabledDateRangeMessage]="templateData.disabledDateRangeMessage"
+  [incompleteMessage]="templateData.incompleteMessage"
   (change)="onChangeDate($event)"
   (inputError)="onInputError($event)"
   (blur)="adapter.onBlur()"

--- a/libs/gui/angular/src/lib/components/date-time-calendar/date-time-calendar.component.html
+++ b/libs/gui/angular/src/lib/components/date-time-calendar/date-time-calendar.component.html
@@ -34,6 +34,7 @@
   [maxTimeMessage]="templateData.maxTimeMessage"
   [disabledTimeRangeMessage]="templateData.disabledTimeRangeMessage"
   [noAvailableTimesMessage]="templateData.noAvailableTimesMessage"
+  [incompleteMessage]="templateData.incompleteMessage"
   (change)="onChangeValue($event)"
   (inputError)="onInputError($event)"
   (blur)="adapter.onBlur()"

--- a/libs/gui/angular/src/lib/components/date-time-input/date-time.component.html
+++ b/libs/gui/angular/src/lib/components/date-time-input/date-time.component.html
@@ -27,6 +27,7 @@
   [maxDateMessage]="templateData.maxDateMessage"
   [minTimeMessage]="templateData.minTimeMessage"
   [maxTimeMessage]="templateData.maxTimeMessage"
+  [incompleteMessage]="templateData.incompleteMessage"
   [hourFormat]="templateData.hourFormat"
   [minuteStep]="templateData.minuteStep"
   (change)="onChangeDateTime($event)"

--- a/libs/gui/angular/src/lib/components/date-time-picker/date-time-picker.component.html
+++ b/libs/gui/angular/src/lib/components/date-time-picker/date-time-picker.component.html
@@ -46,6 +46,7 @@
   [maxTimeMessage]="templateData.maxTimeMessage"
   [disabledTimeRangeMessage]="templateData.disabledTimeRangeMessage"
   [noAvailableTimesMessage]="templateData.noAvailableTimesMessage"
+  [incompleteMessage]="templateData.incompleteMessage"
   (change)="onChangeDateTime($event)"
   (inputError)="onInputError($event)"
   (blur)="adapter.onBlur()"

--- a/libs/gui/angular/src/lib/components/range-date-picker/range-date-picker.component.html
+++ b/libs/gui/angular/src/lib/components/range-date-picker/range-date-picker.component.html
@@ -37,6 +37,7 @@
   [minDateMessage]="templateData.minDateMessage"
   [maxDateMessage]="templateData.maxDateMessage"
   [disabledDateRangeMessage]="templateData.disabledDateRangeMessage"
+  [incompleteMessage]="templateData.incompleteMessage"
   (change)="onChangeDate($event)"
   (inputError)="onInputError($event)"
   (blur)="adapter.onBlur()"

--- a/libs/gui/angular/src/lib/components/range-date-time-calendar/range-date-time-calendar.component.html
+++ b/libs/gui/angular/src/lib/components/range-date-time-calendar/range-date-time-calendar.component.html
@@ -34,6 +34,7 @@
   [maxDateTimeMessage]="templateData.maxDateTimeMessage"
   [disabledRangeMessage]="templateData.disabledRangeMessage"
   [noAvailableTimesMessage]="templateData.noAvailableTimesMessage"
+  [incompleteMessage]="templateData.incompleteMessage"
   [dayCountAriaLabel]="templateData.dayCountAriaLabel"
   [disabledDayCountAriaLabel]="templateData.disabledDayCountAriaLabel"
   (change)="onChangeValue($event)"

--- a/libs/gui/angular/src/lib/components/range-date-time-picker/range-date-time-picker.component.html
+++ b/libs/gui/angular/src/lib/components/range-date-time-picker/range-date-time-picker.component.html
@@ -46,6 +46,7 @@
   [maxDateTimeMessage]="templateData.maxDateTimeMessage"
   [disabledRangeMessage]="templateData.disabledRangeMessage"
   [noAvailableTimesMessage]="templateData.noAvailableTimesMessage"
+  [incompleteMessage]="templateData.incompleteMessage"
   [dayCountAriaLabel]="templateData.dayCountAriaLabel"
   [disabledDayCountAriaLabel]="templateData.disabledDayCountAriaLabel"
   (change)="onChangeValue($event)"

--- a/libs/gui/angular/src/lib/components/range-date-time/range-date-time.component.html
+++ b/libs/gui/angular/src/lib/components/range-date-time/range-date-time.component.html
@@ -29,6 +29,7 @@
   [invalidDateMessage]="templateData.invalidDateMessage"
   [minDateTimeMessage]="templateData.minDateTimeMessage"
   [maxDateTimeMessage]="templateData.maxDateTimeMessage"
+  [incompleteMessage]="templateData.incompleteMessage"
   (blur)="adapter.onBlur()"
   (change)="onChangeDateTime($event)"
   (inputError)="onInputError($event)"

--- a/libs/gui/angular/src/lib/components/range-date/range-date.component.html
+++ b/libs/gui/angular/src/lib/components/range-date/range-date.component.html
@@ -16,6 +16,7 @@
   [monthAriaLabel]="templateData.monthAriaLabel"
   [yearAriaLabel]="templateData.yearAriaLabel"
   [invalidDateMessage]="templateData.invalidDateMessage"
+  [incompleteMessage]="templateData.incompleteMessage"
   [separator]="templateData.separator"
   [removePillAriaLabel]="templateData.removePillAriaLabel"
   [startDateAriaLabel]="templateData.startDateAriaLabel"

--- a/libs/gui/angular/src/lib/components/range-time-picker/range-time-picker.component.html
+++ b/libs/gui/angular/src/lib/components/range-time-picker/range-time-picker.component.html
@@ -35,6 +35,7 @@
   [rangeOrderMessage]="templateData.rangeOrderMessage"
   [disabledRangeMessage]="templateData.disabledRangeMessage"
   [noAvailableTimesMessage]="templateData.noAvailableTimesMessage"
+  [incompleteMessage]="templateData.incompleteMessage"
   (change)="onChangeTime($event)"
   (inputError)="onInputError($event)"
   (blur)="adapter.onBlur()"

--- a/libs/gui/angular/src/lib/components/range-time/range-time.component.html
+++ b/libs/gui/angular/src/lib/components/range-time/range-time.component.html
@@ -26,6 +26,7 @@
   [minTimeMessage]="templateData.minTimeMessage"
   [maxTimeMessage]="templateData.maxTimeMessage"
   [rangeOrderMessage]="templateData.rangeOrderMessage"
+  [incompleteMessage]="templateData.incompleteMessage"
   (blur)="adapter.onBlur()"
   (change)="onChangeTime($event)"
   (inputError)="onInputError($event)"

--- a/libs/gui/angular/src/lib/components/time-input/time.component.html
+++ b/libs/gui/angular/src/lib/components/time-input/time.component.html
@@ -21,6 +21,7 @@
   [maxTime]="templateData.maxTime"
   [minTimeMessage]="templateData.minTimeMessage"
   [maxTimeMessage]="templateData.maxTimeMessage"
+  [incompleteMessage]="templateData.incompleteMessage"
   (change)="onChangeTime($event)"
   (inputError)="onInputError($event)"
   (blur)="adapter.onBlur()"

--- a/libs/gui/angular/src/lib/components/time-picker/time-picker.component.html
+++ b/libs/gui/angular/src/lib/components/time-picker/time-picker.component.html
@@ -28,6 +28,7 @@
   [maxTimeMessage]="templateData.maxTimeMessage"
   [disabledRangeMessage]="templateData.disabledRangeMessage"
   [noAvailableTimesMessage]="templateData.noAvailableTimesMessage"
+  [incompleteMessage]="templateData.incompleteMessage"
   (change)="onChangeTime($event)"
   (inputError)="onInputError($event)"
   (blur)="adapter.onBlur()"

--- a/libs/gui/components/src/lib/components/date-input.ts
+++ b/libs/gui/components/src/lib/components/date-input.ts
@@ -275,12 +275,17 @@ export class GuiDate extends LitElement {
   };
 
   /**
-   * A partial group left behind flips the value to null — so validators
-   * report it even on non-required fields — and surfaces the incomplete
-   * message. An emptied group instead clears any surfaced error. A complete
-   * group already reported through the commit pipeline.
+   * The single point where the input reports focus leaving the control: it
+   * blurs (which the form layer reads as "validate now"), so hopping between
+   * segments never validates a half-typed entry. A partial group left behind
+   * then flips the value to null — so validators report it even on
+   * non-required fields — and surfaces the incomplete message. An emptied
+   * group instead clears any surfaced error. A complete group already
+   * reported through the commit pipeline.
    */
   private onFocusLeave(): void {
+    this.dispatchEvent(new CustomEvent('blur'));
+
     const completeness = this.groupCompleteness();
     if (completeness === 'complete') return;
 

--- a/libs/gui/components/src/lib/components/date-input.ts
+++ b/libs/gui/components/src/lib/components/date-input.ts
@@ -277,15 +277,14 @@ export class GuiDate extends LitElement {
   /**
    * The single point where the input reports focus leaving the control: it
    * blurs (which the form layer reads as "validate now"), so hopping between
-   * segments never validates a half-typed entry. A partial group left behind
-   * then flips the value to null — so validators report it even on
-   * non-required fields — and surfaces the incomplete message. An emptied
-   * group instead clears any surfaced error. A complete group already
-   * reported through the commit pipeline.
+   * segments never validates a half-typed entry.
    */
   private onFocusLeave(): void {
     this.dispatchEvent(new CustomEvent('blur'));
+    this.settleOnFocusLeave();
+  }
 
+  settleOnFocusLeave(): void {
     const completeness = this.groupCompleteness();
     if (completeness === 'complete') return;
 

--- a/libs/gui/components/src/lib/components/date-input.ts
+++ b/libs/gui/components/src/lib/components/date-input.ts
@@ -3,8 +3,10 @@ import { html, LitElement, nothing, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { GUIAriaController } from '../controllers/aria.controller';
+import { GUIFocusLeaveController } from '../controllers/focus-leave.controller';
 import { GUIPartsController } from '../controllers/parts.controller';
 import { dateBoundsError, getDateFormatParts } from '../utils/date';
+import { INCOMPLETE_DATE_MESSAGE } from '../utils/messages';
 import { renderGroupParts, type GUIPartsTemplateData } from '../utils/part-templates';
 import {
   dateInputPartDescriptors,
@@ -12,8 +14,11 @@ import {
   PART_DEFAULT_ARIA_LABELS,
   type DateTimePartDescriptor,
   type DateTimePartType,
+  type GroupCompleteness,
 } from '../utils/parts';
 import { addErrors, addLabel, type ControlTemplateData } from '../utils/templates';
+
+const DATE_PART_TYPES: readonly DateTimePartType[] = ['day', 'month', 'year'];
 
 @customElement('gui-date')
 export class GuiDate extends LitElement {
@@ -37,6 +42,17 @@ export class GuiDate extends LitElement {
   @property({ type: String, attribute: 'invalid-date-message' }) invalidDateMessage:
     | string
     | undefined = undefined;
+  @property({ type: String, attribute: 'incomplete-message' }) incompleteMessage:
+    | string
+    | undefined = undefined;
+  /**
+   * Set by host pickers that run their own whole-widget focus-leave check:
+   * moving focus from this input into the picker's popover must not count as
+   * leaving, so the embedded input skips its incomplete-on-leave handling.
+   */
+  @property({ type: Boolean, attribute: 'defer-focus-leave' }) deferFocusLeave:
+    | boolean
+    | undefined = false;
   @property({ type: String, attribute: 'min-date' }) minDate: string | undefined = undefined;
   @property({ type: String, attribute: 'max-date' }) maxDate: string | undefined = undefined;
   @property({ type: String, attribute: 'min-date-message' }) minDateMessage: string | undefined =
@@ -56,9 +72,34 @@ export class GuiDate extends LitElement {
     commitGroup: (group) => this.validateAndEmit(group),
     isReadonly: () => !!this.readOnly,
     isDisabled: () => !!this.disabled,
-    onEmptyPartBlur: () =>
-      this.dispatchEvent(new CustomEvent('change', { detail: { value: null }, bubbles: true })),
+    onEmptyPartBlur: (group, type) => {
+      // A raw 0 counts as emptying the part, so clear it in state (the clamp
+      // write-back would otherwise leave a phantom value behind).
+      this._parts.setPart(group, type, '');
+
+      if (!this.value) return;
+
+      this._internalNullReport = true;
+      this.value = undefined;
+      this.dispatchEvent(new CustomEvent('change', { detail: { value: null }, bubbles: true }));
+      this._parts.resetSurfacedInputError();
+    },
+    onInputErrorSurfaced: (message) =>
+      this.dispatchEvent(new CustomEvent('inputError', { detail: { message }, bubbles: true })),
+    onSurfacedErrorCleared: (value) =>
+      this.dispatchEvent(new CustomEvent('change', { detail: { value }, bubbles: true })),
   });
+
+  private _focusLeave = new GUIFocusLeaveController(this, {
+    onLeave: () => this.onFocusLeave(),
+  });
+
+  /**
+   * Marks a value clear that the widget itself reported (an emptied part or
+   * an abandoned partial). The surviving segments must not be wiped when the
+   * clear — or its null echo from the form — lands back on the value prop.
+   */
+  private _internalNullReport = false;
 
   protected ariaController: GUIAriaController<unknown, any> = new GUIAriaController(this, {
     getTargets: () => this.querySelectorAll(`.${this.inputBlockClass}`),
@@ -90,6 +131,12 @@ export class GuiDate extends LitElement {
 
   override willUpdate(changedProperties: PropertyValues): void {
     if (changedProperties.has('value')) {
+      const internalNull = this._internalNullReport;
+      this._internalNullReport = false;
+      const prev = changedProperties.get('value') as string | null | undefined;
+
+      if (!this.value && (internalNull || !prev)) return;
+
       this._parts.setGroupFromISO('default', this.value ?? '', 'date');
     }
   }
@@ -134,7 +181,7 @@ export class GuiDate extends LitElement {
     return html`
       ${this.label ? addLabel(this.uid as string, templateData, false, undefined, false) : nothing}
 
-      <div class="gui-widget">
+      <div class="gui-widget" @focusout=${this.onWidgetFocusOut}>
         <div
           id=${this.uid}
           class="gui-widget-input gui-parts gui-parts-ring gui-date-input ${this.icon
@@ -169,14 +216,17 @@ export class GuiDate extends LitElement {
     });
     this._parts.applyWriteBacks(group, writeBacks);
 
+    this.dispatchEvent(
+      new CustomEvent('partsChange', {
+        detail: { date: result.kind === 'valid' ? result.iso : null },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+
     if (result.kind === 'invalid') {
       // Date is complete but invalid
-      this.dispatchEvent(
-        new CustomEvent('inputError', {
-          detail: { message: result.message },
-          bubbles: true,
-        }),
-      );
+      this._parts.surfaceInputError(result.message);
     } else if (result.kind === 'valid') {
       const boundsError = dateBoundsError(result.iso, this.minDate, this.maxDate, undefined, {
         minDateMessage: this.minDateMessage,
@@ -190,17 +240,13 @@ export class GuiDate extends LitElement {
             bubbles: true,
           }),
         );
-        this.dispatchEvent(
-          new CustomEvent('inputError', {
-            detail: { message: boundsError },
-            bubbles: true,
-          }),
-        );
+        this._parts.surfaceInputError(boundsError);
         this.requestUpdate();
         return;
       }
 
       this.value = result.iso;
+      this._parts.resetSurfacedInputError();
 
       this.dispatchEvent(
         new CustomEvent('change', {
@@ -211,6 +257,44 @@ export class GuiDate extends LitElement {
     }
 
     this.requestUpdate();
+  }
+
+  /** The group's fill state, for host pickers' own focus-leave checks. */
+  groupCompleteness(): GroupCompleteness {
+    const { result } = parseDateGroup(this._parts.values['default'] ?? {}, {
+      descriptors: this.partDescriptors,
+      invalidDateMessage: this.invalidDateMessage,
+    });
+    if (result.kind !== 'incomplete') return 'complete';
+    return this._parts.isGroupEmpty('default', DATE_PART_TYPES) ? 'empty' : 'partial';
+  }
+
+  private onWidgetFocusOut = (event: FocusEvent): void => {
+    if (this.deferFocusLeave) return;
+    this._focusLeave.handleFocusOut(event);
+  };
+
+  /**
+   * A partial group left behind flips the value to null — so validators
+   * report it even on non-required fields — and surfaces the incomplete
+   * message. An emptied group instead clears any surfaced error. A complete
+   * group already reported through the commit pipeline.
+   */
+  private onFocusLeave(): void {
+    const completeness = this.groupCompleteness();
+    if (completeness === 'complete') return;
+
+    if (completeness === 'empty') {
+      this._parts.clearSurfacedInputError(null);
+      return;
+    }
+
+    if (this.value) {
+      this._internalNullReport = true;
+      this.value = undefined;
+    }
+    this.dispatchEvent(new CustomEvent('change', { detail: { value: null }, bubbles: true }));
+    this._parts.surfaceInputError(this.incompleteMessage ?? INCOMPLETE_DATE_MESSAGE);
   }
 }
 

--- a/libs/gui/components/src/lib/components/date-picker.ts
+++ b/libs/gui/components/src/lib/components/date-picker.ts
@@ -8,7 +8,6 @@ import type { GuiDate } from './date-input';
 import { GUIFocusLeaveController } from '../controllers/focus-leave.controller';
 import { GUIPopupController } from '../controllers/popup.controller';
 import { dateBoundsError } from '../utils/date';
-import { INCOMPLETE_DATE_MESSAGE } from '../utils/messages';
 import { addErrors, addIcon, addLabel } from '../utils/templates';
 
 @customElement('gui-date-picker')
@@ -173,6 +172,7 @@ export class GuiDatePicker extends LitElement {
           .monthAriaLabel=${this.monthAriaLabel}
           .yearAriaLabel=${this.yearAriaLabel}
           .invalidDateMessage=${this.invalidDateMessage}
+          .incompleteMessage=${this.incompleteMessage}
           @blur=${this.onDateBlur}
           @focus=${this._popup.show}
           @change=${this.onDateChange}
@@ -281,24 +281,15 @@ export class GuiDatePicker extends LitElement {
 
   /**
    * The single point where the picker reports focus leaving the control: it
-   * blurs (which the form layer reads as "validate now"), and a partially
-   * typed date left behind flips the value to null — so validators report it
-   * even on non-required fields — and surfaces the incomplete message.
+   * blurs (which the form layer reads as "validate now"), then hands the
+   * embedded input its deferred settlement — a partial date left behind
+   * surfaces the incomplete message, an emptied one clears a message it
+   * surfaced earlier. The input's resulting change bubbles back through
+   * {@link onDateChange}, so the picker's value follows.
    */
   private onFocusLeave(): void {
     this.dispatchEvent(new CustomEvent('blur'));
-
-    const input = this.querySelector<GuiDate>('gui-date');
-    if (!input || input.groupCompleteness() !== 'partial') return;
-
-    this.commitValue(null);
-    this.dispatchEvent(
-      new CustomEvent('inputError', {
-        detail: { message: this.incompleteMessage ?? INCOMPLETE_DATE_MESSAGE },
-        bubbles: true,
-        composed: true,
-      }),
-    );
+    this.querySelector<GuiDate>('gui-date')?.settleOnFocusLeave();
   }
 }
 

--- a/libs/gui/components/src/lib/components/date-picker.ts
+++ b/libs/gui/components/src/lib/components/date-picker.ts
@@ -4,8 +4,11 @@ import { classMap } from 'lit/directives/class-map.js';
 import type { DateRange } from '@golemui/gui-shared/internals';
 import './date-input';
 import './calendar';
+import type { GuiDate } from './date-input';
+import { GUIFocusLeaveController } from '../controllers/focus-leave.controller';
 import { GUIPopupController } from '../controllers/popup.controller';
 import { dateBoundsError } from '../utils/date';
+import { INCOMPLETE_DATE_MESSAGE } from '../utils/messages';
 import { addErrors, addIcon, addLabel } from '../utils/templates';
 
 @customElement('gui-date-picker')
@@ -73,6 +76,13 @@ export class GuiDatePicker extends LitElement {
   @property({ type: String, attribute: 'disabled-date-range-message' }) disabledDateRangeMessage:
     | string
     | undefined = undefined;
+  @property({ type: String, attribute: 'incomplete-message' }) incompleteMessage:
+    | string
+    | undefined = undefined;
+
+  private _focusLeave = new GUIFocusLeaveController(this, {
+    onLeave: () => this.onFocusLeave(),
+  });
 
   private _popup = new GUIPopupController(this, {
     focusRestoreSelector: 'gui-date input',
@@ -142,6 +152,7 @@ export class GuiDatePicker extends LitElement {
         class="gui-widget"
         @keydown=${this._popup.onAnchorKeyDown}
         @click=${this._popup.onAnchorClick}
+        @focusout=${this._focusLeave.onFocusOut}
       >
         <gui-date
           id="date-input"
@@ -149,6 +160,7 @@ export class GuiDatePicker extends LitElement {
           .uid=${this.uid}
           .hint=${this.hint}
           .showErrors=${false}
+          .deferFocusLeave=${true}
           .errors=${this.errors}
           ?touched=${this.touched}
           ?required=${this.required}
@@ -211,8 +223,14 @@ export class GuiDatePicker extends LitElement {
     this.commitValue(event.detail.value);
   }
 
-  private onDateBlur() {
-    this.dispatchEvent(new CustomEvent('blur'));
+  /**
+   * The field's per-part blur stays inside the widget: moving from a segment
+   * into the popover is not leaving the control, so it must not be reported
+   * as a blur (which the form layer reads as "validate now"). The picker
+   * reports blur from its own focus-leave check instead.
+   */
+  private onDateBlur(event: Event) {
+    event.stopPropagation();
   }
 
   private onCalendarChange(event: CustomEvent) {
@@ -251,8 +269,36 @@ export class GuiDatePicker extends LitElement {
     });
   }
 
-  private onCalendarBlur() {
+  /**
+   * Focus leaving the calendar closes the popover, but it is not necessarily
+   * leaving the picker (focus often returns to the field), so the calendar's
+   * bubbling blur is stopped here and never reaches the form layer.
+   */
+  private onCalendarBlur(event: Event) {
+    event.stopPropagation();
     this._popup.closeOnFocusLeave();
+  }
+
+  /**
+   * The single point where the picker reports focus leaving the control: it
+   * blurs (which the form layer reads as "validate now"), and a partially
+   * typed date left behind flips the value to null — so validators report it
+   * even on non-required fields — and surfaces the incomplete message.
+   */
+  private onFocusLeave(): void {
+    this.dispatchEvent(new CustomEvent('blur'));
+
+    const input = this.querySelector<GuiDate>('gui-date');
+    if (!input || input.groupCompleteness() !== 'partial') return;
+
+    this.commitValue(null);
+    this.dispatchEvent(
+      new CustomEvent('inputError', {
+        detail: { message: this.incompleteMessage ?? INCOMPLETE_DATE_MESSAGE },
+        bubbles: true,
+        composed: true,
+      }),
+    );
   }
 }
 

--- a/libs/gui/components/src/lib/components/date-time-calendar.ts
+++ b/libs/gui/components/src/lib/components/date-time-calendar.ts
@@ -301,6 +301,10 @@ export class GuiDateTimeCalendar extends LitElement {
     this.emitChange(this.value as string, commit);
   }
 
+  private stopInnerPartsChange = (event: Event) => {
+    event.stopPropagation();
+  };
+
   private onTimePickerChange(event: CustomEvent) {
     event.stopPropagation();
 
@@ -464,6 +468,7 @@ export class GuiDateTimeCalendar extends LitElement {
           .disabledRangeMessage=${this.disabledTimeRangeMessage}
           .noAvailableTimesMessage=${this.noAvailableTimesMessage}
           @change=${this.onTimePickerChange}
+          @partsChange=${this.stopInnerPartsChange}
           @listtoggle=${this.onListToggle}
         ></gui-time-picker>
       </div>

--- a/libs/gui/components/src/lib/components/date-time-calendar.ts
+++ b/libs/gui/components/src/lib/components/date-time-calendar.ts
@@ -23,6 +23,12 @@ import {
 } from '../utils/date';
 import { buildMonthDays, computeDayStatus } from '../utils/day-status';
 import {
+  INCOMPLETE_DATE_TIME_MESSAGE,
+  INVALID_DISABLED_TIME_RANGE_MESSAGE,
+} from '../utils/messages';
+import { timeBoundsError } from '../utils/parts';
+import {
+  isTimeDisabled,
   parseISODateTimeString,
   resolveDisabledTimeRangesForDate,
   toISOTimeString,
@@ -103,6 +109,28 @@ export class GuiDateTimeCalendar extends LitElement {
   @property({ type: Boolean, attribute: 'allow-custom-time' }) allowCustomTime:
     | boolean
     | undefined = false;
+  @property({ type: String, attribute: 'incomplete-message' }) incompleteMessage:
+    | string
+    | undefined = undefined;
+  /**
+   * Host picker's working (uncommitted) date/time halves. They seed the
+   * internal selection whenever no committed value exists, so a partial
+   * selection survives the popover unmount/remount cycle. A committed `value`
+   * always takes precedence.
+   */
+  @property({ type: String, attribute: 'working-date' }) workingDate: string | undefined =
+    undefined;
+  @property({ type: String, attribute: 'working-time' }) workingTime: string | undefined =
+    undefined;
+  /**
+   * Set by host pickers that run their own whole-widget focus-leave check:
+   * moving focus from this calendar into the picker's input must not count as
+   * leaving, so the embedded calendar skips its incomplete-on-leave handling
+   * (the `blur` re-dispatch still fires — hosts close the popover with it).
+   */
+  @property({ type: Boolean, attribute: 'defer-focus-leave' }) deferFocusLeave:
+    | boolean
+    | undefined = false;
 
   @state() private _selectedDate: string | undefined = undefined;
   @state() private _selectedTime: string | undefined = undefined;
@@ -162,6 +190,8 @@ export class GuiDateTimeCalendar extends LitElement {
   private _focusLeave = new GUIFocusLeaveController(this, {
     onLeave: () => {
       this.dispatchEvent(new CustomEvent('blur', { bubbles: true, composed: true }));
+      if (this.deferFocusLeave) return;
+      this.reportIncompleteOnLeave();
     },
   });
 
@@ -185,8 +215,18 @@ export class GuiDateTimeCalendar extends LitElement {
     this.classList.add('gui-field');
   }
 
+  /**
+   * Derives the internal selection with a strict precedence: a committed
+   * `value` wins, else the host's working halves, else cleared. Running the
+   * same rule on every external change (value or working props) keeps a
+   * remounted popover consistent and prevents a stale day surviving an
+   * external value clear.
+   */
   override willUpdate(changedProperties: PropertyValues): void {
-    if (!changedProperties.has('value')) return;
+    const valueChanged = changedProperties.has('value');
+    const workingChanged =
+      changedProperties.has('workingDate') || changedProperties.has('workingTime');
+    if (!valueChanged && !workingChanged) return;
     if (this._internalValueChange) {
       this._internalValueChange = false;
       return;
@@ -197,13 +237,26 @@ export class GuiDateTimeCalendar extends LitElement {
       if (!isNaN(date.getTime())) {
         this._selectedDate = toISODateString(date);
         this._selectedTime = toISOTimeString(date);
-        if (!isDateInVisibleMonths(date, this._nav.currentDate, this.numberOfMonths ?? 1)) {
-          this._nav.currentDate = date;
-        }
+        this.navigateToDate(date);
       }
-    } else if (this._selectedTime) {
-      this._selectedDate = undefined;
-      this._selectedTime = undefined;
+      return;
+    }
+
+    const prev = changedProperties.get('value') as string | null | undefined;
+    const clearedFromCommitted = valueChanged && !!prev;
+    if (!clearedFromCommitted && !workingChanged) return;
+
+    this._selectedDate = this.workingDate || undefined;
+    this._selectedTime = this.workingTime || undefined;
+    if (this._selectedDate) {
+      const date = parseISODateString(this._selectedDate);
+      if (!isNaN(date.getTime())) this.navigateToDate(date);
+    }
+  }
+
+  private navigateToDate(date: Date): void {
+    if (!isDateInVisibleMonths(date, this._nav.currentDate, this.numberOfMonths ?? 1)) {
+      this._nav.currentDate = date;
     }
   }
 
@@ -229,17 +282,20 @@ export class GuiDateTimeCalendar extends LitElement {
     if (isoDate === this._selectedDate) return;
 
     this._selectedDate = isoDate;
-    this._selectedTime = undefined;
 
-    if (this.value) {
-      this.setValueInternal(undefined);
-      this.emitChange(null);
+    if (this._selectedTime) {
+      const isoTime = this._selectedTime;
+      this.setValueInternal(`${isoDate}T${isoTime}`);
+      this.emitChange(this.value as string);
+      const error = this.timeErrorForDay(isoTime, isoDate);
+      if (error) this.emitInputError(error);
+      return;
     }
+
+    this.emitPartsChange();
   }
 
   private commitTime(isoTime: string, commit = false) {
-    if (!this._selectedDate) return;
-
     this._selectedTime = isoTime;
     this.setValueInternal(`${this._selectedDate}T${isoTime}`);
     this.emitChange(this.value as string, commit);
@@ -256,10 +312,72 @@ export class GuiDateTimeCalendar extends LitElement {
         this.setValueInternal(undefined);
         this.emitChange(null);
       }
+      this.emitPartsChange();
+      return;
+    }
+
+    // No day chosen yet: park the time as working state and live-sync it —
+    // the pick is kept, not lost, and commits once a day arrives.
+    if (!this._selectedDate) {
+      this._selectedTime = time;
+      this.emitPartsChange();
       return;
     }
 
     this.commitTime(time, commit);
+  }
+
+  /** Live-syncs the working halves to a host picker (never wired by forms). */
+  private emitPartsChange(): void {
+    this.dispatchEvent(
+      new CustomEvent('partsChange', {
+        detail: { date: this._selectedDate ?? null, time: this._selectedTime ?? null },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private emitInputError(message: string): void {
+    this.dispatchEvent(
+      new CustomEvent('inputError', {
+        detail: { message },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  /** The kept time checked against a day's bounds and disabled ranges. */
+  private timeErrorForDay(isoTime: string, isoDate: string): string | null {
+    const boundsError = timeBoundsError(isoTime, {
+      minTime: this.minTime,
+      maxTime: this.maxTime,
+      minTimeMessage: this.minTimeMessage,
+      maxTimeMessage: this.maxTimeMessage,
+    });
+    if (boundsError) return boundsError;
+
+    const ranges = resolveDisabledTimeRangesForDate(this.disabledTimeRanges, isoDate);
+    if (isTimeDisabled(isoTime, ranges)) {
+      return this.disabledTimeRangeMessage ?? INVALID_DISABLED_TIME_RANGE_MESSAGE;
+    }
+    return null;
+  }
+
+  /**
+   * A partial selection (day without time, or time without day) left behind
+   * flips the value to null — so validators report it — and surfaces the
+   * incomplete message. Complete or empty selections report nothing new.
+   */
+  private reportIncompleteOnLeave(): void {
+    if (this.value) return;
+    const hasDate = !!this._selectedDate;
+    const hasTime = !!this._selectedTime;
+    if (hasDate === hasTime) return;
+
+    this.emitChange(null);
+    this.emitInputError(this.incompleteMessage ?? INCOMPLETE_DATE_TIME_MESSAGE);
   }
 
   private onListToggle(event: CustomEvent<{ open: boolean }>) {
@@ -328,8 +446,9 @@ export class GuiDateTimeCalendar extends LitElement {
           class="gui-time-picker gui-field"
           .uid=${this.uid ? `${this.uid}-time` : undefined}
           .showErrors=${false}
+          .deferFocusLeave=${true}
           ?required=${this.required}
-          ?disabled=${this.disabled || !this._selectedDate}
+          ?disabled=${this.disabled}
           ?readonly=${this.readOnly}
           .allowCustomTime=${this.allowCustomTime}
           .value=${this._selectedTime}

--- a/libs/gui/components/src/lib/components/date-time-calendar.ts
+++ b/libs/gui/components/src/lib/components/date-time-calendar.ts
@@ -3,6 +3,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import type { DateRange, DisabledTimeRange } from '@golemui/gui-shared/internals';
 import './time-picker';
+import type { GuiTime } from './time-input';
 import type { GuiTimePicker } from './time-picker';
 import { GUIAriaController } from '../controllers/aria.controller';
 import { GUICalendarKeyboardController } from '../controllers/calendar-keyboard.controller';
@@ -375,17 +376,25 @@ export class GuiDateTimeCalendar extends LitElement {
   }
 
   /**
-   * A partial selection (day without time, or time without day) left behind
-   * flips the value to null — so validators report it — and surfaces the
-   * incomplete message. A selection emptied again instead clears a message
-   * surfaced earlier; complete selections report nothing new.
+   * With no committed value, ANY selection state left behind — a day without
+   * a time, a time without a day, or a half-typed time — is incomplete: the
+   * value flips to null (so validators report it) and the incomplete message
+   * surfaces. A widget emptied again instead clears a message surfaced
+   * earlier; a committed value reports nothing new.
+   *
+   * A half-typed time never reaches `_selectedTime` (partials never emit),
+   * so the embedded input's parts are consulted directly — otherwise an
+   * hour typed with no day picked would read as an empty widget.
    */
   private reportIncompleteOnLeave(): void {
     if (this.value) return;
-    const hasDate = !!this._selectedDate;
-    const hasTime = !!this._selectedTime;
-    if (hasDate === hasTime) {
-      if (!hasDate && this._surfacedError) this.emitChange(null);
+    const leftBehind =
+      !!this._selectedDate ||
+      !!this._selectedTime ||
+      this.querySelector<GuiTime>('gui-time')?.groupCompleteness() === 'partial';
+
+    if (!leftBehind) {
+      if (this._surfacedError) this.emitChange(null);
       return;
     }
 

--- a/libs/gui/components/src/lib/components/date-time-calendar.ts
+++ b/libs/gui/components/src/lib/components/date-time-calendar.ts
@@ -266,6 +266,7 @@ export class GuiDateTimeCalendar extends LitElement {
   }
 
   private emitChange(value: string | null, commit = false) {
+    this._surfacedError = false;
     this.dispatchEvent(
       new CustomEvent('change', {
         detail: { value, commit },
@@ -342,7 +343,11 @@ export class GuiDateTimeCalendar extends LitElement {
     );
   }
 
+  /** Whether an inputError has been emitted and not yet cleared by a change. */
+  private _surfacedError = false;
+
   private emitInputError(message: string): void {
+    this._surfacedError = true;
     this.dispatchEvent(
       new CustomEvent('inputError', {
         detail: { message },
@@ -372,13 +377,17 @@ export class GuiDateTimeCalendar extends LitElement {
   /**
    * A partial selection (day without time, or time without day) left behind
    * flips the value to null — so validators report it — and surfaces the
-   * incomplete message. Complete or empty selections report nothing new.
+   * incomplete message. A selection emptied again instead clears a message
+   * surfaced earlier; complete selections report nothing new.
    */
   private reportIncompleteOnLeave(): void {
     if (this.value) return;
     const hasDate = !!this._selectedDate;
     const hasTime = !!this._selectedTime;
-    if (hasDate === hasTime) return;
+    if (hasDate === hasTime) {
+      if (!hasDate && this._surfacedError) this.emitChange(null);
+      return;
+    }
 
     this.emitChange(null);
     this.emitInputError(this.incompleteMessage ?? INCOMPLETE_DATE_TIME_MESSAGE);

--- a/libs/gui/components/src/lib/components/date-time-input.ts
+++ b/libs/gui/components/src/lib/components/date-time-input.ts
@@ -3,18 +3,30 @@ import { html, LitElement, nothing, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { GUIAriaController } from '../controllers/aria.controller';
+import { GUIFocusLeaveController } from '../controllers/focus-leave.controller';
 import { GUIPartsController } from '../controllers/parts.controller';
 import { dateBoundsError } from '../utils/date';
+import { INCOMPLETE_DATE_TIME_MESSAGE } from '../utils/messages';
 import { renderGroupParts, type GUIPartsTemplateData } from '../utils/part-templates';
 import {
   getTimeLocaleData,
   parseDateTimeGroup,
+  parseDateTimeSubGroups,
   PART_DEFAULT_ARIA_LABELS,
   timeBoundsError,
   type DateTimePartDescriptor,
   type DateTimePartType,
+  type GroupCompleteness,
   type TimeLocaleData,
 } from '../utils/parts';
+
+const DATE_TIME_PART_TYPES: readonly DateTimePartType[] = [
+  'day',
+  'month',
+  'year',
+  'hour',
+  'minute',
+];
 import { getDateTimeFormatParts, toISOTimeString, type HourFormat } from '../utils/time';
 import { addErrors, addLabel, type ControlTemplateData } from '../utils/templates';
 
@@ -59,6 +71,17 @@ export class GuiDateTime extends LitElement {
     undefined;
   @property({ type: String, attribute: 'max-time-message' }) maxTimeMessage: string | undefined =
     undefined;
+  @property({ type: String, attribute: 'incomplete-message' }) incompleteMessage:
+    | string
+    | undefined = undefined;
+  /**
+   * Set by host pickers that run their own whole-widget focus-leave check:
+   * moving focus from this input into the picker's popover must not count as
+   * leaving, so the embedded input skips its incomplete-on-leave handling.
+   */
+  @property({ type: Boolean, attribute: 'defer-focus-leave' }) deferFocusLeave:
+    | boolean
+    | undefined = false;
 
   private readonly inputBlockClass = 'gui-date-time-input';
   private readonly groups = ['default'] as const;
@@ -70,11 +93,36 @@ export class GuiDateTime extends LitElement {
     commitGroup: (group) => this.validateAndEmit(group),
     isReadonly: () => !!this.readOnly,
     isDisabled: () => !!this.disabled,
-    onEmptyPartBlur: () =>
-      this.dispatchEvent(new CustomEvent('change', { detail: { value: null }, bubbles: true })),
+    onEmptyPartBlur: (group, type) => {
+      // A raw 0 counts as emptying the part, so clear it in state (the clamp
+      // write-back would otherwise leave a phantom value behind).
+      this._parts.setPart(group, type, '');
+
+      if (!this.value) return;
+
+      this._internalNullReport = true;
+      this.value = undefined;
+      this.dispatchEvent(new CustomEvent('change', { detail: { value: null }, bubbles: true }));
+      this._parts.resetSurfacedInputError();
+    },
+    onInputErrorSurfaced: (message) =>
+      this.dispatchEvent(new CustomEvent('inputError', { detail: { message }, bubbles: true })),
+    onSurfacedErrorCleared: (value) =>
+      this.dispatchEvent(new CustomEvent('change', { detail: { value }, bubbles: true })),
     getHourFormat: () => this.localeData.effectiveHourFormat,
     getDayPeriodLabels: () => this.localeData.dayPeriodLabels,
   });
+
+  private _focusLeave = new GUIFocusLeaveController(this, {
+    onLeave: () => this.onFocusLeave(),
+  });
+
+  /**
+   * Marks a value clear that the widget itself reported (an emptied part or
+   * an abandoned partial). The surviving segments must not be wiped when the
+   * clear — or its null echo from the form — lands back on the value prop.
+   */
+  private _internalNullReport = false;
 
   protected ariaController: GUIAriaController<unknown, any> = new GUIAriaController(this, {
     getTargets: () => this.querySelectorAll(`.${this.inputBlockClass}`),
@@ -129,19 +177,22 @@ export class GuiDateTime extends LitElement {
 
   override willUpdate(changedProperties: PropertyValues): void {
     // !hasUpdated: parse on first render even when no value was ever set,
-    if (
-      !this.hasUpdated ||
-      changedProperties.has('value') ||
-      changedProperties.has('hourFormat') ||
-      changedProperties.has('localeId')
-    ) {
-      this._parts.setGroupFromISO(
-        'default',
-        this.value ?? '',
-        'dateTime',
-        this.localeData.effectiveHourFormat,
-      );
-    }
+    const localeChanged =
+      !this.hasUpdated || changedProperties.has('hourFormat') || changedProperties.has('localeId');
+    if (!localeChanged && !changedProperties.has('value')) return;
+
+    const internalNull = this._internalNullReport;
+    this._internalNullReport = false;
+    const prev = changedProperties.get('value') as string | null | undefined;
+
+    if (!localeChanged && !this.value && (internalNull || !prev)) return;
+
+    this._parts.setGroupFromISO(
+      'default',
+      this.value ?? '',
+      'dateTime',
+      this.localeData.effectiveHourFormat,
+    );
   }
 
   override render() {
@@ -187,7 +238,7 @@ export class GuiDateTime extends LitElement {
     return html`
       ${this.label ? addLabel(this.uid as string, templateData, false, undefined, false) : nothing}
 
-      <div class="gui-widget">
+      <div class="gui-widget" @focusout=${this.onWidgetFocusOut}>
         <div
           id=${this.uid}
           class="gui-widget-input gui-parts gui-parts-ring gui-date-time-input ${this.icon
@@ -224,6 +275,8 @@ export class GuiDateTime extends LitElement {
     });
     this._parts.applyWriteBacks(group, writeBacks);
 
+    this.emitPartsChange();
+
     if (result.kind === 'incomplete') {
       this.requestUpdate();
       return;
@@ -231,9 +284,7 @@ export class GuiDateTime extends LitElement {
 
     // Impossible date (e.g. Feb 31): surface the error, nothing to advance to.
     if (result.kind === 'invalid') {
-      this.dispatchEvent(
-        new CustomEvent('inputError', { detail: { message: result.message }, bubbles: true }),
-      );
+      this._parts.surfaceInputError(result.message);
       this.requestUpdate();
       return;
     }
@@ -245,16 +296,99 @@ export class GuiDateTime extends LitElement {
       this.dispatchEvent(
         new CustomEvent('change', { detail: { value: result.iso }, bubbles: true }),
       );
-      this.dispatchEvent(
-        new CustomEvent('inputError', { detail: { message: boundsError }, bubbles: true }),
-      );
+      this._parts.surfaceInputError(boundsError);
       this.requestUpdate();
       return;
     }
 
     this.value = result.iso;
+    this._parts.resetSurfacedInputError();
     this.dispatchEvent(new CustomEvent('change', { detail: { value: this.value }, bubbles: true }));
     this.requestUpdate();
+  }
+
+  /**
+   * Live-syncs the date and time halves to a host picker: each half carries
+   * its ISO value once structurally complete, else null.
+   */
+  private emitPartsChange(): void {
+    const { effectiveHourFormat, descriptors } = this.localeData;
+    const { date, time } = parseDateTimeSubGroups(this._parts.values['default'] ?? {}, {
+      hourFormat: effectiveHourFormat,
+      descriptors,
+      invalidDateMessage: this.invalidDateMessage,
+    });
+    this.dispatchEvent(
+      new CustomEvent('partsChange', {
+        detail: {
+          date: date.kind === 'valid' ? date.iso : null,
+          time: time.kind === 'valid' ? time.iso : null,
+        },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  /**
+   * Paints only the date parts from an ISO date (null clears them), leaving
+   * the time parts untouched. Host pickers call this when their calendar's
+   * working date changes, so a picked day lands in the visible segments
+   * without committing anything.
+   */
+  fillDate(iso: string | null): void {
+    this._parts.setGroupFromISO('default', iso, 'date');
+    this.requestUpdate();
+  }
+
+  /**
+   * Paints only the time parts from an ISO time (null clears them), leaving
+   * the date parts untouched. The counterpart of {@link fillDate} for the
+   * picker's working time.
+   */
+  fillTime(iso: string | null): void {
+    this._parts.setGroupFromISO('default', iso, 'time', this.localeData.effectiveHourFormat);
+    this.requestUpdate();
+  }
+
+  /** The group's fill state, for host pickers' own focus-leave checks. */
+  groupCompleteness(): GroupCompleteness {
+    const { effectiveHourFormat, descriptors } = this.localeData;
+    const { result } = parseDateTimeGroup(this._parts.values['default'] ?? {}, {
+      hourFormat: effectiveHourFormat,
+      descriptors,
+      invalidDateMessage: this.invalidDateMessage,
+    });
+    if (result.kind !== 'incomplete') return 'complete';
+    return this._parts.isGroupEmpty('default', DATE_TIME_PART_TYPES) ? 'empty' : 'partial';
+  }
+
+  private onWidgetFocusOut = (event: FocusEvent): void => {
+    if (this.deferFocusLeave) return;
+    this._focusLeave.handleFocusOut(event);
+  };
+
+  /**
+   * A partial group left behind flips the value to null — so validators
+   * report it even on non-required fields — and surfaces the incomplete
+   * message. An emptied group instead clears any surfaced error. A complete
+   * group already reported through the commit pipeline.
+   */
+  private onFocusLeave(): void {
+    const completeness = this.groupCompleteness();
+    if (completeness === 'complete') return;
+
+    if (completeness === 'empty') {
+      this._parts.clearSurfacedInputError(null);
+      return;
+    }
+
+    if (this.value) {
+      this._internalNullReport = true;
+      this.value = undefined;
+    }
+    this.dispatchEvent(new CustomEvent('change', { detail: { value: null }, bubbles: true }));
+    this._parts.surfaceInputError(this.incompleteMessage ?? INCOMPLETE_DATE_TIME_MESSAGE);
   }
 }
 

--- a/libs/gui/components/src/lib/components/date-time-input.ts
+++ b/libs/gui/components/src/lib/components/date-time-input.ts
@@ -369,12 +369,17 @@ export class GuiDateTime extends LitElement {
   };
 
   /**
-   * A partial group left behind flips the value to null — so validators
-   * report it even on non-required fields — and surfaces the incomplete
-   * message. An emptied group instead clears any surfaced error. A complete
-   * group already reported through the commit pipeline.
+   * The single point where the input reports focus leaving the control: it
+   * blurs (which the form layer reads as "validate now"), so hopping between
+   * segments never validates a half-typed entry. A partial group left behind
+   * then flips the value to null — so validators report it even on
+   * non-required fields — and surfaces the incomplete message. An emptied
+   * group instead clears any surfaced error. A complete group already
+   * reported through the commit pipeline.
    */
   private onFocusLeave(): void {
+    this.dispatchEvent(new CustomEvent('blur'));
+
     const completeness = this.groupCompleteness();
     if (completeness === 'complete') return;
 

--- a/libs/gui/components/src/lib/components/date-time-input.ts
+++ b/libs/gui/components/src/lib/components/date-time-input.ts
@@ -371,15 +371,14 @@ export class GuiDateTime extends LitElement {
   /**
    * The single point where the input reports focus leaving the control: it
    * blurs (which the form layer reads as "validate now"), so hopping between
-   * segments never validates a half-typed entry. A partial group left behind
-   * then flips the value to null — so validators report it even on
-   * non-required fields — and surfaces the incomplete message. An emptied
-   * group instead clears any surfaced error. A complete group already
-   * reported through the commit pipeline.
+   * segments never validates a half-typed entry.
    */
   private onFocusLeave(): void {
     this.dispatchEvent(new CustomEvent('blur'));
+    this.settleOnFocusLeave();
+  }
 
+  settleOnFocusLeave(): void {
     const completeness = this.groupCompleteness();
     if (completeness === 'complete') return;
 

--- a/libs/gui/components/src/lib/components/date-time-picker.ts
+++ b/libs/gui/components/src/lib/components/date-time-picker.ts
@@ -16,10 +16,7 @@ import {
   type HourFormat,
 } from '../utils/time';
 import { addErrors, addIcon, addLabel } from '../utils/templates';
-import {
-  INCOMPLETE_DATE_TIME_MESSAGE,
-  INVALID_DISABLED_TIME_RANGE_MESSAGE,
-} from '../utils/messages';
+import { INVALID_DISABLED_TIME_RANGE_MESSAGE } from '../utils/messages';
 
 @customElement('gui-date-time-picker')
 export class GuiDateTimePicker extends LitElement {
@@ -258,6 +255,7 @@ export class GuiDateTimePicker extends LitElement {
           .invalidDateMessage=${this.invalidDateMessage}
           .minTimeMessage=${this.minTimeMessage}
           .maxTimeMessage=${this.maxTimeMessage}
+          .incompleteMessage=${this.incompleteMessage}
           @blur=${this.onDateBlur}
           @focus=${this._popup.show}
           @change=${this.onDateChange}
@@ -386,25 +384,16 @@ export class GuiDateTimePicker extends LitElement {
 
   /**
    * The single point where the picker reports focus leaving the control: it
-   * blurs (which the form layer reads as "validate now"), and a partial
-   * selection left behind flips the value to null — so validators report it
-   * even on non-required fields — and surfaces the incomplete message. The
-   * working state survives, so reopening the popover restores the partial.
+   * blurs (which the form layer reads as "validate now"), then hands the
+   * embedded input its deferred settlement — a partial selection left behind
+   * surfaces the incomplete message, an emptied one clears a message it
+   * surfaced earlier. The input's resulting change bubbles back through the
+   * picker, so its value follows. The working state survives, so reopening
+   * the popover restores the partial.
    */
   private onFocusLeave(): void {
     this.dispatchEvent(new CustomEvent('blur'));
-
-    const input = this.querySelector<GuiDateTime>('gui-date-time');
-    if (!input || input.groupCompleteness() !== 'partial') return;
-
-    this.commitValue(null);
-    this.dispatchEvent(
-      new CustomEvent('inputError', {
-        detail: { message: this.incompleteMessage ?? INCOMPLETE_DATE_TIME_MESSAGE },
-        bubbles: true,
-        composed: true,
-      }),
-    );
+    this.querySelector<GuiDateTime>('gui-date-time')?.settleOnFocusLeave();
   }
 
   private validateBounds(value: string | undefined): string | null {

--- a/libs/gui/components/src/lib/components/date-time-picker.ts
+++ b/libs/gui/components/src/lib/components/date-time-picker.ts
@@ -1,9 +1,11 @@
-import { html, LitElement, nothing } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { html, LitElement, nothing, type PropertyValues } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import type { DateRange, DisabledTimeRange } from '@golemui/gui-shared/internals';
 import './date-time-input';
 import './date-time-calendar';
+import type { GuiDateTime } from './date-time-input';
+import { GUIFocusLeaveController } from '../controllers/focus-leave.controller';
 import { GUIPopupController } from '../controllers/popup.controller';
 import { dateBoundsError, toISODateString } from '../utils/date';
 import {
@@ -14,7 +16,10 @@ import {
   type HourFormat,
 } from '../utils/time';
 import { addErrors, addIcon, addLabel } from '../utils/templates';
-import { INVALID_DISABLED_TIME_RANGE_MESSAGE } from '../utils/messages';
+import {
+  INCOMPLETE_DATE_TIME_MESSAGE,
+  INVALID_DISABLED_TIME_RANGE_MESSAGE,
+} from '../utils/messages';
 
 @customElement('gui-date-time-picker')
 export class GuiDateTimePicker extends LitElement {
@@ -105,6 +110,23 @@ export class GuiDateTimePicker extends LitElement {
   @property({ type: String, attribute: 'no-available-times-message' }) noAvailableTimesMessage:
     | string
     | undefined = undefined;
+  @property({ type: String, attribute: 'incomplete-message' }) incompleteMessage:
+    | string
+    | undefined = undefined;
+
+  /**
+   * The uncommitted date/time halves of an in-progress selection. They live
+   * on the picker — which stays mounted — so a partial selection survives the
+   * popover unmount/remount cycle and reseeds the calendar on reopen.
+   */
+  @state() private _workingDate: string | undefined = undefined;
+  @state() private _workingTime: string | undefined = undefined;
+
+  private _internalValueChange = false;
+
+  private _focusLeave = new GUIFocusLeaveController(this, {
+    onLeave: () => this.onFocusLeave(),
+  });
 
   private _popup = new GUIPopupController(this, {
     focusRestoreSelector: 'gui-date-time input',
@@ -125,6 +147,22 @@ export class GuiDateTimePicker extends LitElement {
     return this;
   }
 
+  override willUpdate(changedProperties: PropertyValues): void {
+    if (!changedProperties.has('value')) return;
+    if (this._internalValueChange) {
+      this._internalValueChange = false;
+      return;
+    }
+
+    const prev = changedProperties.get('value') as string | null | undefined;
+    if (!prev && !this.value) return;
+
+    // External value change (form write/reset): the form is authoritative,
+    // any in-progress working selection is dropped.
+    this._workingDate = undefined;
+    this._workingTime = undefined;
+  }
+
   override render() {
     const datePickerIcon = addIcon('datePicker', { icon: this.icon });
 
@@ -140,6 +178,9 @@ export class GuiDateTimePicker extends LitElement {
           ?disabled=${this.disabled}
           ?readonly=${this.readOnly}
           .value=${this.value}
+          .workingDate=${this._workingDate}
+          .workingTime=${this._workingTime}
+          .deferFocusLeave=${true}
           .prevMonthIcon=${this.prevMonthIcon}
           .nextMonthIcon=${this.nextMonthIcon}
           .prevMonthAriaLabel=${this.prevMonthAriaLabel}
@@ -166,6 +207,7 @@ export class GuiDateTimePicker extends LitElement {
           .noAvailableTimesMessage=${this.noAvailableTimesMessage}
           @blur=${this.onCalendarBlur}
           @change=${this.onCalendarChange}
+          @partsChange=${this.onCalendarPartsChange}
         ></gui-date-time-calendar>`
       : nothing;
 
@@ -186,6 +228,7 @@ export class GuiDateTimePicker extends LitElement {
         class="gui-widget"
         @keydown=${this._popup.onAnchorKeyDown}
         @click=${this._popup.onAnchorClick}
+        @focusout=${this._focusLeave.onFocusOut}
       >
         <gui-date-time
           id="date-input"
@@ -193,6 +236,7 @@ export class GuiDateTimePicker extends LitElement {
           .uid=${this.uid}
           .hint=${this.hint}
           .showErrors=${false}
+          .deferFocusLeave=${true}
           .errors=${this.errors}
           ?touched=${this.touched}
           ?required=${this.required}
@@ -217,6 +261,7 @@ export class GuiDateTimePicker extends LitElement {
           @blur=${this.onDateBlur}
           @focus=${this._popup.show}
           @change=${this.onDateChange}
+          @partsChange=${this.onInputPartsChange}
         ></gui-date-time>
         <button
           type="button"
@@ -265,8 +310,14 @@ export class GuiDateTimePicker extends LitElement {
     this.commitValue(event.detail.value);
   }
 
-  private onDateBlur() {
-    this.dispatchEvent(new CustomEvent('blur'));
+  /**
+   * The field's per-part blur stays inside the widget: moving from a segment
+   * into the popover is not leaving the control, so it must not be reported
+   * as a blur (which the form layer reads as "validate now"). The picker
+   * reports blur from its own focus-leave check instead.
+   */
+  private onDateBlur(event: Event) {
+    event.stopPropagation();
   }
 
   private onCalendarChange(event: CustomEvent) {
@@ -282,8 +333,38 @@ export class GuiDateTimePicker extends LitElement {
     }
   }
 
+  /** The typed halves of the input feed the working state; the calendar follows via its props. */
+  private onInputPartsChange(event: CustomEvent) {
+    event.stopPropagation();
+    this._workingDate = (event.detail.date as string | null) ?? undefined;
+    this._workingTime = (event.detail.time as string | null) ?? undefined;
+  }
+
+  /** A calendar pick feeds the working state and paints the input's segments. */
+  private onCalendarPartsChange(event: CustomEvent) {
+    event.stopPropagation();
+    const date = event.detail.date as string | null;
+    const time = event.detail.time as string | null;
+    this._workingDate = date ?? undefined;
+    this._workingTime = time ?? undefined;
+
+    // Paint only the halves the calendar actually holds: a null half must not
+    // wipe partially typed segments the calendar never saw.
+    const input = this.querySelector<GuiDateTime>('gui-date-time');
+    if (date) input?.fillDate(date);
+    if (time) input?.fillTime(time);
+  }
+
   private commitValue(value: string | null | undefined) {
-    this.value = value ?? undefined;
+    const next = value ?? undefined;
+    if (next !== this.value) this._internalValueChange = true;
+    this.value = next;
+
+    if (this.value) {
+      this._workingDate = undefined;
+      this._workingTime = undefined;
+    }
+
     const error = this.validateBounds(this.value);
     this.dispatchEvent(
       new CustomEvent('change', {
@@ -301,6 +382,29 @@ export class GuiDateTimePicker extends LitElement {
         }),
       );
     }
+  }
+
+  /**
+   * The single point where the picker reports focus leaving the control: it
+   * blurs (which the form layer reads as "validate now"), and a partial
+   * selection left behind flips the value to null — so validators report it
+   * even on non-required fields — and surfaces the incomplete message. The
+   * working state survives, so reopening the popover restores the partial.
+   */
+  private onFocusLeave(): void {
+    this.dispatchEvent(new CustomEvent('blur'));
+
+    const input = this.querySelector<GuiDateTime>('gui-date-time');
+    if (!input || input.groupCompleteness() !== 'partial') return;
+
+    this.commitValue(null);
+    this.dispatchEvent(
+      new CustomEvent('inputError', {
+        detail: { message: this.incompleteMessage ?? INCOMPLETE_DATE_TIME_MESSAGE },
+        bubbles: true,
+        composed: true,
+      }),
+    );
   }
 
   private validateBounds(value: string | undefined): string | null {
@@ -324,8 +428,13 @@ export class GuiDateTimePicker extends LitElement {
     return null;
   }
 
-  // The calendar's blur already bubbles up to the host, so only close here.
-  private onCalendarBlur() {
+  /**
+   * Focus leaving the calendar closes the popover, but it is not necessarily
+   * leaving the picker (focus often returns to the field), so the calendar's
+   * bubbling blur is stopped here and never reaches the form layer.
+   */
+  private onCalendarBlur(event: Event) {
+    event.stopPropagation();
     this._popup.closeOnFocusLeave();
   }
 }

--- a/libs/gui/components/src/lib/components/range-calendar.ts
+++ b/libs/gui/components/src/lib/components/range-calendar.ts
@@ -98,6 +98,13 @@ export class GuiRangeCalendar extends LitElement {
 
   @property({ type: Array }) value: DateRange[] | undefined = [];
   @property({ type: String }) focusDate: string | undefined = undefined;
+  /**
+   * Host picker's in-progress span anchor: the first day of a two-click
+   * selection. Seeding it back restores a half-picked span after the popover
+   * has been closed and reopened (which unmounts this calendar).
+   */
+  @property({ type: String, attribute: 'working-anchor' }) workingAnchor: string | undefined =
+    undefined;
   @property({ type: Boolean }) hidePills = false;
   @property({ type: String }) removePillAriaLabel: string | undefined = undefined;
   @property({ type: String, attribute: 'disabled-date-range-message' }) disabledDateRangeMessage:
@@ -163,6 +170,21 @@ export class GuiRangeCalendar extends LitElement {
   });
 
   /**
+   * Live-syncs the in-progress span anchor to a host picker, which holds it
+   * across the popover's unmount/remount cycle. Never wired by the form
+   * layer, so it can't trigger validation.
+   */
+  protected emitAnchorChange(): void {
+    this.dispatchEvent(
+      new CustomEvent('partsChange', {
+        detail: { anchor: this._selection.anchor ? toISODateString(this._selection.anchor) : null },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  /**
    * Full instant of an endpoint, used to order the pills. Date-only here; a
    * subclass whose endpoints carry a time overrides it so two ranges on the
    * same day still sort by time.
@@ -199,6 +221,12 @@ export class GuiRangeCalendar extends LitElement {
   }
 
   override willUpdate(changedProperties: PropertyValues): void {
+    if (changedProperties.has('workingAnchor') && !this._selection.anchor) {
+      const anchor = this.workingAnchor ? parseISODateString(this.workingAnchor) : null;
+      if (anchor && !isNaN(anchor.getTime())) {
+        this._selection = { anchor, hover: null, selecting: true };
+      }
+    }
     if (changedProperties.has('invalidRange')) {
       if (this.invalidRange) {
         const start = this.endpointDay(this.invalidRange.start);
@@ -430,6 +458,7 @@ export class GuiRangeCalendar extends LitElement {
       date: day.date,
     });
     this._selection = state;
+    this.emitAnchorChange();
 
     // Start selection
     if (!commit) {

--- a/libs/gui/components/src/lib/components/range-calendar.ts
+++ b/libs/gui/components/src/lib/components/range-calendar.ts
@@ -18,7 +18,12 @@ import {
   renderCalendarMonthPanel,
   renderCalendarPanelBody,
 } from '../utils/calendar-templates';
-import { buildMonthDays, computeDayStatus } from '../utils/day-status';
+import {
+  buildMonthDays,
+  computeDayStatus,
+  orderedDaySpan,
+  type DaySpan,
+} from '../utils/day-status';
 import {
   buildPillItems,
   findRangeByKey,
@@ -31,6 +36,7 @@ import {
   idleRangeSelection,
   reduceRangeSelection,
   selectionPreviewSpan,
+  workingPhase,
   type RangeSelectionState,
 } from '../utils/range-selection';
 import './pills';
@@ -99,12 +105,13 @@ export class GuiRangeCalendar extends LitElement {
   @property({ type: Array }) value: DateRange[] | undefined = [];
   @property({ type: String }) focusDate: string | undefined = undefined;
   /**
-   * Host picker's in-progress span anchor: the first day of a two-click
-   * selection. Seeding it back restores a half-picked span after the popover
-   * has been closed and reopened (which unmounts this calendar).
+   * The host picker's working endpoints — typed into its input, or picked here
+   * and held there across the popover's unmount/remount cycle. One endpoint
+   * renders as an in-progress anchor, both as a parked span.
    */
-  @property({ type: String, attribute: 'working-anchor' }) workingAnchor: string | undefined =
+  @property({ type: String, attribute: 'working-start' }) workingStart: string | undefined =
     undefined;
+  @property({ type: String, attribute: 'working-end' }) workingEnd: string | undefined = undefined;
   @property({ type: Boolean }) hidePills = false;
   @property({ type: String }) removePillAriaLabel: string | undefined = undefined;
   @property({ type: String, attribute: 'disabled-date-range-message' }) disabledDateRangeMessage:
@@ -114,6 +121,8 @@ export class GuiRangeCalendar extends LitElement {
 
   @state() protected _selection: RangeSelectionState = idleRangeSelection();
   @state() protected _invalidRange: { start: Date; end: Date } | null = null;
+  @state() protected _workingStart: string | undefined = undefined;
+  @state() protected _workingEnd: string | undefined = undefined;
 
   protected _skipValueNavigation = false;
 
@@ -169,19 +178,61 @@ export class GuiRangeCalendar extends LitElement {
     onLeave: () => this.dispatchEvent(new CustomEvent('blur', { bubbles: true, composed: true })),
   });
 
+  /** ISO day of the in-progress anchor, or undefined while idle. */
+  protected anchorISO(): string | undefined {
+    return this._selection.anchor ? toISODateString(this._selection.anchor) : undefined;
+  }
+
   /**
-   * Live-syncs the in-progress span anchor to a host picker, which holds it
-   * across the popover's unmount/remount cycle. Never wired by the form
-   * layer, so it can't trigger validation.
+   * Live-syncs the in-progress selection to a host picker, which holds it
+   * across the popover's unmount/remount cycle and mirrors it into its input.
+   * Never wired by the form layer, so it can't trigger validation.
    */
-  protected emitAnchorChange(): void {
+  protected emitWorkingChange(): void {
     this.dispatchEvent(
       new CustomEvent('partsChange', {
-        detail: { anchor: this._selection.anchor ? toISODateString(this._selection.anchor) : null },
+        detail: {
+          anchor: this.anchorISO() ?? null,
+          start: this._workingStart ?? null,
+          end: this._workingEnd ?? null,
+        },
         bubbles: true,
         composed: true,
       }),
     );
+  }
+
+  protected get workingSpan(): DaySpan | undefined {
+    if (!this._workingStart || !this._workingEnd) return undefined;
+    return orderedDaySpan(this.endpointDay(this._workingStart), this.endpointDay(this._workingEnd));
+  }
+
+  protected adoptWorkingEndpoints(): void {
+    const phase = workingPhase(this.workingStart, this.workingEnd);
+
+    if (phase.kind === 'span') {
+      if (this._workingStart === phase.start && this._workingEnd === phase.end) return;
+      this._workingStart = phase.start;
+      this._workingEnd = phase.end;
+      this._selection = idleRangeSelection();
+      this._nav.navigateToDate(this.workingSpan?.start ?? this.endpointDay(phase.start));
+      return;
+    }
+
+    this._workingStart = undefined;
+    this._workingEnd = undefined;
+
+    if (phase.kind === 'idle') {
+      if (this._selection.anchor) this._selection = idleRangeSelection();
+      return;
+    }
+
+    if (this.anchorISO() === phase.iso) return;
+
+    const anchor = this.endpointDay(phase.iso);
+    if (isNaN(anchor.getTime())) return;
+    this._selection = { anchor, hover: null, selecting: true };
+    this._nav.navigateToDate(anchor);
   }
 
   /**
@@ -221,11 +272,8 @@ export class GuiRangeCalendar extends LitElement {
   }
 
   override willUpdate(changedProperties: PropertyValues): void {
-    if (changedProperties.has('workingAnchor') && !this._selection.anchor) {
-      const anchor = this.workingAnchor ? parseISODateString(this.workingAnchor) : null;
-      if (anchor && !isNaN(anchor.getTime())) {
-        this._selection = { anchor, hover: null, selecting: true };
-      }
+    if (changedProperties.has('workingStart') || changedProperties.has('workingEnd')) {
+      this.adoptWorkingEndpoints();
     }
     if (changedProperties.has('invalidRange')) {
       if (this.invalidRange) {
@@ -409,7 +457,7 @@ export class GuiRangeCalendar extends LitElement {
       start: this.endpointDay(range.start),
       end: range.end ? this.endpointDay(range.end) : undefined,
     }));
-    const selectingSpan = selectionPreviewSpan(this._selection);
+    const selectingSpan = selectionPreviewSpan(this._selection) ?? this.workingSpan ?? null;
 
     return buildMonthDays({
       currentDate: this._currentDate,
@@ -458,7 +506,9 @@ export class GuiRangeCalendar extends LitElement {
       date: day.date,
     });
     this._selection = state;
-    this.emitAnchorChange();
+    this._workingStart = undefined;
+    this._workingEnd = undefined;
+    this.emitWorkingChange();
 
     // Start selection
     if (!commit) {

--- a/libs/gui/components/src/lib/components/range-date-input.ts
+++ b/libs/gui/components/src/lib/components/range-date-input.ts
@@ -378,8 +378,12 @@ export class GuiRangeDateInput extends LitElement {
       empty: this._parts.isGroupEmpty(group, this.datePartTypes),
     }));
 
-    // Nothing entered: nothing to settle.
-    if (endpoints.every((endpoint) => endpoint.empty)) return;
+    // Nothing entered: nothing to settle, but a message surfaced over fields
+    // the user has since emptied must not outlive them.
+    if (endpoints.every((endpoint) => endpoint.empty)) {
+      this._parts.clearSurfacedInputError(this.value ?? []);
+      return;
+    }
 
     if (endpoints.every((endpoint) => endpoint.result.kind === 'valid')) {
       this.tryCreatePill({ refocus: false });
@@ -478,6 +482,10 @@ export class GuiRangeDateInput extends LitElement {
   public showRange(startISO: string, endISO: string): void {
     this._parts.setGroupFromISO('start', startISO, 'date');
     this._parts.setGroupFromISO('end', endISO, 'date');
+  }
+
+  public surfaceHostError(message: string): void {
+    this._parts.surfaceInputError(message);
   }
 
   /**

--- a/libs/gui/components/src/lib/components/range-date-input.ts
+++ b/libs/gui/components/src/lib/components/range-date-input.ts
@@ -123,17 +123,20 @@ export class GuiRangeDateInput extends LitElement {
   });
 
   /**
-   * The single point where the input reports focus leaving the control: it
-   * blurs (which the form layer reads as "validate now"), so hopping between
-   * segments never validates a half-typed entry, then surfaces a half-entered
-   * range left behind.
+   * The single point where the input reports focus leaving the control. It
+   * settles what is in the fields FIRST, then blurs — the form layer reads a
+   * blur as "validate now", and storing a value runs no validator, so blurring
+   * first would validate the value the commit is about to replace and leave a
+   * `required` error standing over a range the user did finish. Hopping
+   * between segments is not a departure and never reaches here.
    */
   private _focusLeave = new GUIFocusLeaveController(this, {
+    resolveSyncOnRelatedTarget: true,
     onLeave: () => {
       // Embedded in a picker: that host owns focus reporting for the subtree.
       if (this.deferFocusLeave) return;
+      this.finalizeOnLeave();
       this.dispatchEvent(new CustomEvent('blur'));
-      this.reportIncompleteOnLeave();
     },
   });
 
@@ -354,24 +357,34 @@ export class GuiRangeDateInput extends LitElement {
   }
 
   /**
-   * A range left half-entered when focus leaves is abandoned work: some parts
-   * of one endpoint typed, or one endpoint filled and the other still empty
-   * (a picked start with no end lands here too). Both surface the incomplete
-   * message — or the endpoint's own message when one is outright invalid,
-   * which is more useful than "incomplete". `_validationTriggered` makes the
-   * next edit re-evaluate, so the message clears as soon as the user comes
-   * back and continues (or empties the fields). Public so a host picker can
-   * call it from its own whole-widget focus-leave check.
+   * What leaving does with whatever is in the fields. Public so a host picker
+   * can call it from its own whole-widget focus-leave check.
+   *
+   * A complete range is finished work, so leaving commits it exactly as Enter
+   * does — a user who typed a whole range and moved on gets the pill they
+   * plainly meant, and the same validation decides whether it is allowed.
+   *
+   * A half-entered one is abandoned work: some parts of one endpoint typed, or
+   * one endpoint filled and the other still empty (a picked start with no end
+   * lands here too). Both surface the incomplete message — or the endpoint's
+   * own message when one is outright invalid, which is more useful than
+   * "incomplete". `_validationTriggered` makes the next edit re-evaluate, so
+   * the message clears as soon as the user comes back and continues (or
+   * empties the fields).
    */
-  reportIncompleteOnLeave(): void {
+  finalizeOnLeave(): void {
     const endpoints = this.groups.map((group) => ({
       result: this.validateDateParts(group),
       empty: this._parts.isGroupEmpty(group, this.datePartTypes),
     }));
 
-    // Nothing entered, or a complete range the commit path already owns.
+    // Nothing entered: nothing to settle.
     if (endpoints.every((endpoint) => endpoint.empty)) return;
-    if (endpoints.every((endpoint) => endpoint.result.kind === 'valid')) return;
+
+    if (endpoints.every((endpoint) => endpoint.result.kind === 'valid')) {
+      this.tryCreatePill({ refocus: false });
+      return;
+    }
 
     const invalidMessage = endpoints
       .map((endpoint) => (endpoint.result.kind === 'invalid' ? endpoint.result.message : undefined))
@@ -429,7 +442,7 @@ export class GuiRangeDateInput extends LitElement {
     }
   }
 
-  private tryCreatePill() {
+  private tryCreatePill({ refocus = true }: { refocus?: boolean } = {}) {
     this._validationTriggered = true;
 
     const outcome = this.evaluateRange();
@@ -453,7 +466,7 @@ export class GuiRangeDateInput extends LitElement {
     );
 
     // Focus the first start date input
-    this._parts.focusFirst('start');
+    if (refocus) this._parts.focusFirst('start');
 
     this.requestUpdate();
   }

--- a/libs/gui/components/src/lib/components/range-date-input.ts
+++ b/libs/gui/components/src/lib/components/range-date-input.ts
@@ -114,7 +114,11 @@ export class GuiRangeDateInput extends LitElement {
       this.dispatchEvent(new CustomEvent('inputError', { detail: { message }, bubbles: true })),
     onSurfacedErrorCleared: (value) =>
       this.dispatchEvent(
-        new CustomEvent('change', { detail: { value }, bubbles: true, composed: true }),
+        new CustomEvent('change', {
+          detail: { value, commit: false },
+          bubbles: true,
+          composed: true,
+        }),
       ),
   });
 

--- a/libs/gui/components/src/lib/components/range-date-input.ts
+++ b/libs/gui/components/src/lib/components/range-date-input.ts
@@ -3,6 +3,7 @@ import { html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { GUIAriaController } from '../controllers/aria.controller';
+import { GUIFocusLeaveController } from '../controllers/focus-leave.controller';
 import { GUIPartsController } from '../controllers/parts.controller';
 import {
   getDateFormatParts,
@@ -10,6 +11,7 @@ import {
   parseISODateString,
   toISODateString,
 } from '../utils/date';
+import { INCOMPLETE_DATE_MESSAGE } from '../utils/messages';
 import { renderGroupParts, type GUIPartsTemplateData } from '../utils/part-templates';
 import {
   dateInputPartDescriptors,
@@ -59,11 +61,24 @@ export class GuiRangeDateInput extends LitElement {
   @property({ type: String }) startDateAriaLabel: string | undefined = undefined;
   @property({ type: String }) endDateAriaLabel: string | undefined = undefined;
   @property({ type: String }) separator: string | undefined = undefined;
+  @property({ type: String, attribute: 'incomplete-message' }) incompleteMessage:
+    | string
+    | undefined = undefined;
+  /**
+   * Set by host pickers that run their own whole-widget focus-leave check:
+   * moving focus from this input into the picker's popover must not count as
+   * leaving, so the embedded input skips its incomplete-on-leave handling.
+   */
+  @property({ type: Boolean, attribute: 'defer-focus-leave' }) deferFocusLeave:
+    | boolean
+    | undefined = false;
 
   private readonly inputBlockClass = 'gui-range-date-input';
   private readonly groups = ['start', 'end'] as const;
 
   private readonly partDescriptors = dateInputPartDescriptors();
+
+  private readonly datePartTypes: readonly DateTimePartType[] = ['day', 'month', 'year'];
 
   /**
    * Set on the first commit attempt (Enter). While set, every part change
@@ -101,6 +116,21 @@ export class GuiRangeDateInput extends LitElement {
       this.dispatchEvent(
         new CustomEvent('change', { detail: { value }, bubbles: true, composed: true }),
       ),
+  });
+
+  /**
+   * The single point where the input reports focus leaving the control: it
+   * blurs (which the form layer reads as "validate now"), so hopping between
+   * segments never validates a half-typed entry, then surfaces a half-entered
+   * range left behind.
+   */
+  private _focusLeave = new GUIFocusLeaveController(this, {
+    onLeave: () => {
+      // Embedded in a picker: that host owns focus reporting for the subtree.
+      if (this.deferFocusLeave) return;
+      this.dispatchEvent(new CustomEvent('blur'));
+      this.reportIncompleteOnLeave();
+    },
   });
 
   protected ariaController: GUIAriaController<unknown, any> = new GUIAriaController(this, {
@@ -174,7 +204,7 @@ export class GuiRangeDateInput extends LitElement {
     return html`
       ${this.label ? addLabel(this.uid as string, templateData, false, undefined, false) : nothing}
 
-      <div class="gui-widget">
+      <div class="gui-widget" @focusout=${this._focusLeave.onFocusOut}>
         <div
           class="gui-widget-input gui-parts-ring gui-range-date-input ${this.icon
             ? 'gui-range-date-input--icon'
@@ -297,13 +327,56 @@ export class GuiRangeDateInput extends LitElement {
 
   /**
    * Re-parses both endpoints so per-endpoint problems (impossible date, out of
-   * bounds) surface while the user types. Runs on every part change.
+   * bounds) surface while the user types, and notifies the host picker via
+   * `partsChange` so its calendar follows the typed endpoints. Runs on every
+   * part change.
    */
   private syncParts() {
-    return {
-      start: this.validateDateParts('start'),
-      end: this.validateDateParts('end'),
-    };
+    const start = this.validateDateParts('start');
+    const end = this.validateDateParts('end');
+
+    const iso = (endpoint: RangeEndpoint<Date>) =>
+      endpoint.kind === 'valid' ? toISODateString(endpoint.value) : null;
+
+    this.dispatchEvent(
+      new CustomEvent('partsChange', {
+        detail: { start: iso(start), end: iso(end) },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+
+    return { start, end };
+  }
+
+  /**
+   * A range left half-entered when focus leaves is abandoned work: some parts
+   * of one endpoint typed, or one endpoint filled and the other still empty
+   * (a picked start with no end lands here too). Both surface the incomplete
+   * message — or the endpoint's own message when one is outright invalid,
+   * which is more useful than "incomplete". `_validationTriggered` makes the
+   * next edit re-evaluate, so the message clears as soon as the user comes
+   * back and continues (or empties the fields). Public so a host picker can
+   * call it from its own whole-widget focus-leave check.
+   */
+  reportIncompleteOnLeave(): void {
+    const endpoints = this.groups.map((group) => ({
+      result: this.validateDateParts(group),
+      empty: this._parts.isGroupEmpty(group, this.datePartTypes),
+    }));
+
+    // Nothing entered, or a complete range the commit path already owns.
+    if (endpoints.every((endpoint) => endpoint.empty)) return;
+    if (endpoints.every((endpoint) => endpoint.result.kind === 'valid')) return;
+
+    const invalidMessage = endpoints
+      .map((endpoint) => (endpoint.result.kind === 'invalid' ? endpoint.result.message : undefined))
+      .find(Boolean);
+
+    this._validationTriggered = true;
+    this._parts.surfaceInputError(
+      invalidMessage ?? this.incompleteMessage ?? INCOMPLETE_DATE_MESSAGE,
+    );
   }
 
   /**
@@ -388,6 +461,17 @@ export class GuiRangeDateInput extends LitElement {
   public showRange(startISO: string, endISO: string): void {
     this._parts.setGroupFromISO('start', startISO, 'date');
     this._parts.setGroupFromISO('end', endISO, 'date');
+  }
+
+  /**
+   * Fills one endpoint's parts from an ISO date, or clears them when given
+   * null. The range date picker calls this so a day picked in the calendar
+   * lands in the visible field straight away — the reverse of typed parts
+   * moving the calendar's selection.
+   */
+  fillGroup(group: 'start' | 'end', iso: string | null): void {
+    this._parts.setGroupFromISO(group, iso, 'date');
+    this.requestUpdate();
   }
 
   /** Clear both groups' parts (e.g. once a valid range is committed). */

--- a/libs/gui/components/src/lib/components/range-date-picker.ts
+++ b/libs/gui/components/src/lib/components/range-date-picker.ts
@@ -117,14 +117,17 @@ export class GuiRangeDatePicker extends LitElement {
   });
 
   /**
-   * The single point where the picker reports focus leaving the control: it
-   * blurs (which the form layer reads as "validate now") and lets the input
-   * surface a half-typed endpoint left behind.
+   * The single point where the picker reports focus leaving the control: the
+   * input settles what is in its fields — committing a complete range,
+   * surfacing a half-typed one — and only then does the picker blur, which the
+   * form layer reads as "validate now". Blurring first would validate the
+   * value the commit is about to replace.
    */
   private _focusLeave = new GUIFocusLeaveController(this, {
+    resolveSyncOnRelatedTarget: true,
     onLeave: () => {
+      this._dateRef?.finalizeOnLeave();
       this.dispatchEvent(new CustomEvent('blur'));
-      this._dateRef?.reportIncompleteOnLeave();
     },
   });
 

--- a/libs/gui/components/src/lib/components/range-date-picker.ts
+++ b/libs/gui/components/src/lib/components/range-date-picker.ts
@@ -5,6 +5,7 @@ import type { DateRange } from '@golemui/gui-shared/internals';
 import './range-date-input';
 import type { GuiRangeDateInput } from './range-date-input';
 import './range-calendar';
+import { GUIFocusLeaveController } from '../controllers/focus-leave.controller';
 import { GUIPopupController } from '../controllers/popup.controller';
 import { dateBoundsError, rangeSpansDisabledDay } from '../utils/date';
 import { addErrors, addIcon, addLabel } from '../utils/templates';
@@ -86,9 +87,14 @@ export class GuiRangeDatePicker extends LitElement {
     | string
     | undefined = undefined;
 
-  @query('#date-input') private _dateRef?: HTMLElement;
+  @query('#date-input') private _dateRef?: GuiRangeDateInput;
 
   @state() private _focusDate: string | undefined = undefined;
+  /**
+   * The calendar's in-progress span anchor. It lives here — the picker stays
+   * mounted — so a half-picked span survives closing and reopening the popover.
+   */
+  @state() private _workingAnchor: string | undefined = undefined;
   @state() private _invalidRange: { start: string; end: string } | null = null;
 
   private _popup = new GUIPopupController(this, {
@@ -104,6 +110,18 @@ export class GuiRangeDatePicker extends LitElement {
       const dropdownWasOpen = !!this.querySelector('.gui-pills__dropdown');
       if (dropdownWasOpen) popup.suppressNextFocusOut();
       this.closePillsDropdown();
+    },
+  });
+
+  /**
+   * The single point where the picker reports focus leaving the control: it
+   * blurs (which the form layer reads as "validate now") and lets the input
+   * surface a half-typed endpoint left behind.
+   */
+  private _focusLeave = new GUIFocusLeaveController(this, {
+    onLeave: () => {
+      this.dispatchEvent(new CustomEvent('blur'));
+      this._dateRef?.reportIncompleteOnLeave();
     },
   });
 
@@ -145,6 +163,7 @@ export class GuiRangeDatePicker extends LitElement {
           ?readonly=${this.readOnly}
           .value=${this.value}
           .focusDate=${this._focusDate}
+          .workingAnchor=${this._workingAnchor}
           .prevMonthIcon=${this.prevMonthIcon}
           .nextMonthIcon=${this.nextMonthIcon}
           .prevMonthAriaLabel=${this.prevMonthAriaLabel}
@@ -164,6 +183,7 @@ export class GuiRangeDatePicker extends LitElement {
           .invalidRange=${this._invalidRange}
           @blur=${this.onCalendarBlur}
           @change=${this.onCalendarChange}
+          @partsChange=${this.onCalendarPartsChange}
           @inputError=${this.onCalendarInputError}
         ></gui-range-calendar>`
       : nothing;
@@ -185,9 +205,11 @@ export class GuiRangeDatePicker extends LitElement {
         class="gui-widget"
         @keydown=${this._popup.onAnchorKeyDown}
         @click=${this._popup.onAnchorClick}
+        @focusout=${this._focusLeave.onFocusOut}
       >
         <gui-range-date
           id="date-input"
+          .deferFocusLeave=${true}
           class=${classMap(datePickerIcon.widgetClasses)}
           .uid=${this.uid}
           .hint=${this.hint}
@@ -292,7 +314,7 @@ export class GuiRangeDatePicker extends LitElement {
     const start = range.start;
     const end = range.end ?? range.start;
     this._invalidRange = { start, end };
-    const input = this._dateRef as GuiRangeDateInput | undefined;
+    const input = this._dateRef;
     if (input) {
       input.value = this.value ?? [];
       input.showRange(start, end);
@@ -306,21 +328,47 @@ export class GuiRangeDatePicker extends LitElement {
     );
   }
 
-  private onDateBlur() {
-    this.dispatchEvent(new CustomEvent('blur'));
+  /**
+   * The input's per-part blur stays inside the widget: moving from a segment
+   * into the popover is not leaving the control, so it must not be reported
+   * as a blur (which the form layer reads as "validate now"). The picker
+   * reports blur from its own focus-leave check instead.
+   */
+  private onDateBlur(event: Event) {
+    event.stopPropagation();
   }
 
   private onCalendarChange(event: CustomEvent) {
     event.stopPropagation();
-    (this._dateRef as GuiRangeDateInput | undefined)?.clearRangeInputs();
+    this._dateRef?.clearRangeInputs();
+    this._workingAnchor = undefined;
     this.commitValue(event.detail.value);
+  }
+
+  /**
+   * The calendar's in-progress anchor, held here so it survives the popover,
+   * and painted into the start field so the day just picked is readable as a
+   * date — the reverse of typed parts moving the calendar's selection. An
+   * anchor dropped for a completed or restarted span empties the fields.
+   */
+  private onCalendarPartsChange(event: CustomEvent<{ anchor: string | null }>) {
+    event.stopPropagation();
+    const anchor = event.detail.anchor;
+    this._workingAnchor = anchor ?? undefined;
+
+    if (anchor) {
+      this._dateRef?.fillGroup('start', anchor);
+      this._dateRef?.fillGroup('end', null);
+      return;
+    }
+    this._dateRef?.clearRangeInputs();
   }
 
   private onCalendarInputError(event: CustomEvent) {
     const range = event.detail?.range as { start: string; end: string } | undefined;
     if (!range) return;
     this._invalidRange = range;
-    (this._dateRef as GuiRangeDateInput | undefined)?.showRange(range.start, range.end);
+    this._dateRef?.showRange(range.start, range.end);
   }
 
   private commitValue(value: DateRange[] | null | undefined) {
@@ -335,7 +383,13 @@ export class GuiRangeDatePicker extends LitElement {
     );
   }
 
-  private onCalendarBlur() {
+  /**
+   * Focus leaving the calendar closes the popover, but it is not necessarily
+   * leaving the picker (focus often returns to the fields), so the calendar's
+   * bubbling blur is stopped here and never reaches the form layer.
+   */
+  private onCalendarBlur(event: Event) {
+    event.stopPropagation();
     this._popup.closeOnFocusLeave();
   }
 

--- a/libs/gui/components/src/lib/components/range-date-picker.ts
+++ b/libs/gui/components/src/lib/components/range-date-picker.ts
@@ -91,10 +91,13 @@ export class GuiRangeDatePicker extends LitElement {
 
   @state() private _focusDate: string | undefined = undefined;
   /**
-   * The calendar's in-progress span anchor. It lives here — the picker stays
-   * mounted — so a half-picked span survives closing and reopening the popover.
+   * The in-progress range, from either half of the widget: days picked in the
+   * calendar or endpoints typed into the input. It lives here — the picker
+   * stays mounted — so a half-picked span survives closing and reopening the
+   * popover, and it is what the calendar and the input each render.
    */
-  @state() private _workingAnchor: string | undefined = undefined;
+  @state() private _workingStart: string | undefined = undefined;
+  @state() private _workingEnd: string | undefined = undefined;
   @state() private _invalidRange: { start: string; end: string } | null = null;
 
   private _popup = new GUIPopupController(this, {
@@ -163,7 +166,8 @@ export class GuiRangeDatePicker extends LitElement {
           ?readonly=${this.readOnly}
           .value=${this.value}
           .focusDate=${this._focusDate}
-          .workingAnchor=${this._workingAnchor}
+          .workingStart=${this._workingStart}
+          .workingEnd=${this._workingEnd}
           .prevMonthIcon=${this.prevMonthIcon}
           .nextMonthIcon=${this.nextMonthIcon}
           .prevMonthAriaLabel=${this.prevMonthAriaLabel}
@@ -233,6 +237,7 @@ export class GuiRangeDatePicker extends LitElement {
           @blur=${this.onDateBlur}
           @focus=${this._popup.show}
           @change=${this.onDateChange}
+          @partsChange=${this.onInputPartsChange}
           @pillClick=${this.onPillClick}
         ></gui-range-date>
         <button
@@ -287,7 +292,7 @@ export class GuiRangeDatePicker extends LitElement {
         return;
       }
     }
-    this.commitValue(value);
+    this.commitValue(value, event.detail.commit !== false);
   }
 
   /** The message for the first constraint a range violates, or null when valid. */
@@ -314,6 +319,7 @@ export class GuiRangeDatePicker extends LitElement {
     const start = range.start;
     const end = range.end ?? range.start;
     this._invalidRange = { start, end };
+    this.setWorking(undefined, undefined);
     const input = this._dateRef;
     if (input) {
       input.value = this.value ?? [];
@@ -341,27 +347,55 @@ export class GuiRangeDatePicker extends LitElement {
   private onCalendarChange(event: CustomEvent) {
     event.stopPropagation();
     this._dateRef?.clearRangeInputs();
-    this._workingAnchor = undefined;
     this.commitValue(event.detail.value);
   }
 
   /**
-   * The calendar's in-progress anchor, held here so it survives the popover,
-   * and painted into the start field so the day just picked is readable as a
-   * date — the reverse of typed parts moving the calendar's selection. An
-   * anchor dropped for a completed or restarted span empties the fields.
+   * Applies a new working range, repainting only the endpoints that actually
+   * changed. Repainting every reported endpoint would wipe half-typed
+   * segments the other half of the widget never saw; skipping the unchanged
+   * ones also keeps the caret out of the way while the user types.
    */
-  private onCalendarPartsChange(event: CustomEvent<{ anchor: string | null }>) {
-    event.stopPropagation();
-    const anchor = event.detail.anchor;
-    this._workingAnchor = anchor ?? undefined;
+  private setWorking(start?: string, end?: string, paint = false): void {
+    const startChanged = start !== this._workingStart;
+    const endChanged = end !== this._workingEnd;
+    this._workingStart = start;
+    this._workingEnd = end;
 
-    if (anchor) {
-      this._dateRef?.fillGroup('start', anchor);
-      this._dateRef?.fillGroup('end', null);
+    if (!paint) return;
+    if (startChanged) this._dateRef?.fillGroup('start', start ?? null);
+    if (endChanged) this._dateRef?.fillGroup('end', end ?? null);
+  }
+
+  /** Typed endpoints feed the working range; the calendar follows them. */
+  private onInputPartsChange(event: CustomEvent<{ start: string | null; end: string | null }>) {
+    event.stopPropagation();
+    this.setWorking(event.detail.start ?? undefined, event.detail.end ?? undefined);
+  }
+
+  /**
+   * The calendar's in-progress selection, held here so it survives the
+   * popover, and painted into the fields so a picked day reads back as a date
+   * — the reverse of typed parts moving the calendar's selection.
+   */
+  private onCalendarPartsChange(
+    event: CustomEvent<{ anchor: string | null; start: string | null; end: string | null }>,
+  ) {
+    event.stopPropagation();
+    const { anchor, start, end } = event.detail;
+
+    if (start || end) {
+      this.setWorking(start ?? undefined, end ?? undefined, true);
       return;
     }
-    this._dateRef?.clearRangeInputs();
+
+    if (anchor) {
+      if (!this._workingStart && this._workingEnd === anchor) return;
+      this.setWorking(anchor, undefined, true);
+      return;
+    }
+
+    this.setWorking(undefined, undefined, true);
   }
 
   private onCalendarInputError(event: CustomEvent) {
@@ -371,9 +405,17 @@ export class GuiRangeDatePicker extends LitElement {
     this._dateRef?.showRange(range.start, range.end);
   }
 
-  private commitValue(value: DateRange[] | null | undefined) {
+  /**
+   * The single funnel every commit passes through — a calendar span, a typed
+   * Enter — so the working selection is torn down once, and the calendar
+   * (which follows the cleared props) with it. `committed` is false for the
+   * input's error-clearing echo, which carries no new pill and must leave a
+   * half-entered range alone.
+   */
+  private commitValue(value: DateRange[] | null | undefined, committed = true) {
     this.value = value ?? undefined;
     this._invalidRange = null;
+    if (committed) this.setWorking(undefined, undefined);
     this.dispatchEvent(
       new CustomEvent('change', {
         detail: { value: value ?? null },

--- a/libs/gui/components/src/lib/components/range-date-picker.ts
+++ b/libs/gui/components/src/lib/components/range-date-picker.ts
@@ -86,6 +86,9 @@ export class GuiRangeDatePicker extends LitElement {
   @property({ type: String, attribute: 'disabled-date-range-message' }) disabledDateRangeMessage:
     | string
     | undefined = undefined;
+  @property({ type: String, attribute: 'incomplete-message' }) incompleteMessage:
+    | string
+    | undefined = undefined;
 
   @query('#date-input') private _dateRef?: GuiRangeDateInput;
 
@@ -237,6 +240,7 @@ export class GuiRangeDatePicker extends LitElement {
           .monthAriaLabel=${this.monthAriaLabel}
           .yearAriaLabel=${this.yearAriaLabel}
           .invalidDateMessage=${this.invalidDateMessage}
+          .incompleteMessage=${this.incompleteMessage}
           @blur=${this.onDateBlur}
           @focus=${this._popup.show}
           @change=${this.onDateChange}
@@ -324,17 +328,11 @@ export class GuiRangeDatePicker extends LitElement {
     this._invalidRange = { start, end };
     this.setWorking(undefined, undefined);
     const input = this._dateRef;
-    if (input) {
-      input.value = this.value ?? [];
-      input.showRange(start, end);
-    }
-    this.dispatchEvent(
-      new CustomEvent('inputError', {
-        detail: { message },
-        bubbles: true,
-        composed: true,
-      }),
-    );
+    if (!input) return;
+
+    input.value = this.value ?? [];
+    input.showRange(start, end);
+    input.surfaceHostError(message);
   }
 
   /**

--- a/libs/gui/components/src/lib/components/range-date-time-calendar.ts
+++ b/libs/gui/components/src/lib/components/range-date-time-calendar.ts
@@ -154,6 +154,14 @@ export class GuiRangeDateTimeCalendar extends LitElement {
     | undefined = undefined;
   @property({ type: String, attribute: 'working-end-time' }) workingEndTime: string | undefined =
     undefined;
+  /**
+   * Set by host pickers that run their own whole-widget focus-leave check:
+   * moving from this calendar into the picker's trigger is not leaving the
+   * control, so the calendar leaves the commit to the host.
+   */
+  @property({ type: Boolean, attribute: 'defer-focus-leave' }) deferFocusLeave:
+    | boolean
+    | undefined = false;
 
   @state() protected _selection: RangeSelectionState = idleRangeSelection();
   @state() protected _invalidRange: { start: Date; end: Date } | null = null;
@@ -223,8 +231,16 @@ export class GuiRangeDateTimeCalendar extends LitElement {
     isYearGridOpen: () => this._nav.yearSelectorOpen,
   });
 
+  /**
+   * Leaving settles the working selection before blurring. Only a deliberate
+   * pick attempts a commit as it happens, so four pieces completed by typing a
+   * custom time sit here uncommitted — and leaving is as deliberate as Enter.
+   */
   private _focusLeave = new GUIFocusLeaveController(this, {
-    onLeave: () => this.dispatchEvent(new CustomEvent('blur', { bubbles: true, composed: true })),
+    onLeave: () => {
+      if (!this.deferFocusLeave) this.tryCommitWorkingRange();
+      this.dispatchEvent(new CustomEvent('blur', { bubbles: true, composed: true }));
+    },
   });
 
   /**

--- a/libs/gui/components/src/lib/components/range-date-time-calendar.ts
+++ b/libs/gui/components/src/lib/components/range-date-time-calendar.ts
@@ -135,6 +135,18 @@ export class GuiRangeDateTimeCalendar extends LitElement {
     | undefined = undefined;
   @property({ type: String, attribute: 'disabled-day-count-aria-label' })
   disabledDayCountAriaLabel: string | undefined = undefined;
+  @property({ type: String, attribute: 'working-anchor' }) workingAnchor: string | undefined =
+    undefined;
+  @property({ type: String, attribute: 'working-start-date' }) workingStartDate:
+    | string
+    | undefined = undefined;
+  @property({ type: String, attribute: 'working-end-date' }) workingEndDate: string | undefined =
+    undefined;
+  @property({ type: String, attribute: 'working-start-time' }) workingStartTime:
+    | string
+    | undefined = undefined;
+  @property({ type: String, attribute: 'working-end-time' }) workingEndTime: string | undefined =
+    undefined;
 
   @state() protected _selection: RangeSelectionState = idleRangeSelection();
   @state() protected _invalidRange: { start: Date; end: Date } | null = null;
@@ -253,6 +265,7 @@ export class GuiRangeDateTimeCalendar extends LitElement {
   }
 
   override willUpdate(changedProperties: PropertyValues): void {
+    this.adoptWorkingSelection(changedProperties);
     if (
       !this.hasUpdated ||
       changedProperties.has('minDateTime') ||
@@ -335,8 +348,8 @@ export class GuiRangeDateTimeCalendar extends LitElement {
   protected renderBelowHeader(offset: number): TemplateResult | typeof nothing {
     if (offset !== 0) return nothing;
 
-    const startEnabled = !this.disabled && !!this._workingDateStart;
-    const endEnabled = !this.disabled && !!this._workingTimeIn;
+    const startEnabled = !this.disabled;
+    const endEnabled = !this.disabled;
     const startBounds = this.startListBounds;
     const endBounds = this.endListBounds;
 
@@ -573,10 +586,13 @@ export class GuiRangeDateTimeCalendar extends LitElement {
     });
     this._selection = state;
 
-    // Start selection
+    // Starting a new span drops the previous days but keeps the chosen times:
+    // a time of day is independent of which days the range covers.
     if (!commit) {
-      this.resetWorking();
+      this._workingDateStart = undefined;
+      this._workingDateEnd = undefined;
       this._invalidRange = null;
+      this.emitPartsChange();
       return;
     }
 
@@ -590,8 +606,8 @@ export class GuiRangeDateTimeCalendar extends LitElement {
     this._invalidRange = null;
     this._workingDateStart = toISODateString(commit.start);
     this._workingDateEnd = toISODateString(commit.end);
-    this._workingTimeIn = undefined;
-    this._workingTimeOut = undefined;
+    this.emitPartsChange();
+    this.tryCommitWorkingRange();
   }
 
   private spanCoversBlockedDay(startDate: Date, endDate: Date): boolean {
@@ -616,55 +632,61 @@ export class GuiRangeDateTimeCalendar extends LitElement {
   }
 
   private onStartTimeChange(event: CustomEvent) {
-    event.stopPropagation();
-    // Only a deliberate selection (list pick or Enter) advances the flow
-    if (event.detail.commit !== true) return;
-
-    const time = event.detail.value as string | null;
-    if (!time || !this._workingDateStart) {
-      this._workingTimeIn = undefined;
-      this._workingTimeOut = undefined;
-      return;
-    }
-    const error = this.timeError(time, this._workingDateStart, this.resolvedStartTimeRanges);
-    if (error) {
-      // Keep the end picker disabled until the start is valid.
-      this._workingTimeIn = undefined;
-      this._workingTimeOut = undefined;
-      this.emitInputError(error);
-      return;
-    }
-    this._workingTimeIn = time;
-    this._workingTimeOut = undefined;
+    this.onTimeChange(event, 'start');
   }
 
   private onEndTimeChange(event: CustomEvent) {
-    event.stopPropagation();
-    // Only a deliberate selection creates the pill; typing a custom time must
-    // not, or it would commit an unintended pill.
-    if (event.detail.commit !== true) return;
+    this.onTimeChange(event, 'end');
+  }
 
-    const time = event.detail.value as string | null;
-    if (!time) {
-      this._workingTimeOut = undefined;
+  /**
+   * Both endpoints follow one rule: the value is always kept as working state
+   * (so it survives and syncs), but only a deliberate selection — a list pick
+   * or Enter — attempts the commit. Typing a custom time must never create an
+   * unintended pill.
+   */
+  private onTimeChange(event: CustomEvent, endpoint: 'start' | 'end') {
+    event.stopPropagation();
+
+    const time = (event.detail.value as string | null) ?? undefined;
+    if (endpoint === 'start') {
+      this._workingTimeIn = time;
+    } else {
+      this._workingTimeOut = time;
+    }
+    this.emitPartsChange();
+
+    if (event.detail.commit !== true) return;
+    this.tryCommitWorkingRange();
+  }
+
+  /**
+   * Commits once all four pieces are present, in whichever order they were
+   * chosen. A rejected endpoint or span keeps every working value on show
+   * next to its error, so the user corrects one piece instead of restarting.
+   */
+  private tryCommitWorkingRange(): void {
+    const startDate = this._workingDateStart;
+    const endDate = this._workingDateEnd;
+    const timeIn = this._workingTimeIn;
+    const timeOut = this._workingTimeOut;
+    if (!startDate || !endDate || !timeIn || !timeOut) return;
+
+    const startError = this.timeError(timeIn, startDate, this.resolvedStartTimeRanges);
+    if (startError) {
+      this.emitInputError(startError);
       return;
     }
-    if (!this._workingTimeIn || !this._workingDateStart || !this._workingDateEnd) return;
 
-    const endError = this.timeError(time, this._workingDateEnd, this.resolvedEndTimeRanges);
+    const endError = this.timeError(timeOut, endDate, this.resolvedEndTimeRanges);
     if (endError) {
-      this._workingTimeOut = time;
       this.emitInputError(endError);
       return;
     }
 
-    const ordered = orderDateTimeRange(
-      `${this._workingDateStart}T${this._workingTimeIn}`,
-      `${this._workingDateEnd}T${time}`,
-    );
+    const ordered = orderDateTimeRange(`${startDate}T${timeIn}`, `${endDate}T${timeOut}`);
 
     if (dateTimeRangeOverlaps(ordered, this.disabledRanges)) {
-      this._workingTimeOut = time;
       this.emitInputError(this.disabledRangeMessage ?? DISABLED_DATE_RANGE_MESSAGE);
       return;
     }
@@ -672,9 +694,57 @@ export class GuiRangeDateTimeCalendar extends LitElement {
     this._skipValueNavigation = true;
     this.value = mergeDateTimeRanges([...(this.value ?? []), ordered]);
     this.resetWorking();
+    this.emitPartsChange();
     this.dispatchEvent(
       new CustomEvent('change', { detail: { value: this.value }, bubbles: true, composed: true }),
     );
+  }
+
+  /**
+   * Live-syncs the in-progress selection to a host picker, which holds it
+   * across the popover's unmount/remount cycle. Never wired by the form
+   * layer, so it can't trigger validation.
+   */
+  private emitPartsChange(): void {
+    this.dispatchEvent(
+      new CustomEvent('partsChange', {
+        detail: {
+          anchor: this._selection.anchor ? toISODateString(this._selection.anchor) : null,
+          startDate: this._workingDateStart ?? null,
+          endDate: this._workingDateEnd ?? null,
+          startTime: this._workingTimeIn ?? null,
+          endTime: this._workingTimeOut ?? null,
+        },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  /**
+   * Takes over the host picker's working selection on the mount that follows
+   * a popover reopen. Only empty fields are adopted, so the picker echoing
+   * back what this calendar just reported can never overwrite live state.
+   */
+  private adoptWorkingSelection(changedProperties: PropertyValues): void {
+    if (changedProperties.has('workingAnchor') && !this._selection.anchor && this.workingAnchor) {
+      const anchor = parseISODateString(this.workingAnchor);
+      if (!isNaN(anchor.getTime())) {
+        this._selection = { anchor, hover: null, selecting: true };
+      }
+    }
+    if (changedProperties.has('workingStartDate') && !this._workingDateStart) {
+      this._workingDateStart = this.workingStartDate || undefined;
+    }
+    if (changedProperties.has('workingEndDate') && !this._workingDateEnd) {
+      this._workingDateEnd = this.workingEndDate || undefined;
+    }
+    if (changedProperties.has('workingStartTime') && !this._workingTimeIn) {
+      this._workingTimeIn = this.workingStartTime || undefined;
+    }
+    if (changedProperties.has('workingEndTime') && !this._workingTimeOut) {
+      this._workingTimeOut = this.workingEndTime || undefined;
+    }
   }
 
   /**

--- a/libs/gui/components/src/lib/components/range-date-time-calendar.ts
+++ b/libs/gui/components/src/lib/components/range-date-time-calendar.ts
@@ -22,7 +22,12 @@ import {
   renderCalendarMonthPanel,
   renderCalendarPanelBody,
 } from '../utils/calendar-templates';
-import { buildMonthDays, computeDayStatus, type DaySpan } from '../utils/day-status';
+import {
+  buildMonthDays,
+  computeDayStatus,
+  orderedDaySpan,
+  type DaySpan,
+} from '../utils/day-status';
 import {
   buildPillItems,
   findRangeByKey,
@@ -33,6 +38,7 @@ import {
   idleRangeSelection,
   reduceRangeSelection,
   selectionPreviewSpan,
+  workingPhase,
   type RangeSelectionState,
 } from '../utils/range-selection';
 import {
@@ -135,13 +141,14 @@ export class GuiRangeDateTimeCalendar extends LitElement {
     | undefined = undefined;
   @property({ type: String, attribute: 'disabled-day-count-aria-label' })
   disabledDayCountAriaLabel: string | undefined = undefined;
-  @property({ type: String, attribute: 'working-anchor' }) workingAnchor: string | undefined =
+  /**
+   * The host picker's working selection — typed into its input, or picked here
+   * and held there across the popover's unmount/remount cycle. One date
+   * renders as an in-progress anchor, both as a parked span.
+   */
+  @property({ type: String, attribute: 'working-start' }) workingStart: string | undefined =
     undefined;
-  @property({ type: String, attribute: 'working-start-date' }) workingStartDate:
-    | string
-    | undefined = undefined;
-  @property({ type: String, attribute: 'working-end-date' }) workingEndDate: string | undefined =
-    undefined;
+  @property({ type: String, attribute: 'working-end' }) workingEnd: string | undefined = undefined;
   @property({ type: String, attribute: 'working-start-time' }) workingStartTime:
     | string
     | undefined = undefined;
@@ -151,10 +158,10 @@ export class GuiRangeDateTimeCalendar extends LitElement {
   @state() protected _selection: RangeSelectionState = idleRangeSelection();
   @state() protected _invalidRange: { start: Date; end: Date } | null = null;
 
-  @state() private _workingDateStart: string | undefined = undefined;
-  @state() private _workingDateEnd: string | undefined = undefined;
-  @state() private _workingTimeIn: string | undefined = undefined;
-  @state() private _workingTimeOut: string | undefined = undefined;
+  @state() private _workingStart: string | undefined = undefined;
+  @state() private _workingEnd: string | undefined = undefined;
+  @state() private _workingStartTime: string | undefined = undefined;
+  @state() private _workingEndTime: string | undefined = undefined;
   @state() private _openList: 'start' | 'end' | null = null;
 
   protected _skipValueNavigation = false;
@@ -246,13 +253,12 @@ export class GuiRangeDateTimeCalendar extends LitElement {
     return `${start} - ${end}`;
   }
 
-  /** Highlights the parked working date range like a committed one. */
-  protected get workingRange(): DaySpan | undefined {
-    if (!this._workingDateStart || !this._workingDateEnd) return undefined;
-    return {
-      start: parseISODateString(this._workingDateStart),
-      end: parseISODateString(this._workingDateEnd),
-    };
+  protected get workingSpan(): DaySpan | undefined {
+    if (!this._workingStart || !this._workingEnd) return undefined;
+    return orderedDaySpan(
+      parseISODateString(this._workingStart),
+      parseISODateString(this._workingEnd),
+    );
   }
 
   override createRenderRoot() {
@@ -376,7 +382,7 @@ export class GuiRangeDateTimeCalendar extends LitElement {
             ?disabled=${!startEnabled}
             ?readonly=${this.readOnly}
             .allowCustomTime=${this.allowCustomTime}
-            .value=${this._workingTimeIn}
+            .value=${this._workingStartTime}
             .localeId=${this.localeId}
             .hourFormat=${this.hourFormat}
             .minuteStep=${this.minuteStep}
@@ -387,6 +393,7 @@ export class GuiRangeDateTimeCalendar extends LitElement {
             .disabledRangeMessage=${this.disabledRangeMessage}
             .noAvailableTimesMessage=${this.noAvailableTimesMessage}
             @change=${this.onStartTimeChange}
+            @partsChange=${this.stopInnerPartsChange}
             @listtoggle=${(e: CustomEvent<{ open: boolean }>) => this.onListToggle(e, 'start')}
           ></gui-time-picker>
         </div>
@@ -407,7 +414,7 @@ export class GuiRangeDateTimeCalendar extends LitElement {
             ?disabled=${!endEnabled}
             ?readonly=${this.readOnly}
             .allowCustomTime=${this.allowCustomTime}
-            .value=${this._workingTimeOut}
+            .value=${this._workingEndTime}
             .localeId=${this.localeId}
             .hourFormat=${this.hourFormat}
             .minuteStep=${this.minuteStep}
@@ -418,6 +425,7 @@ export class GuiRangeDateTimeCalendar extends LitElement {
             .disabledRangeMessage=${this.disabledRangeMessage}
             .noAvailableTimesMessage=${this.noAvailableTimesMessage}
             @change=${this.onEndTimeChange}
+            @partsChange=${this.stopInnerPartsChange}
             @listtoggle=${(e: CustomEvent<{ open: boolean }>) => this.onListToggle(e, 'end')}
           ></gui-time-picker>
         </div>
@@ -535,7 +543,7 @@ export class GuiRangeDateTimeCalendar extends LitElement {
       start: this.endpointDay(range.start),
       end: range.end ? this.endpointDay(range.end) : undefined,
     }));
-    const selectingSpan = selectionPreviewSpan(this._selection);
+    const selectingSpan = selectionPreviewSpan(this._selection) ?? this.workingSpan ?? null;
 
     return buildMonthDays({
       currentDate: this._currentDate,
@@ -546,7 +554,6 @@ export class GuiRangeDateTimeCalendar extends LitElement {
       toDay: (base) => {
         const status = computeDayStatus(base.date, {
           ranges,
-          workingRange: this.workingRange,
           anchor: this._selection.anchor,
           selectingSpan,
           invalidRange: this._invalidRange,
@@ -589,8 +596,8 @@ export class GuiRangeDateTimeCalendar extends LitElement {
     // Starting a new span drops the previous days but keeps the chosen times:
     // a time of day is independent of which days the range covers.
     if (!commit) {
-      this._workingDateStart = undefined;
-      this._workingDateEnd = undefined;
+      this._workingStart = undefined;
+      this._workingEnd = undefined;
       this._invalidRange = null;
       this.emitPartsChange();
       return;
@@ -604,8 +611,8 @@ export class GuiRangeDateTimeCalendar extends LitElement {
     }
 
     this._invalidRange = null;
-    this._workingDateStart = toISODateString(commit.start);
-    this._workingDateEnd = toISODateString(commit.end);
+    this._workingStart = toISODateString(commit.start);
+    this._workingEnd = toISODateString(commit.end);
     this.emitPartsChange();
     this.tryCommitWorkingRange();
   }
@@ -650,9 +657,9 @@ export class GuiRangeDateTimeCalendar extends LitElement {
 
     const time = (event.detail.value as string | null) ?? undefined;
     if (endpoint === 'start') {
-      this._workingTimeIn = time;
+      this._workingStartTime = time;
     } else {
-      this._workingTimeOut = time;
+      this._workingEndTime = time;
     }
     this.emitPartsChange();
 
@@ -666,10 +673,10 @@ export class GuiRangeDateTimeCalendar extends LitElement {
    * next to its error, so the user corrects one piece instead of restarting.
    */
   private tryCommitWorkingRange(): void {
-    const startDate = this._workingDateStart;
-    const endDate = this._workingDateEnd;
-    const timeIn = this._workingTimeIn;
-    const timeOut = this._workingTimeOut;
+    const startDate = this._workingStart;
+    const endDate = this._workingEnd;
+    const timeIn = this._workingStartTime;
+    const timeOut = this._workingEndTime;
     if (!startDate || !endDate || !timeIn || !timeOut) return;
 
     const startError = this.timeError(timeIn, startDate, this.resolvedStartTimeRanges);
@@ -709,11 +716,11 @@ export class GuiRangeDateTimeCalendar extends LitElement {
     this.dispatchEvent(
       new CustomEvent('partsChange', {
         detail: {
-          anchor: this._selection.anchor ? toISODateString(this._selection.anchor) : null,
-          startDate: this._workingDateStart ?? null,
-          endDate: this._workingDateEnd ?? null,
-          startTime: this._workingTimeIn ?? null,
-          endTime: this._workingTimeOut ?? null,
+          anchor: this.anchorISO() ?? null,
+          start: this._workingStart ?? null,
+          end: this._workingEnd ?? null,
+          startTime: this._workingStartTime ?? null,
+          endTime: this._workingEndTime ?? null,
         },
         bubbles: true,
         composed: true,
@@ -722,29 +729,62 @@ export class GuiRangeDateTimeCalendar extends LitElement {
   }
 
   /**
-   * Takes over the host picker's working selection on the mount that follows
-   * a popover reopen. Only empty fields are adopted, so the picker echoing
-   * back what this calendar just reported can never overwrite live state.
+   * Takes over the host picker's working selection: on the mount that follows
+   * a popover reopen, and on every later change, so a value typed into the
+   * picker's input reaches the days grid and the two time pickers. Adoption
+   * compares values and never emits, so the picker echoing back what this
+   * calendar just reported settles as a no-op instead of looping.
    */
   private adoptWorkingSelection(changedProperties: PropertyValues): void {
-    if (changedProperties.has('workingAnchor') && !this._selection.anchor && this.workingAnchor) {
-      const anchor = parseISODateString(this.workingAnchor);
-      if (!isNaN(anchor.getTime())) {
-        this._selection = { anchor, hover: null, selecting: true };
-      }
+    if (changedProperties.has('workingStart') || changedProperties.has('workingEnd')) {
+      this.adoptWorkingDates();
     }
-    if (changedProperties.has('workingStartDate') && !this._workingDateStart) {
-      this._workingDateStart = this.workingStartDate || undefined;
+    if (changedProperties.has('workingStartTime')) {
+      this._workingStartTime = this.workingStartTime || undefined;
     }
-    if (changedProperties.has('workingEndDate') && !this._workingDateEnd) {
-      this._workingDateEnd = this.workingEndDate || undefined;
+    if (changedProperties.has('workingEndTime')) {
+      this._workingEndTime = this.workingEndTime || undefined;
     }
-    if (changedProperties.has('workingStartTime') && !this._workingTimeIn) {
-      this._workingTimeIn = this.workingStartTime || undefined;
+  }
+
+  /**
+   * One date is an in-progress anchor the next click completes; both are the
+   * parked span that waits for the times. Navigates to a span or anchor that
+   * falls outside the visible months.
+   */
+  private adoptWorkingDates(): void {
+    const phase = workingPhase(this.workingStart, this.workingEnd);
+
+    if (phase.kind === 'span') {
+      if (this._workingStart === phase.start && this._workingEnd === phase.end) return;
+      this._workingStart = phase.start;
+      this._workingEnd = phase.end;
+      this._selection = idleRangeSelection();
+      // The earliest endpoint, so a pair entered end-first still opens on the
+      // beginning of its span.
+      this._nav.navigateToDate(this.workingSpan?.start ?? this.endpointDay(phase.start));
+      return;
     }
-    if (changedProperties.has('workingEndTime') && !this._workingTimeOut) {
-      this._workingTimeOut = this.workingEndTime || undefined;
+
+    this._workingStart = undefined;
+    this._workingEnd = undefined;
+
+    if (phase.kind === 'idle') {
+      if (this._selection.anchor) this._selection = idleRangeSelection();
+      return;
     }
+
+    if (this.anchorISO() === phase.iso) return;
+
+    const anchor = this.endpointDay(phase.iso);
+    if (isNaN(anchor.getTime())) return;
+    this._selection = { anchor, hover: null, selecting: true };
+    this._nav.navigateToDate(anchor);
+  }
+
+  /** ISO day of the in-progress anchor, or undefined while idle. */
+  private anchorISO(): string | undefined {
+    return this._selection.anchor ? toISODateString(this._selection.anchor) : undefined;
   }
 
   /**
@@ -764,10 +804,11 @@ export class GuiRangeDateTimeCalendar extends LitElement {
   }
 
   private resetWorking() {
-    this._workingDateStart = undefined;
-    this._workingDateEnd = undefined;
-    this._workingTimeIn = undefined;
-    this._workingTimeOut = undefined;
+    this._workingStart = undefined;
+    this._workingEnd = undefined;
+    this._workingStartTime = undefined;
+    this._workingEndTime = undefined;
+    this._selection = idleRangeSelection();
     this._openList = null;
     this.resetPicker(this.startPicker);
     this.resetPicker(this.endPicker);
@@ -778,6 +819,17 @@ export class GuiRangeDateTimeCalendar extends LitElement {
     picker.value = undefined;
     picker.closeList();
   }
+
+  /**
+   * The embedded time pickers' own segmented inputs broadcast a bubbling,
+   * composed `partsChange` carrying only `{time}`. Left alone it reaches the
+   * host picker's listener looking like this calendar's report, whose missing
+   * keys read as "every piece is gone" and blank the working selection. The
+   * times this calendar holds already flow out through `@change`.
+   */
+  private stopInnerPartsChange = (event: Event) => {
+    event.stopPropagation();
+  };
 
   private emitInputError(message: string) {
     this.dispatchEvent(
@@ -814,14 +866,14 @@ export class GuiRangeDateTimeCalendar extends LitElement {
   }
 
   private get resolvedStartTimeRanges() {
-    return this._workingDateStart
-      ? resolveDisabledTimesForDate(this.disabledRanges, this._workingDateStart)
+    return this._workingStart
+      ? resolveDisabledTimesForDate(this.disabledRanges, this._workingStart)
       : [];
   }
 
   private get resolvedEndTimeRanges() {
-    return this._workingDateEnd
-      ? resolveDisabledTimesForDate(this.disabledRanges, this._workingDateEnd)
+    return this._workingEnd
+      ? resolveDisabledTimesForDate(this.disabledRanges, this._workingEnd)
       : [];
   }
 
@@ -838,14 +890,14 @@ export class GuiRangeDateTimeCalendar extends LitElement {
   }
 
   private get startListBounds(): { minTime?: string; maxTime?: string } {
-    return this._workingDateStart ? this.dayClampedBounds(this._workingDateStart) : {};
+    return this._workingStart ? this.dayClampedBounds(this._workingStart) : {};
   }
 
   private get endListBounds(): { minTime?: string; maxTime?: string } {
-    if (!this._workingDateEnd) return {};
-    const base = this.dayClampedBounds(this._workingDateEnd);
-    if (this._workingDateEnd !== this._workingDateStart || !this._workingTimeIn) return base;
-    const floor = oneStepAfterISOTime(this._workingTimeIn, this.minuteStep);
+    if (!this._workingEnd) return {};
+    const base = this.dayClampedBounds(this._workingEnd);
+    if (this._workingEnd !== this._workingStart || !this._workingStartTime) return base;
+    const floor = oneStepAfterISOTime(this._workingStartTime, this.minuteStep);
     if (!floor) return { minTime: '23:59:59', maxTime: '00:00:00' };
     return { minTime: floor, maxTime: base.maxTime };
   }

--- a/libs/gui/components/src/lib/components/range-date-time-calendar.ts
+++ b/libs/gui/components/src/lib/components/range-date-time-calendar.ts
@@ -358,6 +358,7 @@ export class GuiRangeDateTimeCalendar extends LitElement {
             .uid=${this.uid ? `${this.uid}-start-time` : undefined}
             .label=${this.startTimeLabel ?? 'Start time'}
             .showErrors=${false}
+            .deferFocusLeave=${true}
             ?required=${this.required}
             ?disabled=${!startEnabled}
             ?readonly=${this.readOnly}
@@ -388,6 +389,7 @@ export class GuiRangeDateTimeCalendar extends LitElement {
             .uid=${this.uid ? `${this.uid}-end-time` : undefined}
             .label=${this.endTimeLabel ?? 'End time'}
             .showErrors=${false}
+            .deferFocusLeave=${true}
             ?required=${this.required}
             ?disabled=${!endEnabled}
             ?readonly=${this.readOnly}

--- a/libs/gui/components/src/lib/components/range-date-time-calendar.ts
+++ b/libs/gui/components/src/lib/components/range-date-time-calendar.ts
@@ -10,6 +10,7 @@ import type { RangeCalendarDay } from './range-calendar';
 import './pills';
 import type { GuiPillEventDetail, GuiPillItem } from './pills';
 import './time-picker';
+import type { GuiTime } from './time-input';
 import type { GuiTimePicker } from './time-picker';
 import {
   getFullDateLabel,
@@ -57,7 +58,10 @@ import {
   type HourFormat,
   type TimeRange,
 } from '../utils/time';
-import { DISABLED_DATE_RANGE_MESSAGE } from '../utils/messages';
+import {
+  DISABLED_DATE_RANGE_MESSAGE,
+  INCOMPLETE_DATE_TIME_MESSAGE,
+} from '../utils/messages';
 
 @customElement('gui-range-date-time-calendar')
 export class GuiRangeDateTimeCalendar extends LitElement {
@@ -134,6 +138,9 @@ export class GuiRangeDateTimeCalendar extends LitElement {
     | string
     | undefined = undefined;
   @property({ type: String, attribute: 'no-available-times-message' }) noAvailableTimesMessage:
+    | string
+    | undefined = undefined;
+  @property({ type: String, attribute: 'incomplete-message' }) incompleteMessage:
     | string
     | undefined = undefined;
   @property({ type: String, attribute: 'day-count-aria-label' }) dayCountAriaLabel:
@@ -238,10 +245,46 @@ export class GuiRangeDateTimeCalendar extends LitElement {
    */
   private _focusLeave = new GUIFocusLeaveController(this, {
     onLeave: () => {
-      if (!this.deferFocusLeave) this.tryCommitWorkingRange();
+      if (!this.deferFocusLeave) this.settleOnLeave();
       this.dispatchEvent(new CustomEvent('blur', { bubbles: true, composed: true }));
     },
   });
+
+  /**
+   * A completed working range commits (or surfaces its own rejection). A
+   * half-finished one — any piece left behind: a span, a lone anchor day, a
+   * parked time, or a half-typed time that never emitted — surfaces the
+   * incomplete message; the committed pills are untouched, the injected
+   * issue alone flags the field. An emptied selection instead clears a
+   * message surfaced earlier.
+   */
+  private settleOnLeave(): void {
+    if (this.tryCommitWorkingRange()) return;
+
+    const leftBehind =
+      !!this.anchorISO() ||
+      !!this._workingStart ||
+      !!this._workingEnd ||
+      !!this._workingStartTime ||
+      !!this._workingEndTime ||
+      this.typedTimeCompleteness(this.startPicker) === 'partial' ||
+      this.typedTimeCompleteness(this.endPicker) === 'partial';
+
+    if (!leftBehind) {
+      if (this._surfacedError) this.emitChange(this.value ?? []);
+      return;
+    }
+
+    this.emitInputError(this.incompleteMessage ?? INCOMPLETE_DATE_TIME_MESSAGE);
+  }
+
+  /**
+   * The fill state of an embedded picker's typed time input. A half-typed
+   * time never emits, so it is visible only in the input's parts.
+   */
+  private typedTimeCompleteness(picker: GuiTimePicker | null) {
+    return picker?.querySelector<GuiTime>('gui-time')?.groupCompleteness() ?? 'empty';
+  }
 
   /**
    * Full instant of an endpoint, used to order the pills — endpoints carry a
@@ -687,39 +730,55 @@ export class GuiRangeDateTimeCalendar extends LitElement {
    * Commits once all four pieces are present, in whichever order they were
    * chosen. A rejected endpoint or span keeps every working value on show
    * next to its error, so the user corrects one piece instead of restarting.
+   *
+   * @return {boolean} Whether the attempt reported — a commit or a rejection
+   *   error. False with pieces missing, where the caller decides what an
+   *   unfinished selection means.
    */
-  private tryCommitWorkingRange(): void {
+  private tryCommitWorkingRange(): boolean {
     const startDate = this._workingStart;
     const endDate = this._workingEnd;
     const timeIn = this._workingStartTime;
     const timeOut = this._workingEndTime;
-    if (!startDate || !endDate || !timeIn || !timeOut) return;
+    if (!startDate || !endDate || !timeIn || !timeOut) return false;
 
     const startError = this.timeError(timeIn, startDate, this.resolvedStartTimeRanges);
     if (startError) {
       this.emitInputError(startError);
-      return;
+      return true;
     }
 
     const endError = this.timeError(timeOut, endDate, this.resolvedEndTimeRanges);
     if (endError) {
       this.emitInputError(endError);
-      return;
+      return true;
     }
 
     const ordered = orderDateTimeRange(`${startDate}T${timeIn}`, `${endDate}T${timeOut}`);
 
     if (dateTimeRangeOverlaps(ordered, this.disabledRanges)) {
       this.emitInputError(this.disabledRangeMessage ?? DISABLED_DATE_RANGE_MESSAGE);
-      return;
+      return true;
     }
 
     this._skipValueNavigation = true;
-    this.value = mergeDateTimeRanges([...(this.value ?? []), ordered]);
+    const next = mergeDateTimeRanges([...(this.value ?? []), ordered]);
+    this.value = next;
     this.resetWorking();
     this.emitPartsChange();
+    this.emitChange(next);
+    return true;
+  }
+
+  /** Whether an inputError has been emitted and not yet cleared by a change. */
+  private _surfacedError = false;
+
+  private emitChange(value: DateTimeRange[]): void {
+    // The form layer clears injected issues on every change, so the mirror
+    // flag resets with it.
+    this._surfacedError = false;
     this.dispatchEvent(
-      new CustomEvent('change', { detail: { value: this.value }, bubbles: true, composed: true }),
+      new CustomEvent('change', { detail: { value }, bubbles: true, composed: true }),
     );
   }
 
@@ -848,6 +907,7 @@ export class GuiRangeDateTimeCalendar extends LitElement {
   };
 
   private emitInputError(message: string) {
+    this._surfacedError = true;
     this.dispatchEvent(
       new CustomEvent('inputError', { detail: { message }, bubbles: true, composed: true }),
     );
@@ -1026,13 +1086,7 @@ export class GuiRangeDateTimeCalendar extends LitElement {
     const removal = removeRangeByKey(this.value, e.detail.key);
     if (!removal) return;
     this.value = removal.next;
-    this.dispatchEvent(
-      new CustomEvent('change', {
-        detail: { value: this.value },
-        bubbles: true,
-        composed: true,
-      }),
-    );
+    this.emitChange(removal.next);
   };
 
   private onPillClickEvent = (e: CustomEvent<GuiPillEventDetail>) => {

--- a/libs/gui/components/src/lib/components/range-date-time-input.ts
+++ b/libs/gui/components/src/lib/components/range-date-time-input.ts
@@ -160,17 +160,20 @@ export class GuiRangeDateTimeInput extends LitElement {
   });
 
   /**
-   * The single point where the input reports focus leaving the control: it
-   * blurs (which the form layer reads as "validate now"), so hopping between
-   * segments never validates a half-typed entry, then surfaces a half-entered
-   * range left behind.
+   * The single point where the input reports focus leaving the control. It
+   * settles what is in the fields FIRST, then blurs — the form layer reads a
+   * blur as "validate now", and storing a value runs no validator, so blurring
+   * first would validate the value the commit is about to replace and leave a
+   * `required` error standing over a range the user did finish. Hopping
+   * between segments is not a departure and never reaches here.
    */
   private _focusLeave = new GUIFocusLeaveController(this, {
+    resolveSyncOnRelatedTarget: true,
     onLeave: () => {
       // Embedded in a picker: that host owns focus reporting for the subtree.
       if (this.deferFocusLeave) return;
+      this.finalizeOnLeave();
       this.dispatchEvent(new CustomEvent('blur'));
-      this.reportIncompleteOnLeave();
     },
   });
 
@@ -433,25 +436,34 @@ export class GuiRangeDateTimeInput extends LitElement {
   }
 
   /**
-   * A range left half-entered when focus leaves is abandoned work: some parts
-   * of one endpoint typed, or one endpoint filled and the other still empty
-   * (a span picked in the calendar with no times lands here too). Both
-   * surface the incomplete message — or the endpoint's own message when one
-   * is outright invalid, which is more useful than "incomplete".
-   * `_validationTriggered` makes the next edit re-evaluate, so the message
-   * clears as soon as the user comes back and continues (or empties the
-   * fields). Public so a host picker can call it from its own whole-widget
-   * focus-leave check.
+   * What leaving does with whatever is in the fields. Public so a host picker
+   * can call it from its own whole-widget focus-leave check.
+   *
+   * A complete range is finished work, so leaving commits it exactly as Enter
+   * does — a user who typed a whole range and moved on gets the pill they
+   * plainly meant, and the same validation decides whether it is allowed.
+   *
+   * A half-entered one is abandoned work: some parts of one endpoint typed, or
+   * one endpoint filled and the other still empty (a span picked in the
+   * calendar with no times lands here too). Both surface the incomplete
+   * message — or the endpoint's own message when one is outright invalid,
+   * which is more useful than "incomplete". `_validationTriggered` makes the
+   * next edit re-evaluate, so the message clears as soon as the user comes
+   * back and continues (or empties the fields).
    */
-  reportIncompleteOnLeave(): void {
+  finalizeOnLeave(): void {
     const endpoints = this.groups.map((group) => ({
       result: this.validateDateTimeParts(group),
       empty: this._parts.isGroupEmpty(group, this.dateTimePartTypes),
     }));
 
-    // Nothing entered, or a complete range the commit path already owns.
+    // Nothing entered: nothing to settle.
     if (endpoints.every((endpoint) => endpoint.empty)) return;
-    if (endpoints.every((endpoint) => endpoint.result.kind === 'valid')) return;
+
+    if (endpoints.every((endpoint) => endpoint.result.kind === 'valid')) {
+      this.tryCreatePill({ refocus: false });
+      return;
+    }
 
     const invalidMessage = endpoints
       .map((endpoint) => (endpoint.result.kind === 'invalid' ? endpoint.result.message : undefined))
@@ -514,7 +526,7 @@ export class GuiRangeDateTimeInput extends LitElement {
     }
   }
 
-  private tryCreatePill() {
+  private tryCreatePill({ refocus = true }: { refocus?: boolean } = {}) {
     this._validationTriggered = true;
 
     const result = this.evaluateRange();
@@ -533,7 +545,7 @@ export class GuiRangeDateTimeInput extends LitElement {
       new CustomEvent('change', { detail: { value: this.value }, bubbles: true, composed: true }),
     );
 
-    this._parts.focusFirst('start');
+    if (refocus) this._parts.focusFirst('start');
     this.requestUpdate();
   }
 

--- a/libs/gui/components/src/lib/components/range-date-time-input.ts
+++ b/libs/gui/components/src/lib/components/range-date-time-input.ts
@@ -457,8 +457,10 @@ export class GuiRangeDateTimeInput extends LitElement {
       empty: this._parts.isGroupEmpty(group, this.dateTimePartTypes),
     }));
 
-    // Nothing entered: nothing to settle.
-    if (endpoints.every((endpoint) => endpoint.empty)) return;
+    if (endpoints.every((endpoint) => endpoint.empty)) {
+      this._parts.clearSurfacedInputError(this.value ?? []);
+      return;
+    }
 
     if (endpoints.every((endpoint) => endpoint.result.kind === 'valid')) {
       this.tryCreatePill({ refocus: false });

--- a/libs/gui/components/src/lib/components/range-date-time-input.ts
+++ b/libs/gui/components/src/lib/components/range-date-time-input.ts
@@ -151,7 +151,11 @@ export class GuiRangeDateTimeInput extends LitElement {
       this.dispatchEvent(new CustomEvent('inputError', { detail: { message }, bubbles: true })),
     onSurfacedErrorCleared: (value) =>
       this.dispatchEvent(
-        new CustomEvent('change', { detail: { value }, bubbles: true, composed: true }),
+        new CustomEvent('change', {
+          detail: { value, commit: false },
+          bubbles: true,
+          composed: true,
+        }),
       ),
   });
 

--- a/libs/gui/components/src/lib/components/range-date-time-input.ts
+++ b/libs/gui/components/src/lib/components/range-date-time-input.ts
@@ -4,6 +4,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit-html/directives/style-map.js';
 import { GUIAriaController } from '../controllers/aria.controller';
+import { GUIFocusLeaveController } from '../controllers/focus-leave.controller';
 import { GUIPartsController } from '../controllers/parts.controller';
 import {
   dateTimeBoundsError,
@@ -19,6 +20,7 @@ import { renderGroupParts, type GUIPartsTemplateData } from '../utils/part-templ
 import {
   getTimeLocaleData,
   parseDateTimeGroup,
+  parseDateTimeSubGroups,
   PART_DEFAULT_ARIA_LABELS,
   type DateTimePartDescriptor,
   type DateTimePartType,
@@ -34,7 +36,7 @@ import {
 import { addErrors, addLabel, type ControlTemplateData } from '../utils/templates';
 import './pills';
 import type { GuiPillEventDetail, GuiPillItem } from './pills';
-import { DISABLED_DATE_RANGE_MESSAGE } from '../utils/messages';
+import { DISABLED_DATE_RANGE_MESSAGE, INCOMPLETE_DATE_TIME_MESSAGE } from '../utils/messages';
 
 @customElement('gui-range-date-time')
 export class GuiRangeDateTimeInput extends LitElement {
@@ -91,9 +93,28 @@ export class GuiRangeDateTimeInput extends LitElement {
   @property({ type: String, attribute: 'disabled-range-message' }) disabledRangeMessage:
     | string
     | undefined = undefined;
+  @property({ type: String, attribute: 'incomplete-message' }) incompleteMessage:
+    | string
+    | undefined = undefined;
+  /**
+   * Set by host pickers that run their own whole-widget focus-leave check:
+   * moving focus from this input into the picker's popover must not count as
+   * leaving, so the embedded input skips its incomplete-on-leave handling.
+   */
+  @property({ type: Boolean, attribute: 'defer-focus-leave' }) deferFocusLeave:
+    | boolean
+    | undefined = false;
 
   private readonly inputBlockClass = 'gui-range-date-time-input';
   private readonly groups = ['start', 'end'] as const;
+
+  private readonly dateTimePartTypes: readonly DateTimePartType[] = [
+    'day',
+    'month',
+    'year',
+    'hour',
+    'minute',
+  ];
 
   /**
    * Set on the first commit attempt (Enter). While set, every part change
@@ -132,6 +153,21 @@ export class GuiRangeDateTimeInput extends LitElement {
       this.dispatchEvent(
         new CustomEvent('change', { detail: { value }, bubbles: true, composed: true }),
       ),
+  });
+
+  /**
+   * The single point where the input reports focus leaving the control: it
+   * blurs (which the form layer reads as "validate now"), so hopping between
+   * segments never validates a half-typed entry, then surfaces a half-entered
+   * range left behind.
+   */
+  private _focusLeave = new GUIFocusLeaveController(this, {
+    onLeave: () => {
+      // Embedded in a picker: that host owns focus reporting for the subtree.
+      if (this.deferFocusLeave) return;
+      this.dispatchEvent(new CustomEvent('blur'));
+      this.reportIncompleteOnLeave();
+    },
   });
 
   protected ariaController: GUIAriaController<unknown, any> = new GUIAriaController(this, {
@@ -222,7 +258,7 @@ export class GuiRangeDateTimeInput extends LitElement {
     return html`
       ${this.label ? addLabel(this.uid as string, templateData, false, undefined, false) : nothing}
 
-      <div class="gui-widget">
+      <div class="gui-widget" @focusout=${this._focusLeave.onFocusOut}>
         <div
           class="gui-widget-input gui-parts-ring gui-range-date-time-input ${this.icon
             ? 'gui-range-date-time-input--icon'
@@ -357,14 +393,70 @@ export class GuiRangeDateTimeInput extends LitElement {
 
   /**
    * Re-parses both endpoints so per-endpoint problems (impossible date-time,
-   * out of instant bounds) surface while the user types. Runs on every part
-   * change.
+   * out of instant bounds) surface while the user types, and notifies the host
+   * picker via `partsChange` so its calendar follows the typed endpoints. Each
+   * endpoint reports its date and time halves separately, so a day highlights
+   * as soon as it is complete even with the time still empty. Runs on every
+   * part change.
    */
   private syncParts() {
+    const start = this.validateDateTimeParts('start');
+    const end = this.validateDateTimeParts('end');
+
+    this.dispatchEvent(
+      new CustomEvent('partsChange', {
+        detail: { start: this.subGroupISO('start'), end: this.subGroupISO('end') },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+
+    return { start, end };
+  }
+
+  /** One endpoint's date and time halves, each null until it parses complete. */
+  private subGroupISO(group: string): { date: string | null; time: string | null } {
+    const { effectiveHourFormat, descriptors } = this.localeData;
+    const { date, time } = parseDateTimeSubGroups(this._parts.values[group] ?? {}, {
+      hourFormat: effectiveHourFormat,
+      descriptors,
+      invalidDateMessage: this.invalidDateMessage,
+    });
     return {
-      start: this.validateDateTimeParts('start'),
-      end: this.validateDateTimeParts('end'),
+      date: date.kind === 'valid' ? date.iso : null,
+      time: time.kind === 'valid' ? time.iso : null,
     };
+  }
+
+  /**
+   * A range left half-entered when focus leaves is abandoned work: some parts
+   * of one endpoint typed, or one endpoint filled and the other still empty
+   * (a span picked in the calendar with no times lands here too). Both
+   * surface the incomplete message — or the endpoint's own message when one
+   * is outright invalid, which is more useful than "incomplete".
+   * `_validationTriggered` makes the next edit re-evaluate, so the message
+   * clears as soon as the user comes back and continues (or empties the
+   * fields). Public so a host picker can call it from its own whole-widget
+   * focus-leave check.
+   */
+  reportIncompleteOnLeave(): void {
+    const endpoints = this.groups.map((group) => ({
+      result: this.validateDateTimeParts(group),
+      empty: this._parts.isGroupEmpty(group, this.dateTimePartTypes),
+    }));
+
+    // Nothing entered, or a complete range the commit path already owns.
+    if (endpoints.every((endpoint) => endpoint.empty)) return;
+    if (endpoints.every((endpoint) => endpoint.result.kind === 'valid')) return;
+
+    const invalidMessage = endpoints
+      .map((endpoint) => (endpoint.result.kind === 'invalid' ? endpoint.result.message : undefined))
+      .find(Boolean);
+
+    this._validationTriggered = true;
+    this._parts.surfaceInputError(
+      invalidMessage ?? this.incompleteMessage ?? INCOMPLETE_DATE_TIME_MESSAGE,
+    );
   }
 
   /**
@@ -438,6 +530,23 @@ export class GuiRangeDateTimeInput extends LitElement {
     );
 
     this._parts.focusFirst('start');
+    this.requestUpdate();
+  }
+
+  /**
+   * Paints only one endpoint's date parts from an ISO date (null clears
+   * them), leaving its time parts untouched. The range date-time picker calls
+   * this so a day picked in the calendar lands in the visible field straight
+   * away — the reverse of typed parts moving the calendar's selection.
+   */
+  fillDate(group: 'start' | 'end', iso: string | null): void {
+    this._parts.setGroupFromISO(group, iso, 'date');
+    this.requestUpdate();
+  }
+
+  /** The counterpart of {@link fillDate} for an endpoint's time parts. */
+  fillTime(group: 'start' | 'end', iso: string | null): void {
+    this._parts.setGroupFromISO(group, iso, 'time', this.localeData.effectiveHourFormat);
     this.requestUpdate();
   }
 }

--- a/libs/gui/components/src/lib/components/range-date-time-picker.ts
+++ b/libs/gui/components/src/lib/components/range-date-time-picker.ts
@@ -1,9 +1,11 @@
 import { html, LitElement, nothing } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import type { DateTimeRange } from '@golemui/gui-shared/internals';
 import './range-date-time-input';
 import './range-date-time-calendar';
+import type { GuiRangeDateTimeInput } from './range-date-time-input';
+import { GUIFocusLeaveController } from '../controllers/focus-leave.controller';
 import { GUIPopupController } from '../controllers/popup.controller';
 import { type HourFormat } from '../utils/time';
 import { addErrors, addIcon, addLabel } from '../utils/templates';
@@ -118,7 +120,19 @@ export class GuiRangeDateTimePicker extends LitElement {
   @property({ type: String, attribute: 'disabled-day-count-aria-label' })
   disabledDayCountAriaLabel: string | undefined = undefined;
 
+  @query('#date-input') private _dateRef?: GuiRangeDateTimeInput;
+
   @state() private _focusDate: string | undefined = undefined;
+  /**
+   * The calendar's in-progress selection. It lives here — the picker stays
+   * mounted — so a half-finished range survives closing and reopening the
+   * popover, which unmounts the calendar.
+   */
+  @state() private _workingAnchor: string | undefined = undefined;
+  @state() private _workingStartDate: string | undefined = undefined;
+  @state() private _workingEndDate: string | undefined = undefined;
+  @state() private _workingStartTime: string | undefined = undefined;
+  @state() private _workingEndTime: string | undefined = undefined;
 
   private _popup = new GUIPopupController(this, {
     focusRestoreSelector: 'gui-range-date-time input',
@@ -140,7 +154,21 @@ export class GuiRangeDateTimePicker extends LitElement {
       this.closePillsDropdown();
     },
     onOpenChanged: (open) => {
+      // The working selection deliberately survives a close: only the
+      // transient focus target is dropped.
       if (!open) this._focusDate = undefined;
+    },
+  });
+
+  /**
+   * The single point where the picker reports focus leaving the control: it
+   * blurs (which the form layer reads as "validate now") and lets the input
+   * surface a half-typed endpoint left behind.
+   */
+  private _focusLeave = new GUIFocusLeaveController(this, {
+    onLeave: () => {
+      this.dispatchEvent(new CustomEvent('blur'));
+      this._dateRef?.reportIncompleteOnLeave();
     },
   });
 
@@ -208,8 +236,14 @@ export class GuiRangeDateTimePicker extends LitElement {
           .noAvailableTimesMessage=${this.noAvailableTimesMessage}
           .dayCountAriaLabel=${this.dayCountAriaLabel}
           .disabledDayCountAriaLabel=${this.disabledDayCountAriaLabel}
+          .workingAnchor=${this._workingAnchor}
+          .workingStartDate=${this._workingStartDate}
+          .workingEndDate=${this._workingEndDate}
+          .workingStartTime=${this._workingStartTime}
+          .workingEndTime=${this._workingEndTime}
           @blur=${this.onCalendarBlur}
           @change=${this.onCalendarChange}
+          @partsChange=${this.onCalendarPartsChange}
           @inputError=${this.onCalendarInputError}
         ></gui-range-date-time-calendar>`
       : nothing;
@@ -231,8 +265,10 @@ export class GuiRangeDateTimePicker extends LitElement {
         class="gui-widget"
         @keydown=${this._popup.onAnchorKeyDown}
         @click=${this._popup.onAnchorClick}
+        @focusout=${this._focusLeave.onFocusOut}
       >
         <gui-range-date-time
+          .deferFocusLeave=${true}
           id="date-input"
           class=${classMap(datePickerIcon.widgetClasses)}
           .uid=${this.uid}
@@ -317,8 +353,38 @@ export class GuiRangeDateTimePicker extends LitElement {
     this.commitValue(event.detail.value);
   }
 
-  private onDateBlur() {
-    this.dispatchEvent(new CustomEvent('blur'));
+  /**
+   * The input's per-part blur stays inside the widget: moving from a segment
+   * into the popover is not leaving the control, so it must not be reported
+   * as a blur (which the form layer reads as "validate now"). The picker
+   * reports blur from its own focus-leave check instead.
+   */
+  private onDateBlur(event: Event) {
+    event.stopPropagation();
+  }
+
+  /** The calendar's in-progress selection, held here across the popover. */
+  /**
+   * The calendar's in-progress selection, held here so it survives the
+   * popover, and painted into the fields so every piece picked in the
+   * calendar reads back as a date-time — the reverse of typed parts moving
+   * the calendar. Until the span completes the anchor is the start day; once
+   * the range commits every piece arrives null and the fields empty.
+   */
+  private onCalendarPartsChange(event: CustomEvent) {
+    event.stopPropagation();
+    this._workingAnchor = (event.detail.anchor as string | null) ?? undefined;
+    this._workingStartDate = (event.detail.startDate as string | null) ?? undefined;
+    this._workingEndDate = (event.detail.endDate as string | null) ?? undefined;
+    this._workingStartTime = (event.detail.startTime as string | null) ?? undefined;
+    this._workingEndTime = (event.detail.endTime as string | null) ?? undefined;
+
+    const input = this._dateRef;
+    if (!input) return;
+    input.fillDate('start', this._workingStartDate ?? this._workingAnchor ?? null);
+    input.fillDate('end', this._workingEndDate ?? null);
+    input.fillTime('start', this._workingStartTime ?? null);
+    input.fillTime('end', this._workingEndTime ?? null);
   }
 
   private onCalendarChange(event: CustomEvent) {
@@ -360,7 +426,13 @@ export class GuiRangeDateTimePicker extends LitElement {
     );
   }
 
-  private onCalendarBlur() {
+  /**
+   * Focus leaving the calendar closes the popover, but it is not necessarily
+   * leaving the picker (focus often returns to the fields), so the calendar's
+   * bubbling blur is stopped here and never reaches the form layer.
+   */
+  private onCalendarBlur(event: Event) {
+    event.stopPropagation();
     this._popup.closeOnFocusLeave();
   }
 

--- a/libs/gui/components/src/lib/components/range-date-time-picker.ts
+++ b/libs/gui/components/src/lib/components/range-date-time-picker.ts
@@ -122,6 +122,9 @@ export class GuiRangeDateTimePicker extends LitElement {
   @property({ type: String, attribute: 'no-available-times-message' }) noAvailableTimesMessage:
     | string
     | undefined = undefined;
+  @property({ type: String, attribute: 'incomplete-message' }) incompleteMessage:
+    | string
+    | undefined = undefined;
   @property({ type: String, attribute: 'day-count-aria-label' }) dayCountAriaLabel:
     | string
     | undefined = undefined;
@@ -313,6 +316,7 @@ export class GuiRangeDateTimePicker extends LitElement {
           .maxDateTimeMessage=${this.maxDateTimeMessage}
           .disabledRanges=${this.disabledRanges}
           .disabledRangeMessage=${this.disabledRangeMessage}
+          .incompleteMessage=${this.incompleteMessage}
           @blur=${this.onDateBlur}
           @focus=${this._popup.show}
           @change=${this.onDateChange}

--- a/libs/gui/components/src/lib/components/range-date-time-picker.ts
+++ b/libs/gui/components/src/lib/components/range-date-time-picker.ts
@@ -10,6 +10,14 @@ import { GUIPopupController } from '../controllers/popup.controller';
 import { type HourFormat } from '../utils/time';
 import { addErrors, addIcon, addLabel } from '../utils/templates';
 
+/** The four pieces of an in-progress range, each absent until chosen. */
+interface WorkingRange {
+  start?: string;
+  end?: string;
+  startTime?: string;
+  endTime?: string;
+}
+
 @customElement('gui-range-date-time-picker')
 export class GuiRangeDateTimePicker extends LitElement {
   @property({ type: String }) uid: string | undefined = undefined;
@@ -124,13 +132,14 @@ export class GuiRangeDateTimePicker extends LitElement {
 
   @state() private _focusDate: string | undefined = undefined;
   /**
-   * The calendar's in-progress selection. It lives here — the picker stays
-   * mounted — so a half-finished range survives closing and reopening the
-   * popover, which unmounts the calendar.
+   * The in-progress range, from either half of the widget: days and times
+   * picked in the calendar, or endpoints typed into the input. It lives here —
+   * the picker stays mounted — so a half-finished range survives closing and
+   * reopening the popover, and it is what the calendar and the input each
+   * render.
    */
-  @state() private _workingAnchor: string | undefined = undefined;
-  @state() private _workingStartDate: string | undefined = undefined;
-  @state() private _workingEndDate: string | undefined = undefined;
+  @state() private _workingStart: string | undefined = undefined;
+  @state() private _workingEnd: string | undefined = undefined;
   @state() private _workingStartTime: string | undefined = undefined;
   @state() private _workingEndTime: string | undefined = undefined;
 
@@ -236,9 +245,8 @@ export class GuiRangeDateTimePicker extends LitElement {
           .noAvailableTimesMessage=${this.noAvailableTimesMessage}
           .dayCountAriaLabel=${this.dayCountAriaLabel}
           .disabledDayCountAriaLabel=${this.disabledDayCountAriaLabel}
-          .workingAnchor=${this._workingAnchor}
-          .workingStartDate=${this._workingStartDate}
-          .workingEndDate=${this._workingEndDate}
+          .workingStart=${this._workingStart}
+          .workingEnd=${this._workingEnd}
           .workingStartTime=${this._workingStartTime}
           .workingEndTime=${this._workingEndTime}
           @blur=${this.onCalendarBlur}
@@ -304,6 +312,7 @@ export class GuiRangeDateTimePicker extends LitElement {
           @blur=${this.onDateBlur}
           @focus=${this._popup.show}
           @change=${this.onDateChange}
+          @partsChange=${this.onInputPartsChange}
           @pillClick=${this.onPillClick}
         ></gui-range-date-time>
         <button
@@ -350,7 +359,7 @@ export class GuiRangeDateTimePicker extends LitElement {
 
   private onDateChange(event: CustomEvent) {
     event.stopPropagation();
-    this.commitValue(event.detail.value);
+    this.commitValue(event.detail.value, event.detail.commit !== false);
   }
 
   /**
@@ -363,28 +372,78 @@ export class GuiRangeDateTimePicker extends LitElement {
     event.stopPropagation();
   }
 
-  /** The calendar's in-progress selection, held here across the popover. */
+  /**
+   * Applies a new working range, repainting only the pieces that actually
+   * changed. Repainting every reported piece would wipe half-typed segments
+   * the other half of the widget never saw — a `11:3` in the start time is
+   * lost the moment the calendar reports it has no start time at all.
+   */
+  private setWorking(next: WorkingRange, paint = false): void {
+    const changed = {
+      start: next.start !== this._workingStart,
+      end: next.end !== this._workingEnd,
+      startTime: next.startTime !== this._workingStartTime,
+      endTime: next.endTime !== this._workingEndTime,
+    };
+    this._workingStart = next.start;
+    this._workingEnd = next.end;
+    this._workingStartTime = next.startTime;
+    this._workingEndTime = next.endTime;
+
+    const input = this._dateRef;
+    if (!paint || !input) return;
+    if (changed.start) input.fillDate('start', next.start ?? null);
+    if (changed.end) input.fillDate('end', next.end ?? null);
+    if (changed.startTime) input.fillTime('start', next.startTime ?? null);
+    if (changed.endTime) input.fillTime('end', next.endTime ?? null);
+  }
+
+  /** Typed endpoints feed the working range; the calendar follows them. */
+  private onInputPartsChange(
+    event: CustomEvent<{
+      start: { date: string | null; time: string | null };
+      end: { date: string | null; time: string | null };
+    }>,
+  ) {
+    event.stopPropagation();
+    const { start, end } = event.detail;
+    this.setWorking({
+      start: start.date ?? undefined,
+      end: end.date ?? undefined,
+      startTime: start.time ?? undefined,
+      endTime: end.time ?? undefined,
+    });
+  }
+
   /**
    * The calendar's in-progress selection, held here so it survives the
-   * popover, and painted into the fields so every piece picked in the
-   * calendar reads back as a date-time — the reverse of typed parts moving
-   * the calendar. Until the span completes the anchor is the start day; once
-   * the range commits every piece arrives null and the fields empty.
+   * popover, and painted into the fields so every piece picked in the calendar
+   * reads back as a date-time — the reverse of typed parts moving the
+   * calendar. Until the span completes its anchor stands in for the start day;
+   * once the range commits every piece arrives null and the fields empty.
    */
   private onCalendarPartsChange(event: CustomEvent) {
     event.stopPropagation();
-    this._workingAnchor = (event.detail.anchor as string | null) ?? undefined;
-    this._workingStartDate = (event.detail.startDate as string | null) ?? undefined;
-    this._workingEndDate = (event.detail.endDate as string | null) ?? undefined;
-    this._workingStartTime = (event.detail.startTime as string | null) ?? undefined;
-    this._workingEndTime = (event.detail.endTime as string | null) ?? undefined;
+    const anchor = (event.detail.anchor as string | null) ?? undefined;
+    const start = (event.detail.start as string | null) ?? undefined;
+    const end = (event.detail.end as string | null) ?? undefined;
+    const times = {
+      startTime: (event.detail.startTime as string | null) ?? undefined,
+      endTime: (event.detail.endTime as string | null) ?? undefined,
+    };
 
-    const input = this._dateRef;
-    if (!input) return;
-    input.fillDate('start', this._workingStartDate ?? this._workingAnchor ?? null);
-    input.fillDate('end', this._workingEndDate ?? null);
-    input.fillTime('start', this._workingStartTime ?? null);
-    input.fillTime('end', this._workingEndTime ?? null);
+    if (start || end) {
+      this.setWorking({ start, end, ...times }, true);
+      return;
+    }
+
+    const keepEnd = !!anchor && !this._workingStart && this._workingEnd === anchor;
+    this.setWorking(
+      keepEnd
+        ? { start: undefined, end: anchor, ...times }
+        : { start: anchor, end: undefined, ...times },
+      true,
+    );
   }
 
   private onCalendarChange(event: CustomEvent) {
@@ -415,8 +474,16 @@ export class GuiRangeDateTimePicker extends LitElement {
     );
   }
 
-  private commitValue(value: DateTimeRange[] | null | undefined) {
+  /**
+   * The single funnel every commit passes through — a calendar pick, a typed
+   * Enter — so the working selection is torn down once, and the calendar
+   * (which follows the cleared props, down to its two time pickers) with it.
+   * `committed` is false for the input's error-clearing echo, which carries no
+   * new pill and must leave a half-entered range alone.
+   */
+  private commitValue(value: DateTimeRange[] | null | undefined, committed = true) {
     this.value = value ?? undefined;
+    if (committed) this.setWorking({});
     this.dispatchEvent(
       new CustomEvent('change', {
         detail: { value: value ?? null },

--- a/libs/gui/components/src/lib/components/range-date-time-picker.ts
+++ b/libs/gui/components/src/lib/components/range-date-time-picker.ts
@@ -170,14 +170,17 @@ export class GuiRangeDateTimePicker extends LitElement {
   });
 
   /**
-   * The single point where the picker reports focus leaving the control: it
-   * blurs (which the form layer reads as "validate now") and lets the input
-   * surface a half-typed endpoint left behind.
+   * The single point where the picker reports focus leaving the control: the
+   * input settles what is in its fields — committing a complete range,
+   * surfacing a half-typed one — and only then does the picker blur, which the
+   * form layer reads as "validate now". Blurring first would validate the
+   * value the commit is about to replace.
    */
   private _focusLeave = new GUIFocusLeaveController(this, {
+    resolveSyncOnRelatedTarget: true,
     onLeave: () => {
+      this._dateRef?.finalizeOnLeave();
       this.dispatchEvent(new CustomEvent('blur'));
-      this._dateRef?.reportIncompleteOnLeave();
     },
   });
 
@@ -249,6 +252,7 @@ export class GuiRangeDateTimePicker extends LitElement {
           .workingEnd=${this._workingEnd}
           .workingStartTime=${this._workingStartTime}
           .workingEndTime=${this._workingEndTime}
+          .deferFocusLeave=${true}
           @blur=${this.onCalendarBlur}
           @change=${this.onCalendarChange}
           @partsChange=${this.onCalendarPartsChange}

--- a/libs/gui/components/src/lib/components/range-time-input.ts
+++ b/libs/gui/components/src/lib/components/range-time-input.ts
@@ -4,6 +4,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit-html/directives/style-map.js';
 import { GUIAriaController } from '../controllers/aria.controller';
+import { GUIFocusLeaveController } from '../controllers/focus-leave.controller';
 import { GUIPartsController } from '../controllers/parts.controller';
 import { renderGroupParts, type GUIPartsTemplateData } from '../utils/part-templates';
 import {
@@ -34,6 +35,7 @@ import { addErrors, addLabel, type ControlTemplateData } from '../utils/template
 import './pills';
 import type { GuiPillEventDetail, GuiPillItem } from './pills';
 import {
+  INCOMPLETE_TIME_MESSAGE,
   INVALID_DISABLED_TIME_RANGE_MESSAGE,
   INVALID_TIME_RANGE_ORDER_MESSAGE,
 } from '../utils/messages';
@@ -82,9 +84,22 @@ export class GuiRangeTimeInput extends LitElement {
   @property({ type: String, attribute: 'disabled-range-message' }) disabledRangeMessage:
     | string
     | undefined = undefined;
+  @property({ type: String, attribute: 'incomplete-message' }) incompleteMessage:
+    | string
+    | undefined = undefined;
+  /**
+   * Set by host pickers that run their own whole-widget focus-leave check:
+   * moving focus from this input into the picker's popup must not count as
+   * leaving, so the embedded input skips its incomplete-on-leave handling.
+   */
+  @property({ type: Boolean, attribute: 'defer-focus-leave' }) deferFocusLeave:
+    | boolean
+    | undefined = false;
 
   private readonly inputBlockClass = 'gui-range-time-input';
   private readonly groups = ['start', 'end'] as const;
+
+  private readonly timePartTypes: readonly DateTimePartType[] = ['hour', 'minute'];
 
   /**
    * Set on the first commit attempt (Enter). While set, every part change
@@ -123,6 +138,21 @@ export class GuiRangeTimeInput extends LitElement {
     },
     getHourFormat: () => this.timeLocaleData.effectiveHourFormat,
     getDayPeriodLabels: () => this.timeLocaleData.dayPeriodLabels,
+  });
+
+  /**
+   * The single point where the input reports focus leaving the control: it
+   * blurs (which the form layer reads as "validate now"), so hopping between
+   * segments never validates a half-typed entry, then surfaces a half-entered
+   * range left behind.
+   */
+  private _focusLeave = new GUIFocusLeaveController(this, {
+    onLeave: () => {
+      // Embedded in a picker: that host owns focus reporting for the subtree.
+      if (this.deferFocusLeave) return;
+      this.dispatchEvent(new CustomEvent('blur'));
+      this.reportIncompleteOnLeave();
+    },
   });
 
   protected ariaController: GUIAriaController<unknown, any> = new GUIAriaController(this, {
@@ -210,7 +240,7 @@ export class GuiRangeTimeInput extends LitElement {
     return html`
       ${this.label ? addLabel(this.uid as string, templateData, false, undefined, false) : nothing}
 
-      <div class="gui-widget">
+      <div class="gui-widget" @focusout=${this._focusLeave.onFocusOut}>
         <div
           class="gui-widget-input gui-parts-ring gui-range-time-input ${this.icon
             ? 'gui-range-time-input--icon'
@@ -373,6 +403,37 @@ export class GuiRangeTimeInput extends LitElement {
     );
 
     return { start, end };
+  }
+
+  /**
+   * A range left half-entered when focus leaves is abandoned work: some parts
+   * of one endpoint typed, or one endpoint filled and the other still empty
+   * (a start picked from the list with no end lands here too). Both surface
+   * the incomplete message — or the endpoint's own message when one is
+   * outright invalid, which is more useful than "incomplete".
+   * `_validationTriggered` makes the next edit re-evaluate, so the message
+   * clears as soon as the user comes back and continues (or empties the
+   * fields). Public so a host picker can call it from its own whole-widget
+   * focus-leave check.
+   */
+  reportIncompleteOnLeave(): void {
+    const endpoints = this.groups.map((group) => ({
+      result: this.validateTimeParts(group),
+      empty: this._parts.isGroupEmpty(group, this.timePartTypes),
+    }));
+
+    // Nothing entered, or a complete range the commit path already owns.
+    if (endpoints.every((endpoint) => endpoint.empty)) return;
+    if (endpoints.every((endpoint) => endpoint.result.kind === 'valid')) return;
+
+    const invalidMessage = endpoints
+      .map((endpoint) => (endpoint.result.kind === 'invalid' ? endpoint.result.message : undefined))
+      .find(Boolean);
+
+    this._validationTriggered = true;
+    this._parts.surfaceInputError(
+      invalidMessage ?? this.incompleteMessage ?? INCOMPLETE_TIME_MESSAGE,
+    );
   }
 
   /**

--- a/libs/gui/components/src/lib/components/range-time-input.ts
+++ b/libs/gui/components/src/lib/components/range-time-input.ts
@@ -434,8 +434,10 @@ export class GuiRangeTimeInput extends LitElement {
       empty: this._parts.isGroupEmpty(group, this.timePartTypes),
     }));
 
-    // Nothing entered: nothing to settle.
-    if (endpoints.every((endpoint) => endpoint.empty)) return;
+    if (endpoints.every((endpoint) => endpoint.empty)) {
+      this._parts.clearSurfacedInputError(this.value ?? []);
+      return;
+    }
 
     if (endpoints.every((endpoint) => endpoint.result.kind === 'valid')) {
       this.tryCreatePill({ refocus: false });

--- a/libs/gui/components/src/lib/components/range-time-input.ts
+++ b/libs/gui/components/src/lib/components/range-time-input.ts
@@ -145,17 +145,20 @@ export class GuiRangeTimeInput extends LitElement {
   });
 
   /**
-   * The single point where the input reports focus leaving the control: it
-   * blurs (which the form layer reads as "validate now"), so hopping between
-   * segments never validates a half-typed entry, then surfaces a half-entered
-   * range left behind.
+   * The single point where the input reports focus leaving the control. It
+   * settles what is in the fields FIRST, then blurs — the form layer reads a
+   * blur as "validate now", and storing a value runs no validator, so blurring
+   * first would validate the value the commit is about to replace and leave a
+   * `required` error standing over a range the user did finish. Hopping
+   * between segments is not a departure and never reaches here.
    */
   private _focusLeave = new GUIFocusLeaveController(this, {
+    resolveSyncOnRelatedTarget: true,
     onLeave: () => {
       // Embedded in a picker: that host owns focus reporting for the subtree.
       if (this.deferFocusLeave) return;
+      this.finalizeOnLeave();
       this.dispatchEvent(new CustomEvent('blur'));
-      this.reportIncompleteOnLeave();
     },
   });
 
@@ -410,25 +413,34 @@ export class GuiRangeTimeInput extends LitElement {
   }
 
   /**
-   * A range left half-entered when focus leaves is abandoned work: some parts
-   * of one endpoint typed, or one endpoint filled and the other still empty
-   * (a start picked from the list with no end lands here too). Both surface
-   * the incomplete message — or the endpoint's own message when one is
-   * outright invalid, which is more useful than "incomplete".
-   * `_validationTriggered` makes the next edit re-evaluate, so the message
-   * clears as soon as the user comes back and continues (or empties the
-   * fields). Public so a host picker can call it from its own whole-widget
-   * focus-leave check.
+   * What leaving does with whatever is in the fields. Public so a host picker
+   * can call it from its own whole-widget focus-leave check.
+   *
+   * A complete range is finished work, so leaving commits it exactly as Enter
+   * does — a user who typed a whole range and moved on gets the pill they
+   * plainly meant, and the same validation decides whether it is allowed.
+   *
+   * A half-entered one is abandoned work: some parts of one endpoint typed, or
+   * one endpoint filled and the other still empty (a start picked from the
+   * list with no end lands here too). Both surface the incomplete message — or
+   * the endpoint's own message when one is outright invalid, which is more
+   * useful than "incomplete". `_validationTriggered` makes the next edit
+   * re-evaluate, so the message clears as soon as the user comes back and
+   * continues (or empties the fields).
    */
-  reportIncompleteOnLeave(): void {
+  finalizeOnLeave(): void {
     const endpoints = this.groups.map((group) => ({
       result: this.validateTimeParts(group),
       empty: this._parts.isGroupEmpty(group, this.timePartTypes),
     }));
 
-    // Nothing entered, or a complete range the commit path already owns.
+    // Nothing entered: nothing to settle.
     if (endpoints.every((endpoint) => endpoint.empty)) return;
-    if (endpoints.every((endpoint) => endpoint.result.kind === 'valid')) return;
+
+    if (endpoints.every((endpoint) => endpoint.result.kind === 'valid')) {
+      this.tryCreatePill({ refocus: false });
+      return;
+    }
 
     const invalidMessage = endpoints
       .map((endpoint) => (endpoint.result.kind === 'invalid' ? endpoint.result.message : undefined))
@@ -483,7 +495,7 @@ export class GuiRangeTimeInput extends LitElement {
     }
   }
 
-  private tryCreatePill(): boolean {
+  private tryCreatePill({ refocus = true }: { refocus?: boolean } = {}): boolean {
     this._validationTriggered = true;
 
     const outcome = this.evaluateRange();
@@ -496,11 +508,13 @@ export class GuiRangeTimeInput extends LitElement {
     this._parts.clearGroup('end');
     this._parts.seedDayPeriods();
 
+    // The commit's own change clears any injected error downstream.
+    this._parts.resetSurfacedInputError();
     this.dispatchEvent(
       new CustomEvent('change', { detail: { value: this.value }, bubbles: true, composed: true }),
     );
 
-    this._parts.focusFirst('start');
+    if (refocus) this._parts.focusFirst('start');
     this.requestUpdate();
     return true;
   }

--- a/libs/gui/components/src/lib/components/range-time-input.ts
+++ b/libs/gui/components/src/lib/components/range-time-input.ts
@@ -123,7 +123,11 @@ export class GuiRangeTimeInput extends LitElement {
       this.dispatchEvent(new CustomEvent('inputError', { detail: { message }, bubbles: true })),
     onSurfacedErrorCleared: (value) =>
       this.dispatchEvent(
-        new CustomEvent('change', { detail: { value }, bubbles: true, composed: true }),
+        new CustomEvent('change', {
+          detail: { value, commit: false },
+          bubbles: true,
+          composed: true,
+        }),
       ),
     isReadonly: () => !!this.readOnly || this.allowCustomTime === false,
     isDisabled: () => !!this.disabled,

--- a/libs/gui/components/src/lib/components/range-time-picker.ts
+++ b/libs/gui/components/src/lib/components/range-time-picker.ts
@@ -5,6 +5,7 @@ import type { TimeRange } from '@golemui/gui-shared/internals';
 import './range-time-input';
 import type { GuiRangeTimeInput } from './range-time-input';
 import './time-list';
+import { GUIFocusLeaveController } from '../controllers/focus-leave.controller';
 import { GUIPopupController } from '../controllers/popup.controller';
 import {
   compareISOTimes,
@@ -100,11 +101,19 @@ export class GuiRangeTimePicker extends LitElement {
       if (dropdownWasOpen) popup.suppressNextFocusOut();
       this.closePillsDropdown();
     },
-    onOpenChanged: (open) => {
-      if (!open) {
-        this._workingIn = undefined;
-        this._workingOut = undefined;
-      }
+    // Closing the panel keeps the working endpoints: a half-picked range is
+    // restored when the user reopens it.
+  });
+
+  /**
+   * The single point where the picker reports focus leaving the control: it
+   * blurs (which the form layer reads as "validate now") and lets the input
+   * surface a half-typed endpoint left behind.
+   */
+  private _focusLeave = new GUIFocusLeaveController(this, {
+    onLeave: () => {
+      this.dispatchEvent(new CustomEvent('blur'));
+      this._inputRef?.reportIncompleteOnLeave();
     },
   });
 
@@ -191,7 +200,6 @@ export class GuiRangeTimePicker extends LitElement {
               .height=${this.height}
               .itemHeight=${this.itemHeight}
               .noAvailableTimesMessage=${this.noAvailableTimesMessage}
-              ?disabled=${!this._workingIn}
               ?readonly=${this.readOnly}
               @change=${this.onOutListChange}
             ></gui-time-list>
@@ -216,6 +224,7 @@ export class GuiRangeTimePicker extends LitElement {
         class="gui-widget"
         @keydown=${this._popup.onAnchorKeyDown}
         @click=${this._popup.onAnchorClick}
+        @focusout=${this._focusLeave.onFocusOut}
       >
         <gui-range-time
           id="time-input"
@@ -223,6 +232,7 @@ export class GuiRangeTimePicker extends LitElement {
           .uid=${this.uid}
           .hint=${this.hint}
           .showErrors=${false}
+          .deferFocusLeave=${true}
           .errors=${this.errors}
           ?touched=${this.touched}
           ?required=${this.required}
@@ -317,36 +327,52 @@ export class GuiRangeTimePicker extends LitElement {
     this._workingOut = event.detail.end ?? undefined;
   }
 
-  private onInputBlur() {
-    this.dispatchEvent(new CustomEvent('blur'));
+  /**
+   * The input's per-part blur stays inside the widget: moving from a segment
+   * into the panel is not leaving the control, so it must not be reported as
+   * a blur (which the form layer reads as "validate now"). The picker reports
+   * blur from its own focus-leave check instead.
+   */
+  private onInputBlur(event: Event) {
+    event.stopPropagation();
   }
 
   private onInListChange(event: CustomEvent) {
     event.stopPropagation();
     const start = event.detail.value as string | undefined;
     this._workingIn = start ?? undefined;
-    this._workingOut = undefined;
     if (start) this._inputRef?.fillGroup('start', start);
+    this.tryCommitWorkingRange();
   }
 
   private onOutListChange(event: CustomEvent) {
     event.stopPropagation();
     const end = event.detail.value as string | undefined;
-    if (!this._workingIn || !end || !this._inputRef) return;
+    this._workingOut = end ?? undefined;
+    if (end) this._inputRef?.fillGroup('end', end);
+    this.tryCommitWorkingRange();
+  }
 
-    this._inputRef.fillGroup('end', end);
-    const committed = this._inputRef.commitFromParts();
+  /**
+   * Commits once both endpoints are present, whichever order they were picked
+   * in — an end chosen before a start simply waits in the fields. A rejected
+   * range (reversed, out of bounds, spanning a disabled block) keeps both
+   * values on show and closes the panel so its error is visible.
+   */
+  private tryCommitWorkingRange(): void {
+    if (!this._workingIn || !this._workingOut || !this._inputRef) return;
 
-    if (committed) {
+    if (this._inputRef.commitFromParts()) {
       this._workingIn = undefined;
       this._workingOut = undefined;
       this.updateComplete.then(() => {
         this._inListRef()?.scrollToSelectedValue?.();
       });
-    } else {
-      this._popup.close();
-      this.dispatchEvent(new CustomEvent('blur'));
+      return;
     }
+
+    this._popup.close();
+    this.dispatchEvent(new CustomEvent('blur'));
   }
 
   private _inListRef() {

--- a/libs/gui/components/src/lib/components/range-time-picker.ts
+++ b/libs/gui/components/src/lib/components/range-time-picker.ts
@@ -308,12 +308,7 @@ export class GuiRangeTimePicker extends LitElement {
 
   private onInputChange(event: CustomEvent) {
     event.stopPropagation();
-    // A successful commit turns the entry into a pill and empties the fields, so
-    // the two lists must drop their working selection: the start list deselects
-    // and the end list disables again, ready for the next range.
-    this._workingIn = undefined;
-    this._workingOut = undefined;
-    this.commitValue(event.detail.value);
+    this.commitValue(event.detail.value, event.detail.commit !== false);
   }
 
   /**
@@ -363,8 +358,6 @@ export class GuiRangeTimePicker extends LitElement {
     if (!this._workingIn || !this._workingOut || !this._inputRef) return;
 
     if (this._inputRef.commitFromParts()) {
-      this._workingIn = undefined;
-      this._workingOut = undefined;
       this.updateComplete.then(() => {
         this._inListRef()?.scrollToSelectedValue?.();
       });
@@ -381,8 +374,19 @@ export class GuiRangeTimePicker extends LitElement {
     );
   }
 
-  private commitValue(value: TimeRange[] | null | undefined) {
+  /**
+   * The single funnel every commit passes through — a list pick, a typed Enter
+   * — so the working selection is torn down once: the start list deselects and
+   * the end list unfloors, ready for the next range. `committed` is false for
+   * the input's error-clearing echo, which carries no new pill and must leave
+   * a half-entered range alone.
+   */
+  private commitValue(value: TimeRange[] | null | undefined, committed = true) {
     this.value = value ?? undefined;
+    if (committed) {
+      this._workingIn = undefined;
+      this._workingOut = undefined;
+    }
     const error = this.validateBounds(this.value);
     this.dispatchEvent(
       new CustomEvent('change', {

--- a/libs/gui/components/src/lib/components/range-time-picker.ts
+++ b/libs/gui/components/src/lib/components/range-time-picker.ts
@@ -78,6 +78,9 @@ export class GuiRangeTimePicker extends LitElement {
   @property({ type: String, attribute: 'no-available-times-message' }) noAvailableTimesMessage:
     | string
     | undefined = undefined;
+  @property({ type: String, attribute: 'incomplete-message' }) incompleteMessage:
+    | string
+    | undefined = undefined;
 
   @query('#time-input') private _inputRef?: GuiRangeTimeInput;
 
@@ -255,6 +258,7 @@ export class GuiRangeTimePicker extends LitElement {
           .maxTimeMessage=${this.maxTimeMessage}
           .rangeOrderMessage=${this.rangeOrderMessage}
           .disabledRangeMessage=${this.disabledRangeMessage}
+          .incompleteMessage=${this.incompleteMessage}
           .removePillAriaLabel=${this.removePillAriaLabel}
           .startTimeAriaLabel=${this.startTimeAriaLabel}
           .endTimeAriaLabel=${this.endTimeAriaLabel}

--- a/libs/gui/components/src/lib/components/range-time-picker.ts
+++ b/libs/gui/components/src/lib/components/range-time-picker.ts
@@ -106,14 +106,17 @@ export class GuiRangeTimePicker extends LitElement {
   });
 
   /**
-   * The single point where the picker reports focus leaving the control: it
-   * blurs (which the form layer reads as "validate now") and lets the input
-   * surface a half-typed endpoint left behind.
+   * The single point where the picker reports focus leaving the control: the
+   * input settles what is in its fields — committing a complete range,
+   * surfacing a half-typed one — and only then does the picker blur, which the
+   * form layer reads as "validate now". Blurring first would validate the
+   * value the commit is about to replace.
    */
   private _focusLeave = new GUIFocusLeaveController(this, {
+    resolveSyncOnRelatedTarget: true,
     onLeave: () => {
+      this._inputRef?.finalizeOnLeave();
       this.dispatchEvent(new CustomEvent('blur'));
-      this._inputRef?.reportIncompleteOnLeave();
     },
   });
 

--- a/libs/gui/components/src/lib/components/time-input.ts
+++ b/libs/gui/components/src/lib/components/time-input.ts
@@ -282,12 +282,17 @@ export class GuiTime extends LitElement {
   };
 
   /**
-   * A partial group left behind flips the value to null — so validators
-   * report it even on non-required fields — and surfaces the incomplete
-   * message. An emptied group instead clears any surfaced error. A complete
-   * group already reported through the commit pipeline.
+   * The single point where the input reports focus leaving the control: it
+   * blurs (which the form layer reads as "validate now"), so hopping between
+   * segments never validates a half-typed entry. A partial group left behind
+   * then flips the value to null — so validators report it even on
+   * non-required fields — and surfaces the incomplete message. An emptied
+   * group instead clears any surfaced error. A complete group already
+   * reported through the commit pipeline.
    */
   private onFocusLeave(): void {
+    this.dispatchEvent(new CustomEvent('blur'));
+
     const completeness = this.groupCompleteness();
     if (completeness === 'complete') return;
 

--- a/libs/gui/components/src/lib/components/time-input.ts
+++ b/libs/gui/components/src/lib/components/time-input.ts
@@ -3,7 +3,9 @@ import { html, LitElement, nothing, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { GUIAriaController } from '../controllers/aria.controller';
+import { GUIFocusLeaveController } from '../controllers/focus-leave.controller';
 import { GUIPartsController } from '../controllers/parts.controller';
+import { INCOMPLETE_TIME_MESSAGE } from '../utils/messages';
 import { renderGroupParts, type GUIPartsTemplateData } from '../utils/part-templates';
 import {
   getTimeLocaleData,
@@ -12,8 +14,11 @@ import {
   timeBoundsError,
   type DateTimePartDescriptor,
   type DateTimePartType,
+  type GroupCompleteness,
   type TimeLocaleData,
 } from '../utils/parts';
+
+const TIME_PART_TYPES: readonly DateTimePartType[] = ['hour', 'minute'];
 import { addErrors, addLabel, type ControlTemplateData } from '../utils/templates';
 import { getTimeFormatParts, type HourFormat } from '../utils/time';
 
@@ -45,6 +50,17 @@ export class GuiTime extends LitElement {
     undefined;
   @property({ type: String, attribute: 'max-time-message' }) maxTimeMessage: string | undefined =
     undefined;
+  @property({ type: String, attribute: 'incomplete-message' }) incompleteMessage:
+    | string
+    | undefined = undefined;
+  /**
+   * Set by host pickers that run their own whole-widget focus-leave check:
+   * moving focus from this input into the picker's popup must not count as
+   * leaving, so the embedded input skips its incomplete-on-leave handling.
+   */
+  @property({ type: Boolean, attribute: 'defer-focus-leave' }) deferFocusLeave:
+    | boolean
+    | undefined = false;
 
   private readonly inputBlockClass = 'gui-time-input';
   private readonly groups = ['default'] as const;
@@ -56,11 +72,36 @@ export class GuiTime extends LitElement {
     commitGroup: (group) => this.validateAndEmit(group),
     isReadonly: () => !!this.readOnly,
     isDisabled: () => !!this.disabled,
-    onEmptyPartBlur: () =>
-      this.dispatchEvent(new CustomEvent('change', { detail: { value: null }, bubbles: true })),
+    onEmptyPartBlur: (group, type) => {
+      // A raw 0 counts as emptying the part, so clear it in state (the clamp
+      // write-back would otherwise leave a phantom value behind).
+      this._parts.setPart(group, type, '');
+
+      if (!this.value) return;
+
+      this._internalNullReport = true;
+      this.value = undefined;
+      this.dispatchEvent(new CustomEvent('change', { detail: { value: null }, bubbles: true }));
+      this._parts.resetSurfacedInputError();
+    },
+    onInputErrorSurfaced: (message) =>
+      this.dispatchEvent(new CustomEvent('inputError', { detail: { message }, bubbles: true })),
+    onSurfacedErrorCleared: (value) =>
+      this.dispatchEvent(new CustomEvent('change', { detail: { value }, bubbles: true })),
     getHourFormat: () => this.timeLocaleData.effectiveHourFormat,
     getDayPeriodLabels: () => this.timeLocaleData.dayPeriodLabels,
   });
+
+  private _focusLeave = new GUIFocusLeaveController(this, {
+    onLeave: () => this.onFocusLeave(),
+  });
+
+  /**
+   * Marks a value clear that the widget itself reported (an emptied part or
+   * an abandoned partial). The surviving segments must not be wiped when the
+   * clear — or its null echo from the form — lands back on the value prop.
+   */
+  private _internalNullReport = false;
 
   protected ariaController: GUIAriaController<unknown, any> = new GUIAriaController(this, {
     getTargets: () => this.querySelectorAll(`.${this.inputBlockClass}`),
@@ -95,19 +136,22 @@ export class GuiTime extends LitElement {
   }
 
   override willUpdate(changedProperties: PropertyValues): void {
-    if (
-      !this.hasUpdated ||
-      changedProperties.has('value') ||
-      changedProperties.has('hourFormat') ||
-      changedProperties.has('localeId')
-    ) {
-      this._parts.setGroupFromISO(
-        'default',
-        this.value ?? '',
-        'time',
-        this.timeLocaleData.effectiveHourFormat,
-      );
-    }
+    const localeChanged =
+      !this.hasUpdated || changedProperties.has('hourFormat') || changedProperties.has('localeId');
+    if (!localeChanged && !changedProperties.has('value')) return;
+
+    const internalNull = this._internalNullReport;
+    this._internalNullReport = false;
+    const prev = changedProperties.get('value') as string | null | undefined;
+
+    if (!localeChanged && !this.value && (internalNull || !prev)) return;
+
+    this._parts.setGroupFromISO(
+      'default',
+      this.value ?? '',
+      'time',
+      this.timeLocaleData.effectiveHourFormat,
+    );
   }
 
   override render() {
@@ -150,7 +194,7 @@ export class GuiTime extends LitElement {
     return html`
       ${this.label ? addLabel(this.uid as string, templateData, false, undefined, false) : nothing}
 
-      <div class="gui-widget">
+      <div class="gui-widget" @focusout=${this.onWidgetFocusOut}>
         <div
           id=${this.uid}
           class="gui-widget-input gui-parts gui-parts-ring gui-time-input ${this.icon
@@ -186,6 +230,14 @@ export class GuiTime extends LitElement {
     });
     this._parts.applyWriteBacks(group, writeBacks);
 
+    this.dispatchEvent(
+      new CustomEvent('partsChange', {
+        detail: { time: result.kind === 'valid' ? result.iso : null },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+
     if (result.kind !== 'valid') {
       this.requestUpdate();
       return;
@@ -202,16 +254,54 @@ export class GuiTime extends LitElement {
       this.dispatchEvent(
         new CustomEvent('change', { detail: { value: result.iso }, bubbles: true }),
       );
-      this.dispatchEvent(
-        new CustomEvent('inputError', { detail: { message: boundsError }, bubbles: true }),
-      );
+      this._parts.surfaceInputError(boundsError);
       this.requestUpdate();
       return;
     }
 
     this.value = result.iso;
+    this._parts.resetSurfacedInputError();
     this.dispatchEvent(new CustomEvent('change', { detail: { value: this.value }, bubbles: true }));
     this.requestUpdate();
+  }
+
+  /** The group's fill state, for host pickers' own focus-leave checks. */
+  groupCompleteness(): GroupCompleteness {
+    const { effectiveHourFormat, descriptors } = this.timeLocaleData;
+    const { result } = parseTimeGroup(this._parts.values['default'] ?? {}, {
+      hourFormat: effectiveHourFormat,
+      descriptors,
+    });
+    if (result.kind !== 'incomplete') return 'complete';
+    return this._parts.isGroupEmpty('default', TIME_PART_TYPES) ? 'empty' : 'partial';
+  }
+
+  private onWidgetFocusOut = (event: FocusEvent): void => {
+    if (this.deferFocusLeave) return;
+    this._focusLeave.handleFocusOut(event);
+  };
+
+  /**
+   * A partial group left behind flips the value to null — so validators
+   * report it even on non-required fields — and surfaces the incomplete
+   * message. An emptied group instead clears any surfaced error. A complete
+   * group already reported through the commit pipeline.
+   */
+  private onFocusLeave(): void {
+    const completeness = this.groupCompleteness();
+    if (completeness === 'complete') return;
+
+    if (completeness === 'empty') {
+      this._parts.clearSurfacedInputError(null);
+      return;
+    }
+
+    if (this.value) {
+      this._internalNullReport = true;
+      this.value = undefined;
+    }
+    this.dispatchEvent(new CustomEvent('change', { detail: { value: null }, bubbles: true }));
+    this._parts.surfaceInputError(this.incompleteMessage ?? INCOMPLETE_TIME_MESSAGE);
   }
 }
 

--- a/libs/gui/components/src/lib/components/time-input.ts
+++ b/libs/gui/components/src/lib/components/time-input.ts
@@ -284,15 +284,14 @@ export class GuiTime extends LitElement {
   /**
    * The single point where the input reports focus leaving the control: it
    * blurs (which the form layer reads as "validate now"), so hopping between
-   * segments never validates a half-typed entry. A partial group left behind
-   * then flips the value to null — so validators report it even on
-   * non-required fields — and surfaces the incomplete message. An emptied
-   * group instead clears any surfaced error. A complete group already
-   * reported through the commit pipeline.
+   * segments never validates a half-typed entry.
    */
   private onFocusLeave(): void {
     this.dispatchEvent(new CustomEvent('blur'));
+    this.settleOnFocusLeave();
+  }
 
+  settleOnFocusLeave(): void {
     const completeness = this.groupCompleteness();
     if (completeness === 'complete') return;
 

--- a/libs/gui/components/src/lib/components/time-picker.ts
+++ b/libs/gui/components/src/lib/components/time-picker.ts
@@ -3,12 +3,14 @@ import { customElement, property, query } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import './time-input';
 import './time-list';
+import type { GuiTime } from './time-input';
 import type { GuiTimeList } from './time-list';
+import { GUIFocusLeaveController } from '../controllers/focus-leave.controller';
 import { GUIPopupController } from '../controllers/popup.controller';
 import { buildTimeOptions, isTimeDisabled, type HourFormat, type TimeRange } from '../utils/time';
 import { timeBoundsError } from '../utils/parts';
 import { addErrors, addIcon, addLabel } from '../utils/templates';
-import { INVALID_DISABLED_TIME_RANGE_MESSAGE } from '../utils/messages';
+import { INCOMPLETE_TIME_MESSAGE, INVALID_DISABLED_TIME_RANGE_MESSAGE } from '../utils/messages';
 
 @customElement('gui-time-picker')
 export class GuiTimePicker extends LitElement {
@@ -52,8 +54,28 @@ export class GuiTimePicker extends LitElement {
   @property({ type: String, attribute: 'no-available-times-message' }) noAvailableTimesMessage:
     | string
     | undefined = undefined;
+  @property({ type: String, attribute: 'incomplete-message' }) incompleteMessage:
+    | string
+    | undefined = undefined;
+  /**
+   * Set by hosts (the date-time calendars) that run their own focus-leave
+   * check over a subtree containing this picker: skips the picker's own
+   * incomplete-on-leave handling.
+   */
+  @property({ type: Boolean, attribute: 'defer-focus-leave' }) deferFocusLeave:
+    | boolean
+    | undefined = false;
 
   @query('gui-time-list') private _listRef?: GuiTimeList;
+
+  private _focusLeave = new GUIFocusLeaveController(this, {
+    onLeave: () => {
+      // Embedded in a calendar: that host owns focus reporting for the subtree.
+      if (this.deferFocusLeave) return;
+      this.dispatchEvent(new CustomEvent('blur'));
+      this.reportIncompleteOnLeave();
+    },
+  });
 
   private _popup = new GUIPopupController(this, {
     focusRestoreSelector: 'gui-time input, gui-time button',
@@ -98,13 +120,19 @@ export class GuiTimePicker extends LitElement {
         false,
       )}
 
-      <div class="gui-widget" @keydown=${this.onKeyDown} @click=${this._popup.onAnchorClick}>
+      <div
+        class="gui-widget"
+        @keydown=${this.onKeyDown}
+        @click=${this._popup.onAnchorClick}
+        @focusout=${this._focusLeave.onFocusOut}
+      >
         <gui-time
           id="time-input"
           class=${classMap(timePickerIcon.widgetClasses)}
           .uid=${this.uid}
           .hint=${this.hint}
           .showErrors=${false}
+          .deferFocusLeave=${true}
           .errors=${this.errors}
           ?touched=${this.touched}
           ?required=${this.required}
@@ -193,8 +221,14 @@ export class GuiTimePicker extends LitElement {
     this.commitValue(event.detail.value);
   }
 
-  private onTimeBlur() {
-    this.dispatchEvent(new CustomEvent('blur'));
+  /**
+   * The field's per-part blur stays inside the widget: moving from a segment
+   * into the time list is not leaving the control, so it must not be reported
+   * as a blur (which the form layer reads as "validate now"). The picker
+   * reports blur from its own focus-leave check instead.
+   */
+  private onTimeBlur(event: Event) {
+    event.stopPropagation();
   }
 
   private onListChange(event: CustomEvent) {
@@ -300,6 +334,25 @@ export class GuiTimePicker extends LitElement {
    * embedded time-picker's list imperatively. */
   closeList() {
     this._popup.close();
+  }
+
+  /**
+   * A partially typed time left behind flips the value to null — so
+   * validators report it — and surfaces the incomplete message. Complete or
+   * empty input reports nothing new.
+   */
+  private reportIncompleteOnLeave(): void {
+    const input = this.querySelector<GuiTime>('gui-time');
+    if (!input || input.groupCompleteness() !== 'partial') return;
+
+    this.commitValue(null);
+    this.dispatchEvent(
+      new CustomEvent('inputError', {
+        detail: { message: this.incompleteMessage ?? INCOMPLETE_TIME_MESSAGE },
+        bubbles: true,
+        composed: true,
+      }),
+    );
   }
 
   private dispatchListToggle(open: boolean) {

--- a/libs/gui/components/src/lib/components/time-picker.ts
+++ b/libs/gui/components/src/lib/components/time-picker.ts
@@ -10,7 +10,7 @@ import { GUIPopupController } from '../controllers/popup.controller';
 import { buildTimeOptions, isTimeDisabled, type HourFormat, type TimeRange } from '../utils/time';
 import { timeBoundsError } from '../utils/parts';
 import { addErrors, addIcon, addLabel } from '../utils/templates';
-import { INCOMPLETE_TIME_MESSAGE, INVALID_DISABLED_TIME_RANGE_MESSAGE } from '../utils/messages';
+import { INVALID_DISABLED_TIME_RANGE_MESSAGE } from '../utils/messages';
 
 @customElement('gui-time-picker')
 export class GuiTimePicker extends LitElement {
@@ -150,6 +150,7 @@ export class GuiTimePicker extends LitElement {
           .dayPeriodAriaLabel=${this.dayPeriodAriaLabel}
           .minTimeMessage=${this.minTimeMessage}
           .maxTimeMessage=${this.maxTimeMessage}
+          .incompleteMessage=${this.incompleteMessage}
           @blur=${this.onTimeBlur}
           @focus=${this._popup.show}
           @change=${this.onTimeChange}
@@ -337,22 +338,13 @@ export class GuiTimePicker extends LitElement {
   }
 
   /**
-   * A partially typed time left behind flips the value to null — so
-   * validators report it — and surfaces the incomplete message. Complete or
-   * empty input reports nothing new.
+   * Hands the embedded input its deferred settlement: a partially typed time
+   * left behind surfaces the incomplete message, an emptied one clears a
+   * message it surfaced earlier. The input's resulting change bubbles back
+   * through {@link onTimeChange}, so the picker's value follows.
    */
   private reportIncompleteOnLeave(): void {
-    const input = this.querySelector<GuiTime>('gui-time');
-    if (!input || input.groupCompleteness() !== 'partial') return;
-
-    this.commitValue(null);
-    this.dispatchEvent(
-      new CustomEvent('inputError', {
-        detail: { message: this.incompleteMessage ?? INCOMPLETE_TIME_MESSAGE },
-        bubbles: true,
-        composed: true,
-      }),
-    );
+    this.querySelector<GuiTime>('gui-time')?.settleOnFocusLeave();
   }
 
   private dispatchListToggle(open: boolean) {

--- a/libs/gui/components/src/lib/controllers/focus-leave.controller.ts
+++ b/libs/gui/components/src/lib/controllers/focus-leave.controller.ts
@@ -5,6 +5,7 @@ export type GUIFocusLeaveHost = ReactiveControllerHost & HTMLElement;
 export interface GUIFocusLeaveControllerOptions {
   /** Called when focus has effectively left the watched subtree. */
   onLeave(): void;
+  resolveSyncOnRelatedTarget?: boolean;
 }
 
 // TODO: Improve this? maybe with a data-focusable attribute?
@@ -66,7 +67,14 @@ export class GUIFocusLeaveController implements ReactiveController {
 
   /** Runs the leave detection for a focusout event. */
   handleFocusOut(event: FocusEvent) {
-    if (this.isInside(event.relatedTarget as Element | null)) {
+    const related = event.relatedTarget as Element | null;
+    if (this.isInside(related)) {
+      return;
+    }
+
+    if (this.options.resolveSyncOnRelatedTarget && related) {
+      this.cancelPendingLeave();
+      this.options.onLeave();
       return;
     }
 

--- a/libs/gui/components/src/lib/controllers/focus-leave.controller.ts
+++ b/libs/gui/components/src/lib/controllers/focus-leave.controller.ts
@@ -7,20 +7,57 @@ export interface GUIFocusLeaveControllerOptions {
   onLeave(): void;
 }
 
+// TODO: Improve this? maybe with a data-focusable attribute?
+/** Elements that take focus when clicked, so clicking them is never a leave. */
+const FOCUSABLE_SELECTOR =
+  'input, button, select, textarea, a[href], [tabindex], [contenteditable]';
+
 /**
  * Detects "focus left the widget" with the exact semantics duplicated across
- * the six picker components:
+ * the six picker components, and distinguishes it from the focus losses a
+ * widget inflicts on itself: clicking chrome that cannot hold focus, or
+ * re-rendering the focused element away. Both send focus to the document
+ * body while the user is still working inside the widget, and reporting
+ * either as a leave would validate a half-finished entry.
  */
 export class GUIFocusLeaveController implements ReactiveController {
   private host: GUIFocusLeaveHost;
   private options: GUIFocusLeaveControllerOptions;
   private _rafId: number | undefined;
+  /** Whether the pointer interaction currently settling started inside the host. */
+  private _pointerInside = false;
 
   constructor(host: GUIFocusLeaveHost, options: GUIFocusLeaveControllerOptions) {
     host.addController(this);
     this.host = host;
     this.options = options;
   }
+
+  hostConnected() {
+    this.host.addEventListener('mousedown', this.onHostMouseDown);
+    document.addEventListener('mousedown', this.onDocumentMouseDown, true);
+  }
+
+  /**
+   * Keeps focus inside the widget when a click lands on chrome that cannot
+   * hold focus — a group wrapper, padding, a label. The browser would
+   * otherwise move focus to the document body, which is indistinguishable
+   * from the user genuinely leaving the widget.
+   */
+  private onHostMouseDown = (event: MouseEvent) => {
+    const target = event.target as Element | null;
+    if (!target) return;
+
+    const focusable = target.closest(FOCUSABLE_SELECTOR);
+    if (focusable && this.host.contains(focusable)) return;
+
+    event.preventDefault();
+  };
+
+  /** Remembers whether the interaction being settled started inside the host. */
+  private onDocumentMouseDown = (event: MouseEvent) => {
+    this._pointerInside = this.isInside(event.target as Element | null);
+  };
 
   /** Template-bindable focusout handler (arrow fn so `this` stays bound). */
   onFocusOut = (event: FocusEvent) => {
@@ -38,9 +75,13 @@ export class GUIFocusLeaveController implements ReactiveController {
     }
     this._rafId = requestAnimationFrame(() => {
       this._rafId = undefined;
-      if (!this.isInside(document.activeElement)) {
-        this.options.onLeave();
-      }
+      const active = document.activeElement;
+      if (this.isInside(active)) return;
+
+      // The user is still working in the widget, so this is not a leave.
+      if (this._pointerInside && (!active || active === document.body)) return;
+
+      this.options.onLeave();
     });
   }
 
@@ -57,6 +98,8 @@ export class GUIFocusLeaveController implements ReactiveController {
   }
 
   hostDisconnected() {
+    this.host.removeEventListener('mousedown', this.onHostMouseDown);
+    document.removeEventListener('mousedown', this.onDocumentMouseDown, true);
     this.cancelPendingLeave();
   }
 }

--- a/libs/gui/components/src/lib/controllers/parts.controller.ts
+++ b/libs/gui/components/src/lib/controllers/parts.controller.ts
@@ -46,10 +46,11 @@ export interface GUIPartsControllerOptions {
    * Called from {@link GUIPartsController.handleBlur} when a numeric part is
    * blurred while empty/invalid (NaN, or 0 on a part whose minimum is not 0).
    * REQUIRED so each host states its policy explicitly:
-   * - In scalar inputs dispatch a change carrying null.
+   * - In scalar inputs clear the part (a raw 0 counts as emptied) and
+   *   dispatch a change carrying null when a committed value existed.
    * - In range inputs an empty part never commits a null value.
    */
-  onEmptyPartBlur(): void;
+  onEmptyPartBlur(group: string, type: DateTimePartType): void;
   /** Enter keyup hook. Omitted: no-op. */
   onEnter?(event: KeyboardEvent, group: string): void;
   /** Accessor for the effective hour format. */
@@ -107,6 +108,18 @@ export class GUIPartsController implements ReactiveController {
     this.host.requestUpdate();
   }
 
+  /**
+   * Whether none of the given numeric parts hold user input. The dayPeriod
+   * toggle is excluded by the caller (it is always seeded in 12h formats).
+   *
+   * @param {string} group - The group to inspect.
+   * @param {readonly DateTimePartType[]} types - The numeric part types the host renders.
+   * @return {boolean} True when every given part is unset.
+   */
+  isGroupEmpty(group: string, types: readonly DateTimePartType[]): boolean {
+    return types.every((type) => this.getPart(group, type) === '');
+  }
+
   /** Writes clamp corrections back into the state. */
   applyWriteBacks(group: string, writeBacks: GroupWriteBacks): void {
     for (const [type, value] of Object.entries(writeBacks)) {
@@ -134,9 +147,12 @@ export class GUIPartsController implements ReactiveController {
   }
 
   /**
-   * Seeds a group's parts from an ISO value; a null/empty value clears the
-   * group (re-seeding its day period for time-aware shapes) and an
-   * unparseable one leaves the state untouched.
+   * Seeds a group's parts from an ISO value; a null/empty value clears only
+   * the shape's parts (re-seeding the day period for time-aware shapes) and
+   * an unparseable one leaves the state untouched.
+   *
+   * Shape-scoped clearing lets a date-time group drop just its date or time
+   * half while the other keeps the user's input.
    *
    * @param {string} group - The group to seed.
    * @param {string | null} iso - The ISO value, or null/'' to clear.
@@ -153,7 +169,13 @@ export class GUIPartsController implements ReactiveController {
     const format = hourFormat ?? this.options.getHourFormat?.() ?? '24';
 
     if (!iso) {
-      this.clearGroup(group);
+      if (shape === 'dateTime') {
+        this.clearGroup(group);
+      } else {
+        const types: DateTimePartType[] =
+          shape === 'date' ? ['day', 'month', 'year'] : ['hour', 'minute', 'second', 'dayPeriod'];
+        for (const type of types) this.setPart(group, type, '');
+      }
       if (shape !== 'date') this.seedWith([group], format);
       return;
     }
@@ -372,7 +394,7 @@ export class GUIPartsController implements ReactiveController {
    * - routes an empty/invalid part to `onEmptyPartBlur`
    * - always dispatches the host's `blur` CustomEvent.
    */
-  handleBlur = (event: FocusEvent, _group: string, type: DateTimePartType): void => {
+  handleBlur = (event: FocusEvent, group: string, type: DateTimePartType): void => {
     const descriptor = this.options.getDescriptor(type);
 
     if (descriptor?.kind !== 'dayPeriod') {
@@ -384,7 +406,7 @@ export class GUIPartsController implements ReactiveController {
       if (!isNaN(val) && (val > 0 || descriptor?.min === 0)) {
         input.value = val.toString().padStart(descriptor?.maxLength ?? 2, '0');
       } else {
-        this.options.onEmptyPartBlur();
+        this.options.onEmptyPartBlur(group, type);
       }
     }
 

--- a/libs/gui/components/src/lib/controllers/parts.controller.ts
+++ b/libs/gui/components/src/lib/controllers/parts.controller.ts
@@ -392,7 +392,6 @@ export class GUIPartsController implements ReactiveController {
    * Blur handling:
    * - zero-pads a valid numeric part in the DOM
    * - routes an empty/invalid part to `onEmptyPartBlur`
-   * - always dispatches the host's `blur` CustomEvent.
    */
   handleBlur = (event: FocusEvent, group: string, type: DateTimePartType): void => {
     const descriptor = this.options.getDescriptor(type);
@@ -409,8 +408,6 @@ export class GUIPartsController implements ReactiveController {
         this.options.onEmptyPartBlur(group, type);
       }
     }
-
-    this.host.dispatchEvent(new CustomEvent('blur'));
   };
 
   /**

--- a/libs/gui/components/src/lib/controllers/parts.controller.ts
+++ b/libs/gui/components/src/lib/controllers/parts.controller.ts
@@ -322,10 +322,11 @@ export class GUIPartsController implements ReactiveController {
       input.value.length === input.maxLength &&
       isDigitKey(event.key)
     ) {
-      if (index === inputs.length - 1) {
-        this.autoAdvanceFromGroupEnd(group);
-      } else {
+      if (index !== inputs.length - 1) {
         inputs[index + 1].focus();
+      } else if (!this.autoAdvanceFromGroupEnd(group)) {
+        this.setPart(group, type, input.value.replace(/[^0-9]/g, ''));
+        this.options.commitGroup(group);
       }
     }
 
@@ -424,17 +425,21 @@ export class GUIPartsController implements ReactiveController {
   /**
    * Auto-advance past the last input of a group, or into the next
    * group's first input, if it has more than one group (like ranged inputs).
+   *
+   * @param {string} group - The group whose last input was just filled.
+   * @return {boolean} Whether focus moved — false past the last group, where
+   *   there is nothing left to advance into and the caller commits instead.
    */
-  private autoAdvanceFromGroupEnd(group: string): void {
+  private autoAdvanceFromGroupEnd(group: string): boolean {
     const groups = this.options.groups;
     if (groups.length > 1) {
       const nextGroup = groups[groups.indexOf(group) + 1];
-      if (nextGroup !== undefined) {
-        this.getGroupInputs(nextGroup)[0]?.focus();
-      }
-      return;
+      if (nextGroup === undefined) return false;
+      this.getGroupInputs(nextGroup)[0]?.focus();
+      return true;
     }
     this.getGroupInputs(group)[0]?.focus();
+    return true;
   }
 
   /**

--- a/libs/gui/components/src/lib/utils/day-status.ts
+++ b/libs/gui/components/src/lib/utils/day-status.ts
@@ -18,6 +18,19 @@ export interface DaySpan {
 }
 
 /**
+ * Orders two days into a span. Every highlight test here walks start → end, so
+ * an unordered pair — a range whose end was entered before its start — would
+ * light up nothing at all.
+ *
+ * @param {Date} a - One endpoint.
+ * @param {Date} b - The other endpoint.
+ * @return {DaySpan} The pair, earliest first.
+ */
+export function orderedDaySpan(a: Date, b: Date): DaySpan {
+  return a.getTime() <= b.getTime() ? { start: a, end: b } : { start: b, end: a };
+}
+
+/**
  * A committed range normalized to calendar-day Dates — the caller applies its
  * `endpointDay` policy first (plain parse for the range calendar, date-part
  * parse for the date-time flavor), so this module never sees ISO endpoint
@@ -34,11 +47,13 @@ export interface DayStatusContext {
   selectedISO?: string;
   /** Committed ranges, endpoints normalized to day Dates. */
   ranges?: NormalizedDayRange[];
-  /** The parked working range of the range date-time calendar. */
-  workingRange?: DaySpan;
   /** Anchor day of an in-progress two-click selection. */
   anchor?: Date | null;
-  /** Ordered hover-preview span. */
+  /**
+   * The ordered in-progress span: the hover preview, or a picker's parked
+   * working range. Only `ranges` renders the solid committed look, so a span
+   * that is not a pill yet always reads as in progress.
+   */
   selectingSpan?: DaySpan | null;
   /** The rejected range currently highlighted in red. */
   invalidRange?: DaySpan | null;
@@ -54,7 +69,7 @@ export interface DayStatus {
   /** Both endpoints on this day — renders `selected` instead of start/end caps. */
   isOneDayRange: boolean;
   isAnchor: boolean;
-  /** Inside the live hover-preview span (endpoints inclusive). */
+  /** Inside the in-progress span (endpoints inclusive). */
   isSelecting: boolean;
   isInvalidStart: boolean;
   isInvalidEnd: boolean;
@@ -117,13 +132,6 @@ export function computeDayStatus(date: Date, ctx: DayStatusContext): DayStatus {
         }
       }
     }
-  }
-
-  if (ctx.workingRange) {
-    const { start, end } = ctx.workingRange;
-    if (isSameDay(date, start)) isRangeStart = true;
-    if (isSameDay(date, end)) isRangeEnd = true;
-    if (dateTime > start.getTime() && dateTime < end.getTime()) isInRange = true;
   }
 
   return {

--- a/libs/gui/components/src/lib/utils/messages.ts
+++ b/libs/gui/components/src/lib/utils/messages.ts
@@ -33,3 +33,13 @@ export const INVALID_MIN_DATE_TIME_MESSAGE =
 /** Default inputError message for a date-time before the maxDateTime bound. **/
 export const INVALID_MAX_DATE_TIME_MESSAGE =
   'Invalid date-time: date-time is after the maximum allowed date-time.';
+
+/** Default inputError message for a partially filled date left behind on focus leave. **/
+export const INCOMPLETE_DATE_MESSAGE = 'Incomplete date: fill in all date parts.';
+
+/** Default inputError message for a partially filled time left behind on focus leave. **/
+export const INCOMPLETE_TIME_MESSAGE = 'Incomplete time: fill in all time parts.';
+
+/** Default inputError message for a partially filled date-time left behind on focus leave. **/
+export const INCOMPLETE_DATE_TIME_MESSAGE =
+  'Incomplete date-time: fill in all date and time parts.';

--- a/libs/gui/components/src/lib/utils/parts.ts
+++ b/libs/gui/components/src/lib/utils/parts.ts
@@ -389,6 +389,67 @@ export function parseDateTimeGroup(
   return { result: { kind: 'valid', iso: toISODateTimeString(instant), instant }, writeBacks };
 }
 
+/**
+ * How much of a group the user has filled in. 'complete' covers any fully
+ * filled group, including one whose combination is invalid (e.g. Feb 31) —
+ * completeness is about fill state, not validity.
+ */
+export type GroupCompleteness = 'empty' | 'partial' | 'complete';
+
+/** The date and time halves of a date-time group, judged independently. */
+export interface DateTimeSubGroupResults {
+  date: GroupParseResult;
+  time: GroupParseResult;
+}
+
+/**
+ * Parses the date and time halves of a date-time group separately, so a
+ * complete half can live-sync (via `partsChange`) while the other is still
+ * empty. Write-backs are NOT applied here — the combined
+ * {@link parseDateTimeGroup} the host runs first already produced them.
+ *
+ * @param {GroupPartValues} parts - The group's raw part values.
+ * @param {object} options - Parse configuration.
+ * @param {HourFormat} options.hourFormat - The effective hour format.
+ * @param {PartDescriptorMap} options.descriptors - Merged date+time descriptors.
+ * @param {string} [options.invalidDateMessage] - Override for the impossible-date message.
+ * @return {DateTimeSubGroupResults} The two independent parse outcomes.
+ */
+export function parseDateTimeSubGroups(
+  parts: GroupPartValues,
+  options: {
+    hourFormat: HourFormat;
+    descriptors: PartDescriptorMap;
+    invalidDateMessage?: string;
+  },
+): DateTimeSubGroupResults {
+  const { result: date } = parseDateGroup(parts, {
+    descriptors: options.descriptors,
+    invalidDateMessage: options.invalidDateMessage,
+  });
+  const { result: time } = parseTimeGroup(parts, {
+    hourFormat: options.hourFormat,
+    descriptors: options.descriptors,
+  });
+  return { date, time };
+}
+
+/** `partsChange` detail of `gui-date`. */
+export interface DatePartsChangeDetail {
+  date: string | null;
+}
+
+/** `partsChange` detail of `gui-time`. */
+export interface TimePartsChangeDetail {
+  time: string | null;
+}
+
+/** `partsChange` detail of `gui-date-time` and `gui-date-time-calendar`. */
+export interface DateTimePartsChangeDetail {
+  date: string | null;
+  time: string | null;
+}
+
 /** Bounds configuration for {@link timeBoundsError}. */
 export interface TimeBounds {
   minTime?: string;

--- a/libs/gui/components/src/lib/utils/range-selection.ts
+++ b/libs/gui/components/src/lib/utils/range-selection.ts
@@ -34,6 +34,28 @@ export function idleRangeSelection(): RangeSelectionState {
   return { anchor: null, hover: null, selecting: false };
 }
 
+/** How a calendar should render its host picker's working endpoints. */
+export type WorkingPhase =
+  | { kind: 'idle' }
+  | { kind: 'anchor'; iso: string }
+  | { kind: 'span'; start: string; end: string };
+
+/**
+ * Reads a host picker's working endpoints as a calendar phase. A lone endpoint
+ * — whichever side it came from — is an in-progress anchor the next click
+ * completes, because {@link reduceRangeSelection} orders a backward pick; a
+ * pair is a parked span rendered like a committed range.
+ *
+ * @param {string} [start] - The working start endpoint, if any.
+ * @param {string} [end] - The working end endpoint, if any.
+ * @return {WorkingPhase} The phase the calendar should present.
+ */
+export function workingPhase(start?: string, end?: string): WorkingPhase {
+  if (start && end) return { kind: 'span', start, end };
+  const lone = start || end;
+  return lone ? { kind: 'anchor', iso: lone } : { kind: 'idle' };
+}
+
 /**
  * Advances the selection state machine.
  *

--- a/libs/gui/lit/src/lib/components/date-picker.element.ts
+++ b/libs/gui/lit/src/lib/components/date-picker.element.ts
@@ -86,6 +86,7 @@ export class DatePickerElement extends LitElement implements WithWidget {
         .minDateMessage=${templateData.minDateMessage as string}
         .maxDateMessage=${templateData.maxDateMessage as string}
         .disabledDateRangeMessage=${templateData.disabledDateRangeMessage as string}
+        .incompleteMessage=${templateData.incompleteMessage as string}
         @inputError=${this.onInputError}
         @blur=${() => this.adapter.onBlur()}
         @change=${this.valueChanged}

--- a/libs/gui/lit/src/lib/components/date-time-calendar.element.ts
+++ b/libs/gui/lit/src/lib/components/date-time-calendar.element.ts
@@ -87,6 +87,7 @@ export class DateTimeCalendarElement extends LitElement implements WithWidget {
         .maxTimeMessage=${templateData.maxTimeMessage as string}
         .disabledTimeRangeMessage=${templateData.disabledTimeRangeMessage as string}
         .noAvailableTimesMessage=${templateData.noAvailableTimesMessage as string}
+        .incompleteMessage=${templateData.incompleteMessage as string}
         @change=${this.valueChanged}
         @inputError=${this.onInputError}
         @blur=${() => this.adapter.onBlur()}

--- a/libs/gui/lit/src/lib/components/date-time-picker.element.ts
+++ b/libs/gui/lit/src/lib/components/date-time-picker.element.ts
@@ -99,6 +99,7 @@ export class DateTimePickerElement extends LitElement implements WithWidget {
         .maxTimeMessage=${templateData.maxTimeMessage as string}
         .disabledTimeRangeMessage=${templateData.disabledTimeRangeMessage as string}
         .noAvailableTimesMessage=${templateData.noAvailableTimesMessage as string}
+        .incompleteMessage=${templateData.incompleteMessage as string}
         @inputError=${this.onInputError}
         @blur=${() => this.adapter.onBlur()}
         @change=${this.valueChanged}

--- a/libs/gui/lit/src/lib/components/date-time.element.ts
+++ b/libs/gui/lit/src/lib/components/date-time.element.ts
@@ -84,6 +84,7 @@ export class DateTimeElement extends LitElement implements WithWidget {
         .maxDateMessage=${this.adapter.templateData.maxDateMessage as string}
         .minTimeMessage=${this.adapter.templateData.minTimeMessage as string}
         .maxTimeMessage=${this.adapter.templateData.maxTimeMessage as string}
+        .incompleteMessage=${this.adapter.templateData.incompleteMessage as string}
         .hourFormat=${this.adapter.templateData.hourFormat}
         .minuteStep=${this.adapter.templateData.minuteStep}
         @inputError=${this.onInputError}

--- a/libs/gui/lit/src/lib/components/date.element.ts
+++ b/libs/gui/lit/src/lib/components/date.element.ts
@@ -77,6 +77,7 @@ export class DateElement extends LitElement implements WithWidget {
         .maxDate=${this.adapter.templateData.maxDate}
         .minDateMessage=${this.adapter.templateData.minDateMessage as string}
         .maxDateMessage=${this.adapter.templateData.maxDateMessage as string}
+        .incompleteMessage=${this.adapter.templateData.incompleteMessage as string}
         @inputError=${this.onInputError}
         @blur=${() => this.adapter.onBlur()}
         @change=${this.valueChanged}

--- a/libs/gui/lit/src/lib/components/range-date-input.element.ts
+++ b/libs/gui/lit/src/lib/components/range-date-input.element.ts
@@ -67,6 +67,7 @@ export class RangeDateInputElement extends LitElement implements WithWidget {
         .monthAriaLabel=${this.adapter.templateData.monthAriaLabel}
         .yearAriaLabel=${this.adapter.templateData.yearAriaLabel}
         .invalidDateMessage=${this.adapter.templateData.invalidDateMessage as string}
+        .incompleteMessage=${this.adapter.templateData.incompleteMessage as string}
         .separator=${this.adapter.templateData.separator}
         .removePillAriaLabel=${this.adapter.templateData.removePillAriaLabel}
         .startDateAriaLabel=${this.adapter.templateData.startDateAriaLabel}

--- a/libs/gui/lit/src/lib/components/range-date-picker.element.ts
+++ b/libs/gui/lit/src/lib/components/range-date-picker.element.ts
@@ -90,6 +90,7 @@ export class RangeDatePickerElement extends LitElement implements WithWidget {
         .minDateMessage=${templateData.minDateMessage as string}
         .maxDateMessage=${templateData.maxDateMessage as string}
         .disabledDateRangeMessage=${templateData.disabledDateRangeMessage as string}
+        .incompleteMessage=${templateData.incompleteMessage as string}
         @inputError=${this.onInputError}
         @blur=${() => this.adapter.onBlur()}
         @change=${this.valueChanged}

--- a/libs/gui/lit/src/lib/components/range-date-time-calendar.element.ts
+++ b/libs/gui/lit/src/lib/components/range-date-time-calendar.element.ts
@@ -87,6 +87,7 @@ export class RangeDateTimeCalendarElement extends LitElement implements WithWidg
         .maxDateTimeMessage=${templateData.maxDateTimeMessage as string}
         .disabledRangeMessage=${templateData.disabledRangeMessage as string}
         .noAvailableTimesMessage=${templateData.noAvailableTimesMessage as string}
+        .incompleteMessage=${templateData.incompleteMessage as string}
         .dayCountAriaLabel=${templateData.dayCountAriaLabel as string}
         .disabledDayCountAriaLabel=${templateData.disabledDayCountAriaLabel as string}
         @change=${this.valueChanged}

--- a/libs/gui/lit/src/lib/components/range-date-time-input.element.ts
+++ b/libs/gui/lit/src/lib/components/range-date-time-input.element.ts
@@ -80,6 +80,7 @@ export class RangeDateTimeInputElement extends LitElement implements WithWidget 
         .invalidDateMessage=${this.adapter.templateData.invalidDateMessage as string}
         .minDateTimeMessage=${this.adapter.templateData.minDateTimeMessage as string}
         .maxDateTimeMessage=${this.adapter.templateData.maxDateTimeMessage as string}
+        .incompleteMessage=${this.adapter.templateData.incompleteMessage as string}
         @change=${this.valueChanged}
         @inputError=${this.onInputError}
       ></gui-range-date-time>

--- a/libs/gui/lit/src/lib/components/range-date-time-picker.element.ts
+++ b/libs/gui/lit/src/lib/components/range-date-time-picker.element.ts
@@ -99,6 +99,7 @@ export class RangeDateTimePickerElement extends LitElement implements WithWidget
         .maxDateTimeMessage=${templateData.maxDateTimeMessage as string}
         .disabledRangeMessage=${templateData.disabledRangeMessage as string}
         .noAvailableTimesMessage=${templateData.noAvailableTimesMessage as string}
+        .incompleteMessage=${templateData.incompleteMessage as string}
         .dayCountAriaLabel=${templateData.dayCountAriaLabel as string}
         .disabledDayCountAriaLabel=${templateData.disabledDayCountAriaLabel as string}
         @change=${this.valueChanged}

--- a/libs/gui/lit/src/lib/components/range-time-input.element.ts
+++ b/libs/gui/lit/src/lib/components/range-time-input.element.ts
@@ -77,6 +77,7 @@ export class RangeTimeInputElement extends LitElement implements WithWidget {
         .minTimeMessage=${this.adapter.templateData.minTimeMessage as string}
         .maxTimeMessage=${this.adapter.templateData.maxTimeMessage as string}
         .rangeOrderMessage=${this.adapter.templateData.rangeOrderMessage as string}
+        .incompleteMessage=${this.adapter.templateData.incompleteMessage as string}
         @change=${this.valueChanged}
         @inputError=${this.onInputError}
       ></gui-range-time>

--- a/libs/gui/lit/src/lib/components/range-time-picker.element.ts
+++ b/libs/gui/lit/src/lib/components/range-time-picker.element.ts
@@ -88,6 +88,7 @@ export class RangeTimePickerElement extends LitElement implements WithWidget {
         .rangeOrderMessage=${templateData.rangeOrderMessage as string}
         .disabledRangeMessage=${templateData.disabledRangeMessage as string}
         .noAvailableTimesMessage=${templateData.noAvailableTimesMessage as string}
+        .incompleteMessage=${templateData.incompleteMessage as string}
         @inputError=${this.onInputError}
         @blur=${() => this.adapter.onBlur()}
         @change=${this.valueChanged}

--- a/libs/gui/lit/src/lib/components/time-picker.element.ts
+++ b/libs/gui/lit/src/lib/components/time-picker.element.ts
@@ -81,6 +81,7 @@ export class TimePickerElement extends LitElement implements WithWidget {
         .maxTimeMessage=${templateData.maxTimeMessage as string}
         .disabledRangeMessage=${templateData.disabledRangeMessage as string}
         .noAvailableTimesMessage=${templateData.noAvailableTimesMessage as string}
+        .incompleteMessage=${templateData.incompleteMessage as string}
         @inputError=${this.onInputError}
         @blur=${() => this.adapter.onBlur()}
         @change=${this.valueChanged}

--- a/libs/gui/lit/src/lib/components/time.element.ts
+++ b/libs/gui/lit/src/lib/components/time.element.ts
@@ -78,6 +78,7 @@ export class TimeElement extends LitElement implements WithWidget {
         .maxTime=${this.adapter.templateData.maxTime}
         .minTimeMessage=${this.adapter.templateData.minTimeMessage as string}
         .maxTimeMessage=${this.adapter.templateData.maxTimeMessage as string}
+        .incompleteMessage=${this.adapter.templateData.incompleteMessage as string}
         @inputError=${this.onInputError}
         @blur=${() => this.adapter.onBlur()}
         @change=${this.valueChanged}

--- a/libs/gui/mcp/src/dx/dx-specs.ts
+++ b/libs/gui/mcp/src/dx/dx-specs.ts
@@ -351,8 +351,9 @@ const INPUTS: DxSpec[] = [
         'Same `minDate`/`maxDate` on `calendar`, `dateInput`, and the range date widgets.',
       'A partially typed date abandoned on focus leave flips the value to null — flagging the field even when ' +
         'optional — and surfaces an "incomplete" error; **`incompleteMessage`** overrides its wording. The same ' +
-        'prop exists on every typed date/time widget (the inputs, the pickers, `dateTimeCalendar` and the range ' +
-        'inputs/pickers), and an emptied widget clears the error on the next focus leave.',
+        'prop exists on every typed date/time widget (the inputs, the pickers, the range inputs/pickers, and the ' +
+        'inline `dateTimeCalendar`/`rangeDateTimeCalendar`), and an emptied widget clears the error on the next ' +
+        'focus leave.',
     ],
   },
   {
@@ -584,7 +585,7 @@ const INPUTS: DxSpec[] = [
     example:
       "gui.inputs.rangeDateTimeCalendar('stay', { label: 'Stay', startTimeLabel: 'Check-in', endTimeLabel: 'Check-out' })",
     notes: [
-      'INLINE range calendar with TWO embedded time pickers (start/end); value is `DateTimeRange[]`, rendered as pills. A day span and the two times can be chosen in ANY order — both time pickers are usable from the start — and the pill is committed once all four pieces are present. Starting a new day span keeps the times already chosen. A day holding more than one range shows a count badge.',
+      'INLINE range calendar with TWO embedded time pickers (start/end); value is `DateTimeRange[]`, rendered as pills. A day span and the two times can be chosen in ANY order — both time pickers are usable from the start — and the pill is committed once all four pieces are present. Starting a new day span keeps the times already chosen. A day holding more than one range shows a count badge. Leaving the widget with a half-finished selection surfaces an "incomplete" error over the untouched pills (`incompleteMessage` overrides its wording); leaving it emptied clears the error.',
       'Everything is in instant-space: bounds are **`minDateTime`** / **`maxDateTime`** and **`disabledRanges`** are `DateTimeRange[]` instant spans (block a whole day with `00:00:00`–`23:59:59`). There is no `minDate`/`maxDate`/`minTime`/`maxTime`/`disabledTimeRanges` — a time-of-day constraint cannot bound a multi-day span.',
     ],
   },

--- a/libs/gui/mcp/src/dx/dx-specs.ts
+++ b/libs/gui/mcp/src/dx/dx-specs.ts
@@ -445,8 +445,11 @@ const INPUTS: DxSpec[] = [
       'An INLINE calendar with an embedded time picker: a segmented time input between the header and the days ' +
         'grid opens a time grid in place of the days (like the year selector).',
       'Emits a local ISO date-time (`YYYY-MM-DDTHH:mm:ss`) only when BOTH day and time are selected — pair with a ' +
-        "`{ type: 'string', format: 'date-time' }` validator. Picking a different day clears the time and resets " +
-        'the value to null.',
+        "`{ type: 'string', format: 'date-time' }` validator. The time picker is usable before a day is picked, " +
+        'and picking a different day KEEPS the chosen time (re-emitting the full value), so the two halves can be ' +
+        'chosen in either order.',
+      'Half-finished entries never emit: the value goes to null — flagging the field even when it is optional — ' +
+        'only once focus leaves the widget with one half missing, which surfaces an "incomplete" message.',
       '`disabledTimeRanges` entries take `start`/`end` ISO times plus optional `date` (ISO date) and/or `weekdays` ' +
         '(getDay() numbering: 0=Sunday … 6=Saturday) to scope the range to specific days.',
     ],
@@ -566,7 +569,7 @@ const INPUTS: DxSpec[] = [
     example:
       "gui.inputs.rangeDateTimeCalendar('stay', { label: 'Stay', startTimeLabel: 'Check-in', endTimeLabel: 'Check-out' })",
     notes: [
-      'INLINE range calendar with TWO embedded time pickers (start/end); value is `DateTimeRange[]`, rendered as pills. Pick a date range, then a start time (enables the end time), then an end time to commit a pill. A day holding more than one range shows a count badge.',
+      'INLINE range calendar with TWO embedded time pickers (start/end); value is `DateTimeRange[]`, rendered as pills. A day span and the two times can be chosen in ANY order — both time pickers are usable from the start — and the pill is committed once all four pieces are present. Starting a new day span keeps the times already chosen. A day holding more than one range shows a count badge.',
       'Everything is in instant-space: bounds are **`minDateTime`** / **`maxDateTime`** and **`disabledRanges`** are `DateTimeRange[]` instant spans (block a whole day with `00:00:00`–`23:59:59`). There is no `minDate`/`maxDate`/`minTime`/`maxTime`/`disabledTimeRanges` — a time-of-day constraint cannot bound a multi-day span.',
     ],
   },
@@ -578,7 +581,7 @@ const INPUTS: DxSpec[] = [
     example:
       "gui.inputs.rangeDateTimePicker('stay', { label: 'Stay', startTimeLabel: 'Check-in', endTimeLabel: 'Check-out' })",
     notes: [
-      'POPOVER date-time range picker: the typed `rangeDateTimeInput` as the trigger (pills live there) with the `rangeDateTimeCalendar` in a dropdown. Value is `DateTimeRange[]`. Committing a pill keeps the popover open so several ranges can be added; it closes on outside-click, blur or Escape.',
+      'POPOVER date-time range picker: the typed `rangeDateTimeInput` as the trigger (pills live there) with the `rangeDateTimeCalendar` in a dropdown. Value is `DateTimeRange[]`. Committing a pill keeps the popover open so several ranges can be added; it closes on outside-click, blur or Escape. A half-finished selection is held by the picker, so it survives closing and reopening the popover.',
       'Everything is in instant-space: bounds are **`minDateTime`** / **`maxDateTime`** and **`disabledRanges`** are `DateTimeRange[]` instant spans (block a whole day with `00:00:00`–`23:59:59`). There is no `minDate`/`maxDate`/`minTime`/`maxTime`/`disabledTimeRanges`.',
     ],
   },
@@ -588,7 +591,10 @@ const INPUTS: DxSpec[] = [
     docSlug: 'range-date-picker',
     call: 'gui.inputs.rangeDatePicker(path, { label? })',
     example: "gui.inputs.rangeDatePicker('stayDates', { label: 'Stay dates' })",
-    notes: ['Popover calendar for a start–end date **range** (the range sibling of `datePicker`).'],
+    notes: [
+      'Popover calendar for a start–end date **range** (the range sibling of `datePicker`). A span with only its ' +
+        'first day picked is held by the picker, so it survives closing and reopening the popover.',
+    ],
   },
   {
     factory: 'rangeTimePicker',
@@ -598,7 +604,7 @@ const INPUTS: DxSpec[] = [
     example:
       "gui.inputs.rangeTimePicker('shift', { label: 'Shift', minTime: '06:00:00', maxTime: '22:00:00' })",
     notes: [
-      'Two-list popover for a start–end time **range** (the range sibling of `timePicker`); value is `TimeRange[]`. The out list floors one slot after the chosen in so end is strictly after start.',
+      'Two-list popover for a start–end time **range** (the range sibling of `timePicker`); value is `TimeRange[]`. Either list can be used first — an end picked before a start simply waits — and the range commits once both are set. Once an in is chosen the out list floors one slot after it so end is strictly after start.',
     ],
   },
 ];

--- a/libs/gui/mcp/src/dx/dx-specs.ts
+++ b/libs/gui/mcp/src/dx/dx-specs.ts
@@ -349,6 +349,10 @@ const INPUTS: DxSpec[] = [
       'Bound the selectable range with **`minDate`** / **`maxDate`** — ISO `YYYY-MM-DD` strings. For ' +
         '"today or later" set `minDate` to today’s date; for "not in the future" set `maxDate` to today. ' +
         'Same `minDate`/`maxDate` on `calendar`, `dateInput`, and the range date widgets.',
+      'A partially typed date abandoned on focus leave flips the value to null — flagging the field even when ' +
+        'optional — and surfaces an "incomplete" error; **`incompleteMessage`** overrides its wording. The same ' +
+        'prop exists on every typed date/time widget (the inputs, the pickers, `dateTimeCalendar` and the range ' +
+        'inputs/pickers), and an emptied widget clears the error on the next focus leave.',
     ],
   },
   {
@@ -378,11 +382,12 @@ const INPUTS: DxSpec[] = [
     docSlug: 'dateinput',
     call: 'gui.inputs.dateInput(path, { label, minDate?, maxDate?, validator? })',
     example:
-      "gui.inputs.dateInput('startDate', { label: 'Start date', validator: { required: true } })",
+      "gui.inputs.dateInput('startDate', { label: 'Start date', incompleteMessage: 'Incomplete date!', validator: { required: true } })",
     notes: [
       'Typed date entry, NO calendar UI — use only when keyboard-first entry is wanted. For most dates use ' +
         '`datePicker` (popover calendar) instead. Accepts the loose `{ required: true }`.',
       '`minDate` / `maxDate` (ISO `YYYY-MM-DD` strings) constrain the accepted range — see `datePicker`.',
+      '`incompleteMessage` overrides the "incomplete" error surfaced when focus leaves a partial entry — see `datePicker`.',
     ],
   },
   {
@@ -395,6 +400,7 @@ const INPUTS: DxSpec[] = [
       'Typed time entry (hh:mm segments). Emits an ISO time string (`HH:mm:ss`) — pair with the ' +
         "`{ format: 'time' }` validator. `hourFormat` forces '12'/'24' (default: locale); " +
         '`minuteStep` sets the arrow-key minute increment.',
+      '`incompleteMessage` overrides the "incomplete" error surfaced when focus leaves a partial entry — see `datePicker`.',
     ],
   },
   {
@@ -408,6 +414,7 @@ const INPUTS: DxSpec[] = [
       'Time field with a popover list of slots built from `minTime`..`maxTime` stepping `minuteStep` ' +
         '(default 30). `disabledRanges` (`{ start, end }[]`, inclusive) greys slots out. Typing is off ' +
         "unless `allowCustomTime: true`. Emits `HH:mm:ss` — pair with the `{ format: 'time' }` validator.",
+      '`incompleteMessage` overrides the "incomplete" error surfaced when focus leaves a partial typed entry — see `datePicker`.',
     ],
   },
   {
@@ -420,6 +427,7 @@ const INPUTS: DxSpec[] = [
       'Typed date+time entry in one locale-ordered row. Emits a local ISO date-time ' +
         "(`YYYY-MM-DDTHH:mm:ss`) — pair with the `{ format: 'date-time' }` validator. " +
         '`hourFormat`/`minuteStep` as in `timeInput`.',
+      '`incompleteMessage` overrides the "incomplete" error surfaced when focus leaves a partial entry — see `datePicker`.',
     ],
   },
   {
@@ -449,7 +457,8 @@ const INPUTS: DxSpec[] = [
         'and picking a different day KEEPS the chosen time (re-emitting the full value), so the two halves can be ' +
         'chosen in either order.',
       'Half-finished entries never emit: the value goes to null — flagging the field even when it is optional — ' +
-        'only once focus leaves the widget with one half missing, which surfaces an "incomplete" message.',
+        'only once focus leaves the widget with one half missing, which surfaces an "incomplete" message ' +
+        '(`incompleteMessage` overrides its wording).',
       '`disabledTimeRanges` entries take `start`/`end` ISO times plus optional `date` (ISO date) and/or `weekdays` ' +
         '(getDay() numbering: 0=Sunday … 6=Saturday) to scope the range to specific days.',
     ],
@@ -467,7 +476,8 @@ const INPUTS: DxSpec[] = [
       'Emits a local ISO date-time (`YYYY-MM-DDTHH:mm:ss`); the popover closes only when BOTH day and time are ' +
         "selected. Pair with a `{ type: 'string', format: 'date-time' }` validator.",
       'Takes the same time props as `dateTimeCalendar` (`minTime`/`maxTime`/`minuteStep`/`disabledTimeRanges` with ' +
-        'per-date/weekday scoping/`allowCustomTime`) plus `icon` and `invalidDateMessage` for the typed input.',
+        'per-date/weekday scoping/`allowCustomTime`) plus `icon`, `invalidDateMessage` and `incompleteMessage` ' +
+        'for the typed input.',
     ],
   },
   {
@@ -536,7 +546,10 @@ const INPUTS: DxSpec[] = [
     docSlug: 'range-date-input',
     call: 'gui.inputs.rangeDateInput(path, { label? })',
     example: "gui.inputs.rangeDateInput('stayDates', { label: 'Stay dates' })",
-    notes: ['Typed start–end date **range** entry (the range sibling of `dateInput`).'],
+    notes: [
+      'Typed start–end date **range** entry (the range sibling of `dateInput`).',
+      '`incompleteMessage` overrides the "incomplete" error surfaced when focus leaves with only one endpoint filled — see `datePicker`.',
+    ],
   },
   {
     factory: 'rangeTimeInput',
@@ -547,6 +560,7 @@ const INPUTS: DxSpec[] = [
       "gui.inputs.rangeTimeInput('shift', { label: 'Shift', minTime: '06:00:00', maxTime: '22:00:00' })",
     notes: [
       'Typed start–end time **range** entry (the range sibling of `timeInput`); value is `TimeRange[]`. End time must be after start time.',
+      '`incompleteMessage` overrides the "incomplete" error surfaced when focus leaves with only one endpoint filled — see `datePicker`.',
     ],
   },
   {
@@ -559,6 +573,7 @@ const INPUTS: DxSpec[] = [
     notes: [
       'Typed start–end date-time **range** entry (the range sibling of `dateTimeInput`); value is `DateTimeRange[]`. A backward selection reorders (swaps) instead of erroring.',
       'Each endpoint is an instant, so it is bounded by instants: use **`minDateTime`** / **`maxDateTime`** (ISO `YYYY-MM-DDTHH:mm:ss`), not `minDate`/`maxDate`. There is no `minTime`/`maxTime` here — a per-day time window is a different constraint from an instant bound.',
+      '`incompleteMessage` overrides the "incomplete" error surfaced when focus leaves with only one endpoint filled — see `datePicker`.',
     ],
   },
   {
@@ -581,7 +596,7 @@ const INPUTS: DxSpec[] = [
     example:
       "gui.inputs.rangeDateTimePicker('stay', { label: 'Stay', startTimeLabel: 'Check-in', endTimeLabel: 'Check-out' })",
     notes: [
-      'POPOVER date-time range picker: the typed `rangeDateTimeInput` as the trigger (pills live there) with the `rangeDateTimeCalendar` in a dropdown. Value is `DateTimeRange[]`. Committing a pill keeps the popover open so several ranges can be added; it closes on outside-click, blur or Escape. A half-finished selection is held by the picker, so it survives closing and reopening the popover.',
+      'POPOVER date-time range picker: the typed `rangeDateTimeInput` as the trigger (pills live there) with the `rangeDateTimeCalendar` in a dropdown. Value is `DateTimeRange[]`. Committing a pill keeps the popover open so several ranges can be added; it closes on outside-click, blur or Escape. A half-finished selection is held by the picker, so it survives closing and reopening the popover. Leaving it that way surfaces an "incomplete" error (`incompleteMessage` overrides its wording).',
       'Everything is in instant-space: bounds are **`minDateTime`** / **`maxDateTime`** and **`disabledRanges`** are `DateTimeRange[]` instant spans (block a whole day with `00:00:00`–`23:59:59`). There is no `minDate`/`maxDate`/`minTime`/`maxTime`/`disabledTimeRanges`.',
     ],
   },
@@ -593,7 +608,8 @@ const INPUTS: DxSpec[] = [
     example: "gui.inputs.rangeDatePicker('stayDates', { label: 'Stay dates' })",
     notes: [
       'Popover calendar for a start–end date **range** (the range sibling of `datePicker`). A span with only its ' +
-        'first day picked is held by the picker, so it survives closing and reopening the popover.',
+        'first day picked is held by the picker, so it survives closing and reopening the popover. Leaving it ' +
+        'that way surfaces an "incomplete" error (`incompleteMessage` overrides its wording).',
     ],
   },
   {
@@ -605,6 +621,7 @@ const INPUTS: DxSpec[] = [
       "gui.inputs.rangeTimePicker('shift', { label: 'Shift', minTime: '06:00:00', maxTime: '22:00:00' })",
     notes: [
       'Two-list popover for a start–end time **range** (the range sibling of `timePicker`); value is `TimeRange[]`. Either list can be used first — an end picked before a start simply waits — and the range commits once both are set. Once an in is chosen the out list floors one slot after it so end is strictly after start.',
+      '`incompleteMessage` overrides the "incomplete" error surfaced when focus leaves with only one endpoint set — see `datePicker`.',
     ],
   },
 ];

--- a/libs/gui/react/src/lib/components/DateInput.tsx
+++ b/libs/gui/react/src/lib/components/DateInput.tsx
@@ -75,6 +75,7 @@ export function DateInput(widgetInstance: WithWidget) {
         maxDate={templateData.maxDate}
         minDateMessage={templateData.minDateMessage as string}
         maxDateMessage={templateData.maxDateMessage as string}
+        incompleteMessage={templateData.incompleteMessage as string}
       />
     </div>
   );

--- a/libs/gui/react/src/lib/components/DatePicker.tsx
+++ b/libs/gui/react/src/lib/components/DatePicker.tsx
@@ -70,6 +70,7 @@ export function DatePicker(widgetInstance: WithWidget) {
         minDateMessage={templateData.minDateMessage as string}
         maxDateMessage={templateData.maxDateMessage as string}
         disabledDateRangeMessage={templateData.disabledDateRangeMessage as string}
+        incompleteMessage={templateData.incompleteMessage as string}
         onChange={handleChange}
         onBlur={onBlur}
         onInputError={handleInputError}

--- a/libs/gui/react/src/lib/components/DateTimeCalendar.tsx
+++ b/libs/gui/react/src/lib/components/DateTimeCalendar.tsx
@@ -71,6 +71,7 @@ export function DateTimeCalendar(widgetInstance: WithWidget) {
         maxTimeMessage={templateData.maxTimeMessage as string}
         disabledTimeRangeMessage={templateData.disabledTimeRangeMessage as string}
         noAvailableTimesMessage={templateData.noAvailableTimesMessage as string}
+        incompleteMessage={templateData.incompleteMessage as string}
         onChange={handleChange}
         onBlur={onBlur}
         onInputError={handleInputError}

--- a/libs/gui/react/src/lib/components/DateTimeInput.tsx
+++ b/libs/gui/react/src/lib/components/DateTimeInput.tsx
@@ -85,6 +85,7 @@ export function DateTimeInput(widgetInstance: WithWidget) {
         maxDateMessage={templateData.maxDateMessage as string}
         minTimeMessage={templateData.minTimeMessage as string}
         maxTimeMessage={templateData.maxTimeMessage as string}
+        incompleteMessage={templateData.incompleteMessage as string}
         hourFormat={hourFormat}
         minuteStep={minuteStep}
       />

--- a/libs/gui/react/src/lib/components/DateTimePicker.tsx
+++ b/libs/gui/react/src/lib/components/DateTimePicker.tsx
@@ -83,6 +83,7 @@ export function DateTimePicker(widgetInstance: WithWidget) {
         maxTimeMessage={templateData.maxTimeMessage as string}
         disabledTimeRangeMessage={templateData.disabledTimeRangeMessage as string}
         noAvailableTimesMessage={templateData.noAvailableTimesMessage as string}
+        incompleteMessage={templateData.incompleteMessage as string}
         onChange={handleChange}
         onBlur={onBlur}
         onInputError={handleInputError}

--- a/libs/gui/react/src/lib/components/RangeDateInput.tsx
+++ b/libs/gui/react/src/lib/components/RangeDateInput.tsx
@@ -78,6 +78,7 @@ export function RangeDateInput(widgetInstance: WithWidget) {
         monthAriaLabel={templateData.monthAriaLabel}
         yearAriaLabel={templateData.yearAriaLabel}
         invalidDateMessage={templateData.invalidDateMessage as string}
+        incompleteMessage={templateData.incompleteMessage as string}
         separator={separator}
         removePillAriaLabel={removePillAriaLabel}
         startDateAriaLabel={startDateAriaLabel}

--- a/libs/gui/react/src/lib/components/RangeDatePicker.tsx
+++ b/libs/gui/react/src/lib/components/RangeDatePicker.tsx
@@ -75,6 +75,7 @@ export function RangeDatePicker(widgetInstance: WithWidget) {
         minDateMessage={templateData.minDateMessage as string}
         maxDateMessage={templateData.maxDateMessage as string}
         disabledDateRangeMessage={templateData.disabledDateRangeMessage as string}
+        incompleteMessage={templateData.incompleteMessage as string}
         onChange={handleChange}
         onBlur={onBlur}
         onInputError={handleInputError}

--- a/libs/gui/react/src/lib/components/RangeDateTimeCalendar.tsx
+++ b/libs/gui/react/src/lib/components/RangeDateTimeCalendar.tsx
@@ -73,6 +73,7 @@ export function RangeDateTimeCalendar(widgetInstance: WithWidget) {
         maxDateTimeMessage={templateData.maxDateTimeMessage as string}
         disabledRangeMessage={templateData.disabledRangeMessage as string}
         noAvailableTimesMessage={templateData.noAvailableTimesMessage as string}
+        incompleteMessage={templateData.incompleteMessage as string}
         dayCountAriaLabel={templateData.dayCountAriaLabel as string}
         disabledDayCountAriaLabel={templateData.disabledDayCountAriaLabel as string}
         onChange={handleChange}

--- a/libs/gui/react/src/lib/components/RangeDateTimeInput.tsx
+++ b/libs/gui/react/src/lib/components/RangeDateTimeInput.tsx
@@ -91,6 +91,7 @@ export function RangeDateTimeInput(widgetInstance: WithWidget) {
         invalidDateMessage={templateData.invalidDateMessage as string}
         minDateTimeMessage={templateData.minDateTimeMessage as string}
         maxDateTimeMessage={templateData.maxDateTimeMessage as string}
+        incompleteMessage={templateData.incompleteMessage as string}
       />
     </div>
   );

--- a/libs/gui/react/src/lib/components/RangeDateTimePicker.tsx
+++ b/libs/gui/react/src/lib/components/RangeDateTimePicker.tsx
@@ -85,6 +85,7 @@ export function RangeDateTimePicker(widgetInstance: WithWidget) {
         maxDateTimeMessage={templateData.maxDateTimeMessage as string}
         disabledRangeMessage={templateData.disabledRangeMessage as string}
         noAvailableTimesMessage={templateData.noAvailableTimesMessage as string}
+        incompleteMessage={templateData.incompleteMessage as string}
         dayCountAriaLabel={templateData.dayCountAriaLabel as string}
         disabledDayCountAriaLabel={templateData.disabledDayCountAriaLabel as string}
         onChange={handleChange}

--- a/libs/gui/react/src/lib/components/RangeTimeInput.tsx
+++ b/libs/gui/react/src/lib/components/RangeTimeInput.tsx
@@ -88,6 +88,7 @@ export function RangeTimeInput(widgetInstance: WithWidget) {
         minTimeMessage={templateData.minTimeMessage as string}
         maxTimeMessage={templateData.maxTimeMessage as string}
         rangeOrderMessage={templateData.rangeOrderMessage as string}
+        incompleteMessage={templateData.incompleteMessage as string}
       />
     </div>
   );

--- a/libs/gui/react/src/lib/components/RangeTimePicker.tsx
+++ b/libs/gui/react/src/lib/components/RangeTimePicker.tsx
@@ -72,6 +72,7 @@ export function RangeTimePicker(widgetInstance: WithWidget) {
         rangeOrderMessage={templateData.rangeOrderMessage as string}
         disabledRangeMessage={templateData.disabledRangeMessage as string}
         noAvailableTimesMessage={templateData.noAvailableTimesMessage as string}
+        incompleteMessage={templateData.incompleteMessage as string}
         onChange={handleChange}
         onBlur={onBlur}
         onInputError={handleInputError}

--- a/libs/gui/react/src/lib/components/TimeInput.tsx
+++ b/libs/gui/react/src/lib/components/TimeInput.tsx
@@ -79,6 +79,7 @@ export function TimeInput(widgetInstance: WithWidget) {
         maxTime={templateData.maxTime}
         minTimeMessage={templateData.minTimeMessage as string}
         maxTimeMessage={templateData.maxTimeMessage as string}
+        incompleteMessage={templateData.incompleteMessage as string}
       />
     </div>
   );

--- a/libs/gui/react/src/lib/components/TimePicker.tsx
+++ b/libs/gui/react/src/lib/components/TimePicker.tsx
@@ -65,6 +65,7 @@ export function TimePicker(widgetInstance: WithWidget) {
         maxTimeMessage={templateData.maxTimeMessage as string}
         disabledRangeMessage={templateData.disabledRangeMessage as string}
         noAvailableTimesMessage={templateData.noAvailableTimesMessage as string}
+        incompleteMessage={templateData.incompleteMessage as string}
         onChange={handleChange}
         onBlur={onBlur}
         onInputError={handleInputError}

--- a/libs/gui/schemas/src/lib/components/dateinput.schema.json
+++ b/libs/gui/schemas/src/lib/components/dateinput.schema.json
@@ -83,6 +83,10 @@
         "maxDateMessage": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
+        "incompleteMessage": {
+          "$ref": "../common.schema.json#/$defs/localizable",
+          "description": "Error surfaced when focus leaves the widget with a partially filled entry behind; the value goes to null so validators report it even on non-required fields."
+        },
         "hint": {
           "$ref": "#/$defs/hintProp"
         },
@@ -113,6 +117,9 @@
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^maxDateMessage\\.[^.]+$": {
+          "$ref": "../common.schema.json#/$defs/localizable"
+        },
+        "^incompleteMessage\\.[^.]+$": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^hint\\.[^.]+$": {

--- a/libs/gui/schemas/src/lib/components/dateinput.schema.spec.ts
+++ b/libs/gui/schemas/src/lib/components/dateinput.schema.spec.ts
@@ -60,6 +60,7 @@ describe('Dateinput schema validation', () => {
               yearAriaLabel: 'Year',
               hint: 'Enter your birthday',
               icon: 'calendar',
+              incompleteMessage: 'Incomplete date',
             },
           },
         ],

--- a/libs/gui/schemas/src/lib/components/datepicker.schema.json
+++ b/libs/gui/schemas/src/lib/components/datepicker.schema.json
@@ -119,6 +119,10 @@
         "disabledDateRangeMessage": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
+        "incompleteMessage": {
+          "$ref": "../common.schema.json#/$defs/localizable",
+          "description": "Error surfaced when focus leaves the widget with a partially filled entry behind; the value goes to null so validators report it even on non-required fields."
+        },
         "hint": {
           "$ref": "#/$defs/hintProp"
         },
@@ -188,6 +192,9 @@
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^disabledDateRangeMessage\\.[^.]+$": {
+          "$ref": "../common.schema.json#/$defs/localizable"
+        },
+        "^incompleteMessage\\.[^.]+$": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^hint\\.[^.]+$": {

--- a/libs/gui/schemas/src/lib/components/datepicker.schema.spec.ts
+++ b/libs/gui/schemas/src/lib/components/datepicker.schema.spec.ts
@@ -72,6 +72,7 @@ describe('Datepicker schema validation', () => {
               maxDate: '2025-12-31',
               numberOfMonths: 2,
               disabledRanges: [{ start: '2023-12-25', end: '2024-01-01' }, { start: '2024-07-04' }],
+              incompleteMessage: 'Incomplete date',
             },
           },
         ],

--- a/libs/gui/schemas/src/lib/components/datetimecalendar.schema.json
+++ b/libs/gui/schemas/src/lib/components/datetimecalendar.schema.json
@@ -156,6 +156,10 @@
         "noAvailableTimesMessage": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
+        "incompleteMessage": {
+          "$ref": "../common.schema.json#/$defs/localizable",
+          "description": "Error surfaced when focus leaves the widget with a partially filled entry behind; the value goes to null so validators report it even on non-required fields."
+        },
         "hint": {
           "$ref": "#/$defs/hintProp"
         },
@@ -228,6 +232,9 @@
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^noAvailableTimesMessage\\.[^.]+$": {
+          "$ref": "../common.schema.json#/$defs/localizable"
+        },
+        "^incompleteMessage\\.[^.]+$": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^hint\\.[^.]+$": {

--- a/libs/gui/schemas/src/lib/components/datetimecalendar.schema.spec.ts
+++ b/libs/gui/schemas/src/lib/components/datetimecalendar.schema.spec.ts
@@ -82,6 +82,7 @@ describe('DateTimeCalendar schema validation', () => {
               maxTimeMessage: { key: 'dtc.max', default: 'Too late' },
               disabledTimeRangeMessage: 'Unavailable slot',
               noAvailableTimesMessage: 'No slots today',
+              incompleteMessage: 'Incomplete date-time',
             },
           },
         ],

--- a/libs/gui/schemas/src/lib/components/datetimeinput.schema.json
+++ b/libs/gui/schemas/src/lib/components/datetimeinput.schema.json
@@ -129,6 +129,10 @@
         "maxTimeMessage": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
+        "incompleteMessage": {
+          "$ref": "../common.schema.json#/$defs/localizable",
+          "description": "Error surfaced when focus leaves the widget with a partially filled entry behind; the value goes to null so validators report it even on non-required fields."
+        },
         "dayAriaLabel": {
           "$ref": "#/$defs/dayAriaLabelProp"
         },
@@ -174,6 +178,9 @@
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^maxTimeMessage\\.[^.]+$": {
+          "$ref": "../common.schema.json#/$defs/localizable"
+        },
+        "^incompleteMessage\\.[^.]+$": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^hint\\.[^.]+$": {

--- a/libs/gui/schemas/src/lib/components/datetimeinput.schema.spec.ts
+++ b/libs/gui/schemas/src/lib/components/datetimeinput.schema.spec.ts
@@ -65,6 +65,7 @@ describe('Datetimeinput schema validation', () => {
               icon: 'schedule',
               hourFormat: '24',
               minuteStep: 15,
+              incompleteMessage: 'Incomplete date-time',
             },
           },
         ],

--- a/libs/gui/schemas/src/lib/components/datetimepicker.schema.json
+++ b/libs/gui/schemas/src/lib/components/datetimepicker.schema.json
@@ -192,6 +192,10 @@
         "noAvailableTimesMessage": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
+        "incompleteMessage": {
+          "$ref": "../common.schema.json#/$defs/localizable",
+          "description": "Error surfaced when focus leaves the widget with a partially filled entry behind; the value goes to null so validators report it even on non-required fields."
+        },
         "hint": {
           "$ref": "#/$defs/hintProp"
         },
@@ -300,6 +304,9 @@
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^noAvailableTimesMessage\\.[^.]+$": {
+          "$ref": "../common.schema.json#/$defs/localizable"
+        },
+        "^incompleteMessage\\.[^.]+$": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^hint\\.[^.]+$": {

--- a/libs/gui/schemas/src/lib/components/datetimepicker.schema.spec.ts
+++ b/libs/gui/schemas/src/lib/components/datetimepicker.schema.spec.ts
@@ -92,6 +92,7 @@ describe('DateTimePicker schema validation', () => {
               maxTimeMessage: { key: 'dtp.max', default: 'Too late' },
               disabledTimeRangeMessage: 'Unavailable slot',
               noAvailableTimesMessage: 'No slots today',
+              incompleteMessage: 'Incomplete date-time',
             },
           },
         ],

--- a/libs/gui/schemas/src/lib/components/rangedateinput.schema.json
+++ b/libs/gui/schemas/src/lib/components/rangedateinput.schema.json
@@ -77,6 +77,10 @@
         "invalidDateMessage": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
+        "incompleteMessage": {
+          "$ref": "../common.schema.json#/$defs/localizable",
+          "description": "Error surfaced when focus leaves the widget with a partially filled entry behind; the value goes to null so validators report it even on non-required fields."
+        },
         "hint": {
           "$ref": "#/$defs/hintProp"
         },
@@ -107,6 +111,9 @@
       },
       "patternProperties": {
         "^invalidDateMessage\\.[^.]+$": {
+          "$ref": "../common.schema.json#/$defs/localizable"
+        },
+        "^incompleteMessage\\.[^.]+$": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^hint\\.[^.]+$": {

--- a/libs/gui/schemas/src/lib/components/rangedateinput.schema.spec.ts
+++ b/libs/gui/schemas/src/lib/components/rangedateinput.schema.spec.ts
@@ -64,6 +64,7 @@ describe('RangeDateInput schema validation', () => {
               removePillAriaLabel: 'Remove date',
               startDateAriaLabel: 'Start date',
               endDateAriaLabel: 'End date',
+              incompleteMessage: 'Incomplete date',
             },
           },
         ],

--- a/libs/gui/schemas/src/lib/components/rangedatepicker.schema.json
+++ b/libs/gui/schemas/src/lib/components/rangedatepicker.schema.json
@@ -131,6 +131,10 @@
         "disabledDateRangeMessage": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
+        "incompleteMessage": {
+          "$ref": "../common.schema.json#/$defs/localizable",
+          "description": "Error surfaced when focus leaves the widget with a partially filled entry behind; the value goes to null so validators report it even on non-required fields."
+        },
         "hint": {
           "$ref": "#/$defs/hintProp"
         },
@@ -212,6 +216,9 @@
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^disabledDateRangeMessage\\.[^.]+$": {
+          "$ref": "../common.schema.json#/$defs/localizable"
+        },
+        "^incompleteMessage\\.[^.]+$": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^hint\\.[^.]+$": {

--- a/libs/gui/schemas/src/lib/components/rangedatepicker.schema.spec.ts
+++ b/libs/gui/schemas/src/lib/components/rangedatepicker.schema.spec.ts
@@ -78,6 +78,7 @@ describe('RangeDatePicker schema validation', () => {
               maxDate: '2025-12-31',
               numberOfMonths: 2,
               disabledRanges: [{ start: '2024-12-25', end: '2025-01-01' }, { start: '2025-07-04' }],
+              incompleteMessage: 'Incomplete date',
             },
           },
         ],

--- a/libs/gui/schemas/src/lib/components/rangedatetimecalendar.schema.json
+++ b/libs/gui/schemas/src/lib/components/rangedatetimecalendar.schema.json
@@ -184,6 +184,10 @@
         "noAvailableTimesMessage": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
+        "incompleteMessage": {
+          "$ref": "../common.schema.json#/$defs/localizable",
+          "description": "Error surfaced when focus leaves the widget with a half-finished range selection behind; the committed pills are untouched, the injected issue alone flags the field."
+        },
         "dayCountAriaLabel": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
@@ -262,6 +266,9 @@
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^noAvailableTimesMessage\\.[^.]+$": {
+          "$ref": "../common.schema.json#/$defs/localizable"
+        },
+        "^incompleteMessage\\.[^.]+$": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^dayCountAriaLabel\\.[^.]+$": {

--- a/libs/gui/schemas/src/lib/components/rangedatetimecalendar.schema.spec.ts
+++ b/libs/gui/schemas/src/lib/components/rangedatetimecalendar.schema.spec.ts
@@ -73,6 +73,7 @@ describe('RangeDateTimeCalendar schema validation', () => {
               disabledRanges: [{ start: '2026-02-17T10:00:00', end: '2026-02-17T12:00:00' }],
               disabledRangeMessage: 'Overlaps a closed period',
               noAvailableTimesMessage: 'No slots',
+              incompleteMessage: 'Incomplete date-time range',
               dayCountAriaLabel: '{count} ranges',
               disabledDayCountAriaLabel: '{count} disabled ranges',
             },

--- a/libs/gui/schemas/src/lib/components/rangedatetimeinput.schema.json
+++ b/libs/gui/schemas/src/lib/components/rangedatetimeinput.schema.json
@@ -137,6 +137,10 @@
         "maxDateTimeMessage": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
+        "incompleteMessage": {
+          "$ref": "../common.schema.json#/$defs/localizable",
+          "description": "Error surfaced when focus leaves the widget with a partially filled entry behind; the value goes to null so validators report it even on non-required fields."
+        },
         "dayAriaLabel": {
           "$ref": "#/$defs/dayAriaLabelProp"
         },
@@ -194,6 +198,9 @@
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^maxDateTimeMessage\\.[^.]+$": {
+          "$ref": "../common.schema.json#/$defs/localizable"
+        },
+        "^incompleteMessage\\.[^.]+$": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^dayAriaLabel\\.[^.]+$": {

--- a/libs/gui/schemas/src/lib/components/rangedatetimeinput.schema.spec.ts
+++ b/libs/gui/schemas/src/lib/components/rangedatetimeinput.schema.spec.ts
@@ -75,6 +75,7 @@ describe('RangeDateTimeInput schema validation', () => {
               maxDateTime: '2026-12-31T18:00:00',
               minDateTimeMessage: 'Too early',
               maxDateTimeMessage: 'Too late',
+              incompleteMessage: 'Incomplete date-time',
             },
           },
         ],

--- a/libs/gui/schemas/src/lib/components/rangedatetimepicker.schema.json
+++ b/libs/gui/schemas/src/lib/components/rangedatetimepicker.schema.json
@@ -256,6 +256,10 @@
         "noAvailableTimesMessage": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
+        "incompleteMessage": {
+          "$ref": "../common.schema.json#/$defs/localizable",
+          "description": "Error surfaced when focus leaves the widget with a partially filled entry behind; the value goes to null so validators report it even on non-required fields."
+        },
         "dayCountAriaLabel": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
@@ -370,6 +374,9 @@
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^noAvailableTimesMessage\\.[^.]+$": {
+          "$ref": "../common.schema.json#/$defs/localizable"
+        },
+        "^incompleteMessage\\.[^.]+$": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^dayCountAriaLabel\\.[^.]+$": {

--- a/libs/gui/schemas/src/lib/components/rangedatetimepicker.schema.spec.ts
+++ b/libs/gui/schemas/src/lib/components/rangedatetimepicker.schema.spec.ts
@@ -85,6 +85,7 @@ describe('RangeDateTimePicker schema validation', () => {
               disabledRanges: [{ start: '2026-02-17T10:00:00', end: '2026-02-17T12:00:00' }],
               disabledRangeMessage: 'Overlaps a closed period',
               noAvailableTimesMessage: 'No slots',
+              incompleteMessage: 'Incomplete date-time',
               dayCountAriaLabel: '{count} ranges',
               disabledDayCountAriaLabel: '{count} disabled ranges',
             },

--- a/libs/gui/schemas/src/lib/components/rangetimeinput.schema.json
+++ b/libs/gui/schemas/src/lib/components/rangetimeinput.schema.json
@@ -124,6 +124,10 @@
         "rangeOrderMessage": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
+        "incompleteMessage": {
+          "$ref": "../common.schema.json#/$defs/localizable",
+          "description": "Error surfaced when focus leaves the widget with a partially filled entry behind; the value goes to null so validators report it even on non-required fields."
+        },
         "hourAriaLabel": {
           "$ref": "#/$defs/hourAriaLabelProp"
         },
@@ -172,6 +176,9 @@
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^rangeOrderMessage\\.[^.]+$": {
+          "$ref": "../common.schema.json#/$defs/localizable"
+        },
+        "^incompleteMessage\\.[^.]+$": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^hourAriaLabel\\.[^.]+$": {

--- a/libs/gui/schemas/src/lib/components/rangetimeinput.schema.spec.ts
+++ b/libs/gui/schemas/src/lib/components/rangetimeinput.schema.spec.ts
@@ -71,6 +71,7 @@ describe('RangeTimeInput schema validation', () => {
               minTimeMessage: 'Too early',
               maxTimeMessage: 'Too late',
               rangeOrderMessage: 'End time must be after start time',
+              incompleteMessage: 'Incomplete time',
             },
           },
         ],

--- a/libs/gui/schemas/src/lib/components/rangetimepicker.schema.json
+++ b/libs/gui/schemas/src/lib/components/rangetimepicker.schema.json
@@ -173,6 +173,10 @@
         "noAvailableTimesMessage": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
+        "incompleteMessage": {
+          "$ref": "../common.schema.json#/$defs/localizable",
+          "description": "Error surfaced when focus leaves the widget with a partially filled entry behind; the value goes to null so validators report it even on non-required fields."
+        },
         "toggleAriaLabel": {
           "$ref": "#/$defs/toggleAriaLabelProp"
         },
@@ -248,6 +252,9 @@
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^noAvailableTimesMessage\\.[^.]+$": {
+          "$ref": "../common.schema.json#/$defs/localizable"
+        },
+        "^incompleteMessage\\.[^.]+$": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^toggleAriaLabel\\.[^.]+$": {

--- a/libs/gui/schemas/src/lib/components/rangetimepicker.schema.spec.ts
+++ b/libs/gui/schemas/src/lib/components/rangetimepicker.schema.spec.ts
@@ -78,6 +78,7 @@ describe('RangeTimePicker schema validation', () => {
               itemHeight: 36,
               disabledRangeMessage: 'That slot is unavailable',
               noAvailableTimesMessage: 'No times available',
+              incompleteMessage: 'Incomplete time',
             },
           },
         ],

--- a/libs/gui/schemas/src/lib/components/timeinput.schema.json
+++ b/libs/gui/schemas/src/lib/components/timeinput.schema.json
@@ -99,6 +99,10 @@
         "maxTimeMessage": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
+        "incompleteMessage": {
+          "$ref": "../common.schema.json#/$defs/localizable",
+          "description": "Error surfaced when focus leaves the widget with a partially filled entry behind; the value goes to null so validators report it even on non-required fields."
+        },
         "hourAriaLabel": {
           "$ref": "#/$defs/hourAriaLabelProp"
         },
@@ -132,6 +136,9 @@
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^maxTimeMessage\\.[^.]+$": {
+          "$ref": "../common.schema.json#/$defs/localizable"
+        },
+        "^incompleteMessage\\.[^.]+$": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^hourAriaLabel\\.[^.]+$": {

--- a/libs/gui/schemas/src/lib/components/timeinput.schema.spec.ts
+++ b/libs/gui/schemas/src/lib/components/timeinput.schema.spec.ts
@@ -62,6 +62,7 @@ describe('Timeinput schema validation', () => {
               icon: 'schedule',
               hourFormat: '24',
               minuteStep: 15,
+              incompleteMessage: 'Incomplete time',
             },
           },
         ],

--- a/libs/gui/schemas/src/lib/components/timepicker.schema.json
+++ b/libs/gui/schemas/src/lib/components/timepicker.schema.json
@@ -110,6 +110,10 @@
         "noAvailableTimesMessage": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
+        "incompleteMessage": {
+          "$ref": "../common.schema.json#/$defs/localizable",
+          "description": "Error surfaced when focus leaves the widget with a partially filled entry behind; the value goes to null so validators report it even on non-required fields."
+        },
         "hint": {
           "$ref": "#/$defs/hintProp"
         },
@@ -164,6 +168,9 @@
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^noAvailableTimesMessage\\.[^.]+$": {
+          "$ref": "../common.schema.json#/$defs/localizable"
+        },
+        "^incompleteMessage\\.[^.]+$": {
           "$ref": "../common.schema.json#/$defs/localizable"
         },
         "^hint\\.[^.]+$": {

--- a/libs/gui/schemas/src/lib/components/timepicker.schema.spec.ts
+++ b/libs/gui/schemas/src/lib/components/timepicker.schema.spec.ts
@@ -73,6 +73,7 @@ describe('Timepicker schema validation', () => {
               maxTimeMessage: { key: 'tp.max', default: 'Too late' },
               disabledRangeMessage: 'Unavailable slot',
               noAvailableTimesMessage: 'No slots today',
+              incompleteMessage: 'Incomplete time',
             },
           },
         ],

--- a/libs/gui/shared/src/lib/widget.props.ts
+++ b/libs/gui/shared/src/lib/widget.props.ts
@@ -472,7 +472,8 @@ export type RangeDatePickerProps = RangeCalendarProps &
 export type RangeDateTimeCalendarProps = Omit<
   RangeCalendarProps,
   'minDate' | 'maxDate' | 'disabledRanges' | 'disabledDateRangeMessage'
-> & {
+> &
+  IncompleteMessageProps & {
   hourFormat?: '12' | '24';
   minuteStep?: number;
   /** Allows typing a time in each picker; when false (default) times come only from the grid. */

--- a/libs/gui/shared/src/lib/widget.props.ts
+++ b/libs/gui/shared/src/lib/widget.props.ts
@@ -210,13 +210,19 @@ export type CalendarProps = {
   numberOfMonths?: number;
 };
 
+/** Shared by every typed date/time widget that can be left half-filled. */
+export type IncompleteMessageProps = {
+  incompleteMessage?: Localizable;
+};
+
 /**
  * Calendar with an embedded time picker. The value is a local ISO date-time
  * (YYYY-MM-DDTHH:mm:ss), emitted only when both the day and the time are
  * selected; picking a different day clears the time and emits null. With
  * numberOfMonths > 1 the time row and grid render on the first panel only.
  */
-export type DateTimeCalendarProps = CalendarProps & {
+export type DateTimeCalendarProps = CalendarProps &
+  IncompleteMessageProps & {
   /** '12' or '24'. Defaults to the locale's hour cycle. */
   hourFormat?: '12' | '24';
   /** Minutes between selectable slots. Defaults to 30. */
@@ -340,7 +346,7 @@ export type RangeCalendarProps = {
   removePillAriaLabel?: string;
 };
 
-export type DateinputProps = {
+export type DateinputProps = IncompleteMessageProps & {
   hint?: string;
   icon?: string;
   dayAriaLabel?: string;
@@ -355,7 +361,7 @@ export type DateinputProps = {
   maxDateMessage?: Localizable;
 };
 
-export type DateTimeInputProps = {
+export type DateTimeInputProps = IncompleteMessageProps & {
   hint?: string;
   icon?: string;
   dayAriaLabel?: string;
@@ -381,7 +387,7 @@ export type DateTimeInputProps = {
   maxTimeMessage?: Localizable;
 };
 
-export type TimeInputProps = {
+export type TimeInputProps = IncompleteMessageProps & {
   hint?: string;
   icon?: string;
   hourAriaLabel?: string;
@@ -424,7 +430,7 @@ export type TimePickerProps = TimeInputProps &
     noAvailableTimesMessage?: Localizable;
   };
 
-export type RangeDateInputProps = {
+export type RangeDateInputProps = IncompleteMessageProps & {
   hint?: string;
   icon?: string;
   separator?: string;
@@ -500,7 +506,7 @@ export type RangeDateTimeCalendarProps = Omit<
   disabledDayCountAriaLabel?: Localizable;
 };
 
-export type RangeTimeInputProps = {
+export type RangeTimeInputProps = IncompleteMessageProps & {
   hint?: string;
   icon?: string;
   separator?: string;
@@ -522,7 +528,7 @@ export type RangeTimeInputProps = {
   rangeOrderMessage?: Localizable;
 };
 
-export type RangeDateTimeInputProps = {
+export type RangeDateTimeInputProps = IncompleteMessageProps & {
   hint?: string;
   icon?: string;
   separator?: string;

--- a/libs/gui/vue/src/lib/components/DateInput.vue
+++ b/libs/gui/vue/src/lib/components/DateInput.vue
@@ -74,6 +74,7 @@ onUnmounted(() => {
       :maxDate="templateData.maxDate"
       :minDateMessage="templateData.minDateMessage"
       :maxDateMessage="templateData.maxDateMessage"
+      :incompleteMessage="templateData.incompleteMessage"
     />
   </div>
 </template>

--- a/libs/gui/vue/src/lib/components/DatePicker.vue
+++ b/libs/gui/vue/src/lib/components/DatePicker.vue
@@ -91,6 +91,7 @@ onUnmounted(() => {
       :minDateMessage="templateData.minDateMessage"
       :maxDateMessage="templateData.maxDateMessage"
       :disabledDateRangeMessage="templateData.disabledDateRangeMessage"
+      :incompleteMessage="templateData.incompleteMessage"
     />
   </div>
 </template>

--- a/libs/gui/vue/src/lib/components/DateTimeCalendar.vue
+++ b/libs/gui/vue/src/lib/components/DateTimeCalendar.vue
@@ -95,6 +95,7 @@ onUnmounted(() => {
       :maxTimeMessage="templateData.maxTimeMessage"
       :disabledTimeRangeMessage="templateData.disabledTimeRangeMessage"
       :noAvailableTimesMessage="templateData.noAvailableTimesMessage"
+      :incompleteMessage="templateData.incompleteMessage"
     />
   </div>
 </template>

--- a/libs/gui/vue/src/lib/components/DateTimeInput.vue
+++ b/libs/gui/vue/src/lib/components/DateTimeInput.vue
@@ -81,6 +81,7 @@ onUnmounted(() => {
       :maxDateMessage="templateData.maxDateMessage"
       :minTimeMessage="templateData.minTimeMessage"
       :maxTimeMessage="templateData.maxTimeMessage"
+      :incompleteMessage="templateData.incompleteMessage"
       :hourFormat="templateData.hourFormat"
       :minuteStep="templateData.minuteStep ?? 1"
     />

--- a/libs/gui/vue/src/lib/components/DateTimePicker.vue
+++ b/libs/gui/vue/src/lib/components/DateTimePicker.vue
@@ -105,6 +105,7 @@ onUnmounted(() => {
       :maxTimeMessage="templateData.maxTimeMessage"
       :disabledTimeRangeMessage="templateData.disabledTimeRangeMessage"
       :noAvailableTimesMessage="templateData.noAvailableTimesMessage"
+      :incompleteMessage="templateData.incompleteMessage"
     />
   </div>
 </template>

--- a/libs/gui/vue/src/lib/components/RangeDateInput.vue
+++ b/libs/gui/vue/src/lib/components/RangeDateInput.vue
@@ -71,6 +71,7 @@ onUnmounted(() => {
       :monthAriaLabel="templateData.monthAriaLabel"
       :yearAriaLabel="templateData.yearAriaLabel"
       :invalidDateMessage="templateData.invalidDateMessage"
+      :incompleteMessage="templateData.incompleteMessage"
       :separator="templateData.separator"
       :removePillAriaLabel="templateData.removePillAriaLabel"
       :startDateAriaLabel="templateData.startDateAriaLabel"

--- a/libs/gui/vue/src/lib/components/RangeDatePicker.vue
+++ b/libs/gui/vue/src/lib/components/RangeDatePicker.vue
@@ -96,6 +96,7 @@ onUnmounted(() => {
       :minDateMessage="templateData.minDateMessage"
       :maxDateMessage="templateData.maxDateMessage"
       :disabledDateRangeMessage="templateData.disabledDateRangeMessage"
+      :incompleteMessage="templateData.incompleteMessage"
     />
   </div>
 </template>

--- a/libs/gui/vue/src/lib/components/RangeDateTimeCalendar.vue
+++ b/libs/gui/vue/src/lib/components/RangeDateTimeCalendar.vue
@@ -94,6 +94,7 @@ onUnmounted(() => {
       :maxDateTimeMessage="templateData.maxDateTimeMessage"
       :disabledRangeMessage="templateData.disabledRangeMessage"
       :noAvailableTimesMessage="templateData.noAvailableTimesMessage"
+      :incompleteMessage="templateData.incompleteMessage"
       :dayCountAriaLabel="templateData.dayCountAriaLabel"
       :disabledDayCountAriaLabel="templateData.disabledDayCountAriaLabel"
     />

--- a/libs/gui/vue/src/lib/components/RangeDateTimeInput.vue
+++ b/libs/gui/vue/src/lib/components/RangeDateTimeInput.vue
@@ -84,6 +84,7 @@ onUnmounted(() => {
       :invalidDateMessage="templateData.invalidDateMessage"
       :minDateTimeMessage="templateData.minDateTimeMessage"
       :maxDateTimeMessage="templateData.maxDateTimeMessage"
+      :incompleteMessage="templateData.incompleteMessage"
     />
   </div>
 </template>

--- a/libs/gui/vue/src/lib/components/RangeDateTimePicker.vue
+++ b/libs/gui/vue/src/lib/components/RangeDateTimePicker.vue
@@ -106,6 +106,7 @@ onUnmounted(() => {
       :maxDateTimeMessage="templateData.maxDateTimeMessage"
       :disabledRangeMessage="templateData.disabledRangeMessage"
       :noAvailableTimesMessage="templateData.noAvailableTimesMessage"
+      :incompleteMessage="templateData.incompleteMessage"
       :dayCountAriaLabel="templateData.dayCountAriaLabel"
       :disabledDayCountAriaLabel="templateData.disabledDayCountAriaLabel"
     />

--- a/libs/gui/vue/src/lib/components/RangeTimeInput.vue
+++ b/libs/gui/vue/src/lib/components/RangeTimeInput.vue
@@ -81,6 +81,7 @@ onUnmounted(() => {
       :minTimeMessage="templateData.minTimeMessage"
       :maxTimeMessage="templateData.maxTimeMessage"
       :rangeOrderMessage="templateData.rangeOrderMessage"
+      :incompleteMessage="templateData.incompleteMessage"
     />
   </div>
 </template>

--- a/libs/gui/vue/src/lib/components/RangeTimePicker.vue
+++ b/libs/gui/vue/src/lib/components/RangeTimePicker.vue
@@ -89,6 +89,7 @@ onUnmounted(() => {
       :rangeOrderMessage="templateData.rangeOrderMessage"
       :disabledRangeMessage="templateData.disabledRangeMessage"
       :noAvailableTimesMessage="templateData.noAvailableTimesMessage"
+      :incompleteMessage="templateData.incompleteMessage"
     />
   </div>
 </template>

--- a/libs/gui/vue/src/lib/components/TimeInput.vue
+++ b/libs/gui/vue/src/lib/components/TimeInput.vue
@@ -75,6 +75,7 @@ onUnmounted(() => {
       :maxTime="templateData.maxTime"
       :minTimeMessage="templateData.minTimeMessage"
       :maxTimeMessage="templateData.maxTimeMessage"
+      :incompleteMessage="templateData.incompleteMessage"
     />
   </div>
 </template>

--- a/libs/gui/vue/src/lib/components/TimePicker.vue
+++ b/libs/gui/vue/src/lib/components/TimePicker.vue
@@ -82,6 +82,7 @@ onUnmounted(() => {
       :maxTimeMessage="templateData.maxTimeMessage"
       :disabledRangeMessage="templateData.disabledRangeMessage"
       :noAvailableTimesMessage="templateData.noAvailableTimesMessage"
+      :incompleteMessage="templateData.incompleteMessage"
     />
   </div>
 </template>

--- a/libs/ui-testing/src/lib/gui-features/dateinput.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/dateinput.cy.ts
@@ -123,9 +123,10 @@ export const runDateInputComponentTests = (mountFn: MountComponentFn) => {
         cy.get(sel.month).should('have.value', '12');
       });
 
-      it('should clear all parts when 00 is typed (zero commits as an empty value)', () => {
-        // Typing 00 clamps to 01 in state, but the blur handler sees the raw 0,
-        // emits change {value: null}, and the null value resets every part.
+      it('should clear the part when 00 is typed without emitting a value', () => {
+        // Typing 00 clamps to 01 in state, but the blur handler sees the raw 0
+        // and clears the part. With no previously committed value nothing is
+        // emitted: the value stays undefined ("not filled in yet").
         const formSubmitHandler = cy.stub().as('formSubmitHandler');
         mountDateInput({ formSubmit: formSubmitHandler });
 
@@ -133,7 +134,7 @@ export const runDateInputComponentTests = (mountFn: MountComponentFn) => {
         cy.get(sel.month).should('have.value', '');
 
         submitAndGetData('@formSubmitHandler').then((data) => {
-          expect(data).to.deep.equal({ myDate: null });
+          expect(data.myDate).to.equal(undefined);
         });
       });
 
@@ -261,15 +262,82 @@ export const runDateInputComponentTests = (mountFn: MountComponentFn) => {
         cy.get(sel.day).invoke('val').should('match', /^0?9$/);
       });
 
-      it('should emit a null value when a part is emptied and blurred', () => {
-        const formSubmitHandler = cy.stub().as('formSubmitHandler');
-        mountDateInput({ data: { myDate: '2026-06-15' }, formSubmit: formSubmitHandler });
+      it('should emit a null value and keep the other parts when one part is emptied', () => {
+        mountDateInput({ data: { myDate: '2026-06-15' } });
+
+        const changeSpy = cy.spy().as('changeSpy');
+        cy.get('gui-date').then(($el) => {
+          $el[0].addEventListener('change', changeSpy as unknown as EventListener);
+        });
 
         cy.get(sel.day).type('{selectAll}{backspace}');
         cy.get(sel.day).blur();
 
+        cy.get('@changeSpy').then((spy: any) => {
+          expect(spy.getCall(0).args[0].detail.value).to.equal(null);
+        });
+
+        // Only the emptied part clears: the rest of the entry is not wiped
+        cy.get(sel.day).should('have.value', '');
+        cy.get(sel.month).should('have.value', '06');
+        cy.get(sel.year).should('have.value', '2026');
+      });
+    });
+
+    describe('incomplete input on focus leave', () => {
+      it('should flip a partial date to null with an incomplete error when focus leaves', () => {
+        mountDateInput();
+
+        const changeSpy = cy.spy().as('changeSpy');
+        cy.get('gui-date').then(($el) => {
+          $el[0].addEventListener('change', changeSpy as unknown as EventListener);
+        });
+
+        cy.get(sel.month).type('06');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+
+        // The null report marks the field invalid, so validators catch a
+        // lingering partial even on non-required fields
+        cy.get(`[data-cy="${uid}_validator-error"]`).should('contain.text', 'Incomplete date');
+        cy.get('@changeSpy').then((spy: any) => {
+          expect(spy.getCall(0).args[0].detail.value).to.equal(null);
+        });
+      });
+
+      it('should clear the incomplete error once the date is completed', () => {
+        mountDateInput();
+
+        cy.get(sel.month).type('06');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get(`[data-cy="${uid}_validator-error"]`).should('contain.text', 'Incomplete date');
+
+        cy.get(sel.day).type('15');
+        cy.focused().type('2026');
+        cy.get(`[data-cy="${uid}_validator-error"]`).should('not.exist');
+      });
+
+      it('should show the incomplete error for a committed value left with an emptied part', () => {
+        mountDateInput({ data: { myDate: '2026-06-15' } });
+
+        cy.get(sel.day).type('{selectAll}{backspace}');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+
+        cy.get(`[data-cy="${uid}_validator-error"]`).should('contain.text', 'Incomplete date');
+        cy.get(sel.month).should('have.value', '06');
+        cy.get(sel.year).should('have.value', '2026');
+      });
+
+      it('should not report an emptied widget as incomplete on focus leave', () => {
+        const formSubmitHandler = cy.stub().as('formSubmitHandler');
+        mountDateInput({ formSubmit: formSubmitHandler });
+
+        cy.get(sel.month).type('06');
+        cy.get(sel.month).type('{selectAll}{backspace}');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+
+        cy.get(`[data-cy="${uid}_validator-error"]`).should('not.exist');
         submitAndGetData('@formSubmitHandler').then((data) => {
-          expect(data).to.deep.equal({ myDate: null });
+          expect(data.myDate ?? null).to.equal(null);
         });
       });
     });

--- a/libs/ui-testing/src/lib/gui-features/dateinput.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/dateinput.cy.ts
@@ -17,6 +17,7 @@ export const runDateInputComponentTests = (mountFn: MountComponentFn) => {
       data?: Record<string, any>;
       lang?: string;
       props?: Record<string, any>;
+      validator?: Record<string, any>;
       formSubmit?: (event: any) => void;
       readonly?: boolean;
       disabled?: boolean;
@@ -32,6 +33,7 @@ export const runDateInputComponentTests = (mountFn: MountComponentFn) => {
               type: 'dateInput',
               path: 'myDate',
               ...(options?.props ? { props: options.props } : {}),
+              ...(options?.validator ? { validator: options.validator as any } : {}),
               ...(options?.readonly !== undefined ? { readonly: options.readonly } : {}),
               ...(options?.disabled !== undefined ? { disabled: options.disabled } : {}),
             },
@@ -157,6 +159,8 @@ export const runDateInputComponentTests = (mountFn: MountComponentFn) => {
         cy.focused().type('31');
         cy.focused().type('2026');
 
+        // The widget's own verdict shows without waiting for focus to leave:
+        // it is feedback on a complete entry the user just typed
         cy.get(`[data-cy="${uid}_validator-error"]`).should('contain.text', 'Invalid date');
         cy.get('@changeSpy').should('not.have.been.called');
       });
@@ -285,6 +289,22 @@ export const runDateInputComponentTests = (mountFn: MountComponentFn) => {
     });
 
     describe('incomplete input on focus leave', () => {
+      it('should not validate while moving between the parts of one entry', () => {
+        // Filling a part auto-advances to the next one. That hop is not
+        // leaving the widget, so the form must not judge a half-typed entry:
+        // a required field lighting up after the first part is the bug.
+        mountDateInput({ validator: { type: 'string', required: true } });
+
+        cy.get(sel.month).type('06');
+        cy.get(`[data-cy="${uid}_validator-errors"]`).should('not.exist');
+        cy.focused().type('15');
+        cy.get(`[data-cy="${uid}_validator-errors"]`).should('not.exist');
+
+        // Leaving the widget is the one moment the entry is judged
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get(`[data-cy="${uid}_validator-errors"]`).should('exist');
+      });
+
       it('should flip a partial date to null with an incomplete error when focus leaves', () => {
         mountDateInput();
 

--- a/libs/ui-testing/src/lib/gui-features/dateinput.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/dateinput.cy.ts
@@ -360,6 +360,30 @@ export const runDateInputComponentTests = (mountFn: MountComponentFn) => {
           expect(data.myDate ?? null).to.equal(null);
         });
       });
+
+      it('should clear the incomplete error when the emptied widget is left again', () => {
+        // Regression: leave a partial behind (incomplete error), come back,
+        // empty the field and leave again — the error must not outlive
+        // fields that no longer hold anything.
+        mountDateInput();
+
+        cy.get(sel.month).type('06');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get(`[data-cy="${uid}_validator-error"]`).should('contain.text', 'Incomplete date');
+
+        cy.get(sel.month).type('{selectAll}{backspace}');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get(`[data-cy="${uid}_validator-errors"]`).should('not.exist');
+      });
+
+      it('should honor the incompleteMessage prop', () => {
+        mountDateInput({ props: { incompleteMessage: 'Incomplete date!' } });
+
+        cy.get(sel.month).type('06');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+
+        cy.get(`[data-cy="${uid}_validator-error"]`).should('contain.text', 'Incomplete date!');
+      });
     });
 
     describe('readonly and disabled', () => {

--- a/libs/ui-testing/src/lib/gui-features/datepicker.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/datepicker.cy.ts
@@ -196,6 +196,55 @@ export const runDatePickerComponentTests = (mountFn: MountComponentFn) => {
       });
     });
 
+    describe('incomplete input on focus leave', () => {
+      it('should flip a partial typed date to null with an incomplete error when focus leaves', () => {
+        // Non-required field: the null report still marks it invalid, so the
+        // lingering partial is caught without a required validator
+        mountWithProps({});
+
+        cy.get('gui-date input[data-type="month"]').click();
+        cy.focused().type('06');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+
+        cy.get('[data-cy="testSubject_validator-error"]').should(
+          'contain.text',
+          'Incomplete date',
+        );
+      });
+
+      it('should clear the incomplete error when the emptied picker is left again', () => {
+        // Regression: leave a partial behind (incomplete error), come back,
+        // empty the field and leave again — the error must not outlive
+        // fields that no longer hold anything.
+        mountWithProps({});
+
+        cy.get('gui-date input[data-type="month"]').click();
+        cy.focused().type('06');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get('[data-cy="testSubject_validator-error"]').should(
+          'contain.text',
+          'Incomplete date',
+        );
+
+        cy.get('gui-date input[data-type="month"]').type('{selectAll}{backspace}');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get('[data-cy="testSubject_validator-errors"]').should('not.exist');
+      });
+
+      it('should honor the incompleteMessage prop', () => {
+        mountWithProps({ props: { incompleteMessage: 'Incomplete date!' } });
+
+        cy.get('gui-date input[data-type="month"]').click();
+        cy.focused().type('06');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+
+        cy.get('[data-cy="testSubject_validator-error"]').should(
+          'contain.text',
+          'Incomplete date!',
+        );
+      });
+    });
+
     describe('accessibility', () => {
       const toggleSel = 'button.gui-date-picker__arrow';
 

--- a/libs/ui-testing/src/lib/gui-features/datetimecalendar.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/datetimecalendar.cy.ts
@@ -394,6 +394,41 @@ export const runDateTimeCalendarComponentTests = (mountFn: MountComponentFn) => 
           expect(spy.getCall(0).args[0].detail.message).to.equal('Office opens at 9');
         });
       });
+
+      it('should report a half-typed time with no day as incomplete when focus leaves', () => {
+        // A partial time never emits, so it lives only in the input's parts:
+        // the leave check must still count it as something left behind.
+        mountCalendar({
+          data: { myAppointment: null },
+          props: { ...officeProps, hourFormat: '24', allowCustomTime: true },
+        });
+
+        cy.get(sel.hour).type('10');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+
+        cy.get('[data-cy="testSubject_validator-error"]').should(
+          'contain.text',
+          'Incomplete date-time',
+        );
+      });
+
+      it('should clear the incomplete error when the emptied time is left again', () => {
+        mountCalendar({
+          data: { myAppointment: null },
+          props: { ...officeProps, hourFormat: '24', allowCustomTime: true },
+        });
+
+        cy.get(sel.hour).type('10');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get('[data-cy="testSubject_validator-error"]').should(
+          'contain.text',
+          'Incomplete date-time',
+        );
+
+        cy.get(sel.hour).type('{selectAll}{backspace}', { force: true });
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get('[data-cy="testSubject_validator-errors"]').should('not.exist');
+      });
     });
 
     describe('empty time window', () => {

--- a/libs/ui-testing/src/lib/gui-features/datetimecalendar.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/datetimecalendar.cy.ts
@@ -74,11 +74,11 @@ export const runDateTimeCalendarComponentTests = (mountFn: MountComponentFn) => 
     const option = (isoTime: string) => cy.get(`${sel.options}[data-value="${isoTime}"]`);
 
     describe('rendering and hydration', () => {
-      it('should render the days grid and a disabled time input when empty', () => {
+      it('should render the days grid and an enabled time input when empty', () => {
         mountCalendar({ props: officeProps });
 
         cy.get(sel.daysGrid).should('exist');
-        cy.get(sel.hour).should('be.disabled');
+        cy.get(sel.hour).should('not.be.disabled');
         cy.get(sel.timeGrid).should('have.attr', 'hidden');
       });
 
@@ -93,7 +93,7 @@ export const runDateTimeCalendarComponentTests = (mountFn: MountComponentFn) => 
     });
 
     describe('day and time selection flow', () => {
-      it('should enable the time input on day selection and keep the value null', () => {
+      it('should keep the value null after a day-only selection', () => {
         const formSubmitHandler = cy.stub().as('formSubmitHandler');
         mountCalendar({
           data: { myAppointment: null },
@@ -107,6 +107,41 @@ export const runDateTimeCalendarComponentTests = (mountFn: MountComponentFn) => 
         submitAndGetData('@formSubmitHandler').then((data) => {
           expect(data).to.deep.equal({ myAppointment: null });
         });
+      });
+
+      it('should keep a time picked before any day and commit once a day is selected', () => {
+        const formSubmitHandler = cy.stub().as('formSubmitHandler');
+        mountCalendar({
+          data: { myAppointment: null },
+          props: officeProps,
+          formSubmit: formSubmitHandler,
+        });
+
+        // The time input is enabled with no day selected: the pick is parked
+        cy.get(sel.hour).click();
+        option('10:00:00').click();
+        cy.get(sel.hour).should('have.value', '10');
+
+        firstAvailableDay().then(($btn) => {
+          const isoDate = $btn.attr('data-date') as string;
+          cy.wrap($btn).click();
+
+          submitAndGetData('@formSubmitHandler').then((data) => {
+            expect(data).to.deep.equal({ myAppointment: `${isoDate}T10:00:00` });
+          });
+        });
+      });
+
+      it('should flip a day-only selection to null with an incomplete error when focus leaves', () => {
+        mountCalendar({ data: { myAppointment: null }, props: officeProps });
+
+        firstAvailableDay().click();
+        cy.get('[data-cy="submitBtn_button"]').focus();
+
+        cy.get('[data-cy="testSubject_validator-error"]').should(
+          'contain.text',
+          'Incomplete date-time',
+        );
       });
 
       it('should open the time grid in place of the days grid when the time input is focused', () => {
@@ -145,7 +180,7 @@ export const runDateTimeCalendarComponentTests = (mountFn: MountComponentFn) => 
         });
       });
 
-      it('should clear the time and emit null when a different day is selected', () => {
+      it('should keep the time and commit the new full value when a different day is selected', () => {
         const formSubmitHandler = cy.stub().as('formSubmitHandler');
         mountCalendar({
           data: { myAppointment: '2026-02-13T09:30:00' },
@@ -155,11 +190,11 @@ export const runDateTimeCalendarComponentTests = (mountFn: MountComponentFn) => 
 
         day('2026-02-16').click();
 
-        cy.get(sel.hour).should('have.value', '');
-        cy.get(sel.minute).should('have.value', '');
+        cy.get(sel.hour).should('have.value', '09');
+        cy.get(sel.minute).should('have.value', '30');
 
         submitAndGetData('@formSubmitHandler').then((data) => {
-          expect(data).to.deep.equal({ myAppointment: null });
+          expect(data).to.deep.equal({ myAppointment: '2026-02-16T09:30:00' });
         });
       });
 
@@ -227,7 +262,7 @@ export const runDateTimeCalendarComponentTests = (mountFn: MountComponentFn) => 
 
       it('should reject a typed time inside a day-scoped range with inputError', () => {
         // Hydrate a Monday so the view shows February, then move to the
-        // scoped 13th (clearing the time) and type into the empty parts
+        // scoped 13th — the 11:00 time is kept and stays in the parts
         mountCalendar({
           data: { myAppointment: '2026-02-16T11:00:00' },
           props: {
@@ -239,15 +274,15 @@ export const runDateTimeCalendarComponentTests = (mountFn: MountComponentFn) => 
         });
 
         day('2026-02-13').click();
-        cy.get(sel.hour).should('have.value', '');
+        cy.get(sel.hour).should('have.value', '11');
 
         const inputErrorSpy = cy.spy().as('inputErrorSpy');
         cy.get('gui-date-time-calendar').then(($el) => {
           $el[0].addEventListener('inputError', inputErrorSpy as unknown as EventListener);
         });
 
-        cy.get(sel.hour).type('09');
-        cy.focused().type('30', { force: true });
+        cy.get(sel.hour).type('{selectAll}09');
+        cy.focused().type('{selectAll}30', { force: true });
 
         cy.get('@inputErrorSpy').then((spy: any) => {
           expect(spy.getCall(0).args[0].detail.message).to.contain('disabled range');
@@ -264,7 +299,8 @@ export const runDateTimeCalendarComponentTests = (mountFn: MountComponentFn) => 
 
       it('should close the open grid with Enter after typing a custom time', () => {
         const formSubmitHandler = cy.stub().as('formSubmitHandler');
-        // Move to a different day first so the parts are empty for typing
+        // Moving to a different day keeps the 09:30 time, so the typed time
+        // overwrites the kept parts
         mountCalendar({
           data: { myAppointment: '2026-02-16T09:30:00' },
           props: { ...officeProps, hourFormat: '24', allowCustomTime: true },
@@ -275,8 +311,8 @@ export const runDateTimeCalendarComponentTests = (mountFn: MountComponentFn) => 
         cy.get(sel.hour).click();
         cy.get(sel.openTimeGrid).should('exist');
 
-        cy.get(sel.hour).type('10');
-        cy.focused().type('30', { force: true });
+        cy.get(sel.hour).type('{selectAll}10');
+        cy.focused().type('{selectAll}30', { force: true });
         cy.focused().type('{enter}', { force: true });
 
         cy.get(sel.timeGrid).should('have.attr', 'hidden');

--- a/libs/ui-testing/src/lib/gui-features/datetimeinput.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/datetimeinput.cy.ts
@@ -391,6 +391,25 @@ export const runDateTimeInputComponentTests = (mountFn: MountComponentFn) => {
         cy.focused().type('30', { force: true });
         cy.get('[data-cy="testSubject_validator-error"]').should('not.exist');
       });
+
+      it('should clear the incomplete error when the emptied widget is left again', () => {
+        // Regression: leave a partial behind (incomplete error), come back,
+        // empty the field and leave again — the error must not outlive
+        // fields that no longer hold anything.
+        mountDateTimeInput();
+
+        cy.get(sel.month).click();
+        cy.focused().type('06');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get('[data-cy="testSubject_validator-error"]').should(
+          'contain.text',
+          'Incomplete date-time',
+        );
+
+        cy.get(sel.month).type('{selectAll}{backspace}');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get('[data-cy="testSubject_validator-errors"]').should('not.exist');
+      });
     });
 
     describe('readonly and disabled', () => {

--- a/libs/ui-testing/src/lib/gui-features/datetimeinput.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/datetimeinput.cy.ts
@@ -17,6 +17,7 @@ export const runDateTimeInputComponentTests = (mountFn: MountComponentFn) => {
       lang?: string;
       translator?: MutableI18nTranslator;
       props?: Record<string, any>;
+      validator?: Record<string, any>;
       formSubmit?: (event: any) => void;
       readonly?: boolean;
       disabled?: boolean;
@@ -32,6 +33,7 @@ export const runDateTimeInputComponentTests = (mountFn: MountComponentFn) => {
               type: 'dateTimeInput',
               path: 'myDateTime',
               ...(options?.props ? { props: options.props } : {}),
+              ...(options?.validator ? { validator: options.validator as any } : {}),
               ...(options?.readonly !== undefined ? { readonly: options.readonly } : {}),
               ...(options?.disabled !== undefined ? { disabled: options.disabled } : {}),
             },
@@ -317,6 +319,23 @@ export const runDateTimeInputComponentTests = (mountFn: MountComponentFn) => {
     });
 
     describe('incomplete input on focus leave', () => {
+      it('should not validate while moving between the parts of one entry', () => {
+        // Filling a part auto-advances to the next one. That hop is not
+        // leaving the widget, so the form must not judge a half-typed entry:
+        // a required field lighting up after the first part is the bug.
+        mountDateTimeInput({ validator: { type: 'string', required: true } });
+
+        cy.get(sel.month).click();
+        cy.focused().type('06');
+        cy.get('[data-cy="testSubject_validator-errors"]').should('not.exist');
+        cy.focused().type('15');
+        cy.get('[data-cy="testSubject_validator-errors"]').should('not.exist');
+
+        // Leaving the widget is the one moment the entry is judged
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get('[data-cy="testSubject_validator-errors"]').should('exist');
+      });
+
       it('should flip a date-only entry to null with an incomplete error when focus leaves', () => {
         mountDateTimeInput();
 

--- a/libs/ui-testing/src/lib/gui-features/datetimeinput.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/datetimeinput.cy.ts
@@ -277,19 +277,27 @@ export const runDateTimeInputComponentTests = (mountFn: MountComponentFn) => {
     });
 
     describe('blur', () => {
-      it('should emit a null value when a part is emptied and blurred', () => {
-        const formSubmitHandler = cy.stub().as('formSubmitHandler');
-        mountDateTimeInput({
-          data: { myDateTime: '2026-06-15T14:30:00' },
-          formSubmit: formSubmitHandler,
+      it('should emit a null value and keep the other parts when one part is emptied', () => {
+        mountDateTimeInput({ data: { myDateTime: '2026-06-15T14:30:00' } });
+
+        const changeSpy = cy.spy().as('changeSpy');
+        cy.get('gui-date-time').then(($el) => {
+          $el[0].addEventListener('change', changeSpy as unknown as EventListener);
         });
 
         cy.get(sel.day).type('{selectAll}{backspace}');
         cy.get(sel.day).blur();
 
-        submitAndGetData('@formSubmitHandler').then((data) => {
-          expect(data).to.deep.equal({ myDateTime: null });
+        cy.get('@changeSpy').then((spy: any) => {
+          expect(spy.getCall(0).args[0].detail.value).to.equal(null);
         });
+
+        // Only the emptied part clears: the rest of the entry is not wiped
+        cy.get(sel.day).should('have.value', '');
+        cy.get(sel.month).should('have.value', '06');
+        cy.get(sel.year).should('have.value', '2026');
+        cy.get(sel.hour).should('have.value', '02');
+        cy.get(sel.minute).should('have.value', '30');
       });
 
       it('should keep a minute of 00 on blur', () => {
@@ -305,6 +313,64 @@ export const runDateTimeInputComponentTests = (mountFn: MountComponentFn) => {
         submitAndGetData('@formSubmitHandler').then((data) => {
           expect(data).to.deep.equal({ myDateTime: '2026-06-15T14:00:00' });
         });
+      });
+    });
+
+    describe('incomplete input on focus leave', () => {
+      it('should flip a date-only entry to null with an incomplete error when focus leaves', () => {
+        mountDateTimeInput();
+
+        const changeSpy = cy.spy().as('changeSpy');
+        cy.get('gui-date-time').then(($el) => {
+          $el[0].addEventListener('change', changeSpy as unknown as EventListener);
+        });
+
+        // en-US orders the parts month/day/year, then the time run
+        cy.get(sel.month).click();
+        cy.focused().type('06');
+        cy.focused().type('15');
+        cy.focused().type('2026');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+
+        cy.get('[data-cy="testSubject_validator-error"]').should(
+          'contain.text',
+          'Incomplete date-time',
+        );
+        cy.get('@changeSpy').then((spy: any) => {
+          expect(spy.getCall(0).args[0].detail.value).to.equal(null);
+        });
+      });
+
+      it('should show the incomplete error for a committed value left with an emptied part', () => {
+        mountDateTimeInput({ data: { myDateTime: '2026-06-15T14:30:00' } });
+
+        cy.get(sel.day).type('{selectAll}{backspace}');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+
+        cy.get('[data-cy="testSubject_validator-error"]').should(
+          'contain.text',
+          'Incomplete date-time',
+        );
+        cy.get(sel.month).should('have.value', '06');
+        cy.get(sel.hour).should('have.value', '02');
+      });
+
+      it('should clear the incomplete error once the date-time is completed', () => {
+        mountDateTimeInput({ props: { hourFormat: '24' } });
+
+        cy.get(sel.month).click();
+        cy.focused().type('06');
+        cy.focused().type('15');
+        cy.focused().type('2026');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get('[data-cy="testSubject_validator-error"]').should(
+          'contain.text',
+          'Incomplete date-time',
+        );
+
+        cy.get(sel.hour).type('10');
+        cy.focused().type('30', { force: true });
+        cy.get('[data-cy="testSubject_validator-error"]').should('not.exist');
       });
     });
 

--- a/libs/ui-testing/src/lib/gui-features/datetimepicker.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/datetimepicker.cy.ts
@@ -3,8 +3,9 @@ import { type MountComponentFn } from '../utils';
 
 // Behavior tests for the gui-date-time-picker web component: a gui-date-time
 // input opening a gui-date-time-calendar popover. The popover closes only on
-// a COMPLETE day+time commit — picking a day emits null (time cleared) and
-// must keep it open for the second step.
+// a deliberate commit (a list pick or Enter) — picking a day keeps any
+// previously chosen time (committing the new full value) or, with no time
+// yet, parks a working partial that survives closing the popover.
 export const runDateTimePickerComponentTests = (mountFn: MountComponentFn) => {
   describe('DateTimePicker Component', () => {
     const sel = {
@@ -36,6 +37,7 @@ export const runDateTimePickerComponentTests = (mountFn: MountComponentFn) => {
     const mountPicker = (options?: {
       data?: Record<string, any>;
       props?: Record<string, any>;
+      validator?: Record<string, any>;
       formSubmit?: (event: any) => void;
       readonly?: boolean;
       disabled?: boolean;
@@ -51,6 +53,7 @@ export const runDateTimePickerComponentTests = (mountFn: MountComponentFn) => {
               type: 'dateTimePicker',
               path: 'myAppointment',
               ...(options?.props ? { props: options.props } : {}),
+              ...(options?.validator ? { validator: options.validator as any } : {}),
               ...(options?.readonly !== undefined ? { readonly: options.readonly } : {}),
               ...(options?.disabled !== undefined ? { disabled: options.disabled } : {}),
             },
@@ -124,10 +127,12 @@ export const runDateTimePickerComponentTests = (mountFn: MountComponentFn) => {
 
       cy.get(sel.day).click();
 
-      // Day step: emits null (time cleared) and the popover must stay open
+      // Day step: the kept time commits the new full value immediately, and
+      // the popover must stay open (not a deliberate list-pick/Enter commit)
       cy.get(sel.dayButton('2026-02-16')).click();
       cy.get(sel.calendar).should('exist');
-      cy.get(sel.day).should('have.value', '');
+      cy.get(sel.day).should('have.value', '16');
+      cy.get(sel.hour).should('have.value', '09');
 
       // Time step: the commit closes the popover and fills the field
       cy.get(sel.popoverHour).click();
@@ -142,6 +147,190 @@ export const runDateTimePickerComponentTests = (mountFn: MountComponentFn) => {
       submitAndGetData('@formSubmitHandler').then((data) => {
         expect(data).to.deep.equal({ myAppointment: '2026-02-16T10:00:00' });
       });
+    });
+
+    it('should fill the date segments and keep the value null after a day-only pick', () => {
+      const formSubmitHandler = cy.stub().as('formSubmitHandler');
+      mountPicker({
+        data: { myAppointment: null },
+        props: officeProps,
+        formSubmit: formSubmitHandler,
+      });
+
+      cy.get(sel.day).click();
+      cy.get('gui-date-time-calendar .gui-calendar__day-button:not(.other-month):not(:disabled)')
+        .first()
+        .then(($btn) => {
+          const isoDate = $btn.attr('data-date') as string;
+
+          cy.wrap($btn).click();
+          cy.get(sel.calendar).should('exist');
+          cy.get(sel.day).should('have.value', isoDate.slice(8, 10));
+          cy.get(sel.month).should('have.value', isoDate.slice(5, 7));
+          cy.get(sel.hour).should('have.value', '');
+
+          submitAndGetData('@formSubmitHandler').then((data) => {
+            expect(data).to.deep.equal({ myAppointment: null });
+          });
+        });
+    });
+
+    it('should select the typed day in the calendar as the date half completes', () => {
+      mountPicker({ props: { ...officeProps, hourFormat: '24' } });
+
+      cy.get(sel.month).click();
+      cy.focused().type('02');
+      cy.focused().type('13');
+      cy.focused().type('2026');
+
+      cy.get(sel.dayButton('2026-02-13')).should('have.attr', 'aria-selected', 'true');
+    });
+
+    it('should keep a time picked before any day and commit once a day is picked', () => {
+      const formSubmitHandler = cy.stub().as('formSubmitHandler');
+      mountPicker({
+        data: { myAppointment: null },
+        props: officeProps,
+        formSubmit: formSubmitHandler,
+      });
+
+      cy.get(sel.day).click();
+      cy.get(sel.popoverHour).click();
+      cy.get(sel.option('10:00:00')).click();
+
+      // No day yet: the pick is parked, the popover stays open, the field
+      // time segments fill
+      cy.get(sel.calendar).should('exist');
+      cy.get(sel.hour).should('have.value', '10');
+
+      cy.get('gui-date-time-calendar .gui-calendar__day-button:not(.other-month):not(:disabled)')
+        .first()
+        .then(($btn) => {
+          const isoDate = $btn.attr('data-date') as string;
+
+          cy.wrap($btn).click();
+          cy.get(sel.day).should('have.value', isoDate.slice(8, 10));
+
+          submitAndGetData('@formSubmitHandler').then((data) => {
+            expect(data).to.deep.equal({ myAppointment: `${isoDate}T10:00:00` });
+          });
+        });
+    });
+
+    it('should keep a day-only pick across popover close and reopen', () => {
+      mountPicker({ data: { myAppointment: null }, props: officeProps });
+
+      cy.get(sel.day).click();
+      cy.get('gui-date-time-calendar .gui-calendar__day-button:not(.other-month):not(:disabled)')
+        .first()
+        .then(($btn) => {
+          const isoDate = $btn.attr('data-date') as string;
+
+          cy.wrap($btn).click();
+          // Escape closes the popover; the working selection must survive
+          cy.focused().type('{esc}');
+          cy.get(sel.calendar).should('not.exist');
+
+          cy.get(sel.day).click();
+          cy.get(sel.calendar).should('exist');
+          cy.get(sel.dayButton(isoDate)).should('have.attr', 'aria-selected', 'true');
+        });
+    });
+
+    it('should not show an error while a selection is still in progress in the popover', () => {
+      // Completing a selection step by step must stay quiet: no error until
+      // the user actually abandons the widget with a partial value.
+      mountPicker({
+        data: { myAppointment: null },
+        props: officeProps,
+        validator: { type: 'string', format: 'date-time', required: true },
+      });
+
+      cy.get(sel.day).click();
+      cy.get('gui-date-time-calendar .gui-calendar__day-button:not(.other-month):not(:disabled)')
+        .first()
+        .click();
+      cy.get('[data-cy="testSubject_validator-errors"]').should('not.exist');
+
+      // Moving on to the time step must not flag the field either
+      cy.get(sel.popoverHour).click();
+      cy.get('[data-cy="testSubject_validator-errors"]').should('not.exist');
+
+      cy.get(sel.option('10:00:00')).click();
+      cy.get('[data-cy="testSubject_validator-errors"]').should('not.exist');
+    });
+
+    it('should not show an error when clicking a non-focusable area of the popover', () => {
+      // Clicking widget chrome (the time input's group wrapper, padding...)
+      // must not read as leaving the control just because the clicked
+      // element cannot hold focus.
+      mountPicker({
+        data: { myAppointment: null },
+        props: officeProps,
+        validator: { type: 'string', format: 'date-time', required: true },
+      });
+
+      cy.get(sel.day).click();
+      cy.get('gui-date-time-calendar .gui-calendar__day-button:not(.other-month):not(:disabled)')
+        .first()
+        .click();
+
+      cy.get('gui-date-time-calendar gui-time [role="group"]').click('right');
+
+      cy.get(sel.calendar).should('exist');
+      cy.get('[data-cy="testSubject_validator-errors"]').should('not.exist');
+    });
+
+    it('should keep the other parts and show the incomplete error when a part is emptied', () => {
+      mountPicker({ data: { myAppointment: '2026-02-13T09:30:00' }, props: officeProps });
+
+      cy.get(sel.day).type('{selectAll}{backspace}');
+      cy.get('[data-cy="submitBtn_button"]').focus();
+
+      // The field keeps what the user still has: only the emptied part clears
+      cy.get(sel.day).should('have.value', '');
+      cy.get(sel.month).should('have.value', '02');
+      cy.get(sel.year).should('have.value', '2026');
+      cy.get(sel.hour).should('have.value', '09');
+      cy.get('[data-cy="testSubject_validator-error"]').should(
+        'contain.text',
+        'Incomplete date-time',
+      );
+    });
+
+    it('should report an abandoned partial when clicking away onto the page background', () => {
+      // The counterpart of the chrome-click case: a click outside that lands
+      // on a non-focusable area is still leaving the widget.
+      mountPicker({ data: { myAppointment: null }, props: officeProps });
+
+      cy.get(sel.day).click();
+      cy.get('gui-date-time-calendar .gui-calendar__day-button:not(.other-month):not(:disabled)')
+        .first()
+        .click();
+
+      cy.get('body').click(0, 0);
+
+      cy.get(sel.calendar).should('not.exist');
+      cy.get('[data-cy="testSubject_validator-error"]').should(
+        'contain.text',
+        'Incomplete date-time',
+      );
+    });
+
+    it('should flip a day-only pick to null with an incomplete error when focus leaves', () => {
+      mountPicker({ data: { myAppointment: null }, props: officeProps });
+
+      cy.get(sel.day).click();
+      cy.get('gui-date-time-calendar .gui-calendar__day-button:not(.other-month):not(:disabled)')
+        .first()
+        .click();
+
+      cy.get('[data-cy="submitBtn_button"]').focus();
+      cy.get(sel.calendar).should('not.exist');
+      cy.get('[data-cy="testSubject_validator-error"]').should(
+        'contain.text',
+        'Incomplete date-time',
+      );
     });
 
     it('should commit a fully typed date-time from the field', () => {

--- a/libs/ui-testing/src/lib/gui-features/datetimepicker.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/datetimepicker.cy.ts
@@ -333,6 +333,25 @@ export const runDateTimePickerComponentTests = (mountFn: MountComponentFn) => {
       );
     });
 
+    it('should clear the incomplete error when the emptied picker is left again', () => {
+      // Regression: leave a typed partial behind (incomplete error), come
+      // back, empty the field and leave again — the error must not outlive
+      // fields that no longer hold anything.
+      mountPicker({ props: officeProps });
+
+      cy.get(sel.month).click();
+      cy.focused().type('02');
+      cy.get('[data-cy="submitBtn_button"]').focus();
+      cy.get('[data-cy="testSubject_validator-error"]').should(
+        'contain.text',
+        'Incomplete date-time',
+      );
+
+      cy.get(sel.month).type('{selectAll}{backspace}');
+      cy.get('[data-cy="submitBtn_button"]').focus();
+      cy.get('[data-cy="testSubject_validator-errors"]').should('not.exist');
+    });
+
     it('should commit a fully typed date-time from the field', () => {
       const formSubmitHandler = cy.stub().as('formSubmitHandler');
       mountPicker({

--- a/libs/ui-testing/src/lib/gui-features/rangedateinput.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangedateinput.cy.ts
@@ -440,6 +440,23 @@ export const runRangeDateInputComponentTests = (mountFn: MountComponentFn) => {
         cy.get(`[data-cy="${uid}_validator-error"]`).should('not.exist');
         cy.get(sel.pillText).should('have.length', 1);
       });
+
+      it('should clear the incomplete error when the emptied endpoint is left again', () => {
+        // Regression: leave one endpoint behind (incomplete error), come
+        // back, empty its fields and leave again — the error must not
+        // outlive fields that no longer hold anything.
+        mountRangeDateInput();
+
+        typeDate('start', '06', '10', '2026');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get(`[data-cy="${uid}_validator-error"]`).should('contain.text', 'Incomplete date');
+
+        cy.get(sel.start.month).type('{selectAll}{backspace}');
+        cy.get(sel.start.day).type('{selectAll}{backspace}');
+        cy.get(sel.start.year).type('{selectAll}{backspace}');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get(`[data-cy="${uid}_validator-errors"]`).should('not.exist');
+      });
     });
 
     describe('readonly and disabled', () => {

--- a/libs/ui-testing/src/lib/gui-features/rangedateinput.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangedateinput.cy.ts
@@ -359,7 +359,48 @@ export const runRangeDateInputComponentTests = (mountFn: MountComponentFn) => {
       });
     });
 
-    describe('incomplete input on focus leave', () => {
+    describe('focus leave', () => {
+      it('should commit a complete typed range when focus leaves, without Enter', () => {
+        mountRangeDateInput();
+
+        typeDate('start', '06', '10', '2026');
+        typeDate('end', '06', '16', '2026');
+        cy.get(sel.pillText).should('not.exist');
+
+        // Leaving acts as Enter: a range the user finished is not abandoned
+        // work, and making them press a key to keep it loses it silently.
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get(sel.pillText).should('have.length', 1).and('contain', '06/10/2026');
+        cy.get(sel.start.month).should('have.value', '');
+      });
+
+      it('should not steal focus back when the leave creates the pill', () => {
+        mountRangeDateInput();
+
+        typeDate('start', '06', '10', '2026');
+        typeDate('end', '06', '16', '2026');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+
+        // Enter refocuses the start field, ready for the next range. Leaving
+        // must not — that would drag the user back into the control.
+        cy.get(sel.pillText).should('have.length', 1);
+        cy.focused().should('have.attr', 'data-cy', 'submitBtn_button');
+      });
+
+      it('should include a range committed by the click that submits the form', () => {
+        const formSubmitHandler = cy.stub().as('formSubmitHandler');
+        mountRangeDateInput({ formSubmit: formSubmitHandler });
+
+        typeDate('start', '06', '10', '2026');
+        typeDate('end', '06', '16', '2026');
+
+        // One click both leaves the widget and submits. The leave has to settle
+        // before the form reads its data, or the range is missing from it.
+        submitAndGetData('@formSubmitHandler').then((data: any) => {
+          expect(data).to.deep.equal({ myRanges: [{ start: '2026-06-10', end: '2026-06-16' }] });
+        });
+      });
+
       it('should not validate while moving between the parts of one endpoint', () => {
         // Filling a part auto-advances to the next one. That hop is not
         // leaving the widget, so the form must not judge a half-typed entry:

--- a/libs/ui-testing/src/lib/gui-features/rangedateinput.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangedateinput.cy.ts
@@ -27,6 +27,7 @@ export const runRangeDateInputComponentTests = (mountFn: MountComponentFn) => {
       data?: Record<string, any>;
       lang?: string;
       props?: Record<string, any>;
+      validator?: Record<string, any>;
       formSubmit?: (event: any) => void;
       readonly?: boolean;
       disabled?: boolean;
@@ -42,6 +43,7 @@ export const runRangeDateInputComponentTests = (mountFn: MountComponentFn) => {
               type: 'rangeDateInput',
               path: 'myRanges',
               ...(options?.props ? { props: options.props } : {}),
+              ...(options?.validator ? { validator: options.validator as any } : {}),
               ...(options?.readonly !== undefined ? { readonly: options.readonly } : {}),
               ...(options?.disabled !== undefined ? { disabled: options.disabled } : {}),
             },
@@ -354,6 +356,48 @@ export const runRangeDateInputComponentTests = (mountFn: MountComponentFn) => {
             myRanges: [{ start: '2026-06-10', end: '2026-06-16' }],
           });
         });
+      });
+    });
+
+    describe('incomplete input on focus leave', () => {
+      it('should not validate while moving between the parts of one endpoint', () => {
+        // Filling a part auto-advances to the next one. That hop is not
+        // leaving the widget, so the form must not judge a half-typed entry:
+        // a required field lighting up after the first part is the bug.
+        mountRangeDateInput({ validator: { type: 'array', required: true } });
+
+        cy.get(sel.start.month).type('06');
+        cy.get(`[data-cy="${uid}_validator-errors"]`).should('not.exist');
+        cy.focused().type('15');
+        cy.get(`[data-cy="${uid}_validator-errors"]`).should('not.exist');
+
+        // Leaving the widget is the one moment the entry is judged
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get(`[data-cy="${uid}_validator-errors"]`).should('exist');
+      });
+
+      it('should report an incomplete range when only one endpoint was filled', () => {
+        // A whole endpoint typed with the other left empty is as unfinished as
+        // a half-typed one: the range never became a pill.
+        mountRangeDateInput();
+
+        typeDate('start', '06', '10', '2026');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+
+        cy.get(`[data-cy="${uid}_validator-error"]`).should('contain.text', 'Incomplete date');
+      });
+
+      it('should clear the incomplete error once the range is completed', () => {
+        mountRangeDateInput();
+
+        typeDate('start', '06', '10', '2026');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get(`[data-cy="${uid}_validator-error"]`).should('contain.text', 'Incomplete date');
+
+        typeDate('end', '06', '16', '2026');
+        cy.focused().type('{enter}');
+        cy.get(`[data-cy="${uid}_validator-error"]`).should('not.exist');
+        cy.get(sel.pillText).should('have.length', 1);
       });
     });
 

--- a/libs/ui-testing/src/lib/gui-features/rangedatepicker.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangedatepicker.cy.ts
@@ -95,6 +95,34 @@ export const runRangeDatePickerComponentTests = (mountFn: MountComponentFn) => {
       });
     });
 
+    it('should fill the date fields with the days picked in the calendar', () => {
+      mountRangeDatePicker({ data: { myRanges: [juneRange] } });
+
+      cy.get(sel.startMonth).click();
+
+      // The anchor lands in the start field straight away, so a half-picked
+      // span reads back as a date instead of only a calendar highlight
+      cy.get(sel.dayButton('2026-06-18')).click();
+      cy.get(sel.startMonth).should('have.value', '06');
+      cy.get(sel.startDay).should('have.value', '18');
+      cy.get(sel.endDay).should('have.value', '');
+
+      // Completing the span turns it into a pill and empties the fields again
+      cy.get(sel.dayButton('2026-06-20')).click();
+      cy.get(sel.pillText).should('have.length', 2);
+      cy.get(sel.startDay).should('have.value', '');
+    });
+
+    it('should report an incomplete range when only the span anchor was picked', () => {
+      mountRangeDatePicker({ data: { myRanges: [juneRange] } });
+
+      cy.get(sel.startMonth).click();
+      cy.get(sel.dayButton('2026-06-18')).click();
+
+      cy.get('[data-cy="submitBtn_button"]').focus();
+      cy.get(`[data-cy="${uid}_validator-error"]`).should('contain.text', 'Incomplete date');
+    });
+
     it('should keep the calendar open when keyboard navigation crosses a month boundary', () => {
       mountRangeDatePicker({ data: { myRanges: [juneRange] } });
 

--- a/libs/ui-testing/src/lib/gui-features/rangedatepicker.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangedatepicker.cy.ts
@@ -251,6 +251,26 @@ export const runRangeDatePickerComponentTests = (mountFn: MountComponentFn) => {
       cy.get(`[data-cy="${uid}_validator-error"]`).should('contain.text', 'Incomplete date');
     });
 
+    it('should clear the incomplete error when the emptied field is left again', () => {
+      // Regression: leave a span anchor behind (incomplete error), come
+      // back, empty the fields it filled and leave again — the error must
+      // not outlive fields that no longer hold anything.
+      mountRangeDatePicker({ data: { myRanges: [juneRange] } });
+
+      cy.get(sel.startMonth).click();
+      cy.get(sel.dayButton('2026-06-18')).click();
+      cy.get('[data-cy="submitBtn_button"]').focus();
+      cy.get(`[data-cy="${uid}_validator-error"]`).should('contain.text', 'Incomplete date');
+
+      cy.get(sel.startMonth).type('{selectAll}{backspace}');
+      cy.get(sel.startDay).type('{selectAll}{backspace}');
+      cy.get('gui-range-date input[data-group="start"][data-type="year"]').type(
+        '{selectAll}{backspace}',
+      );
+      cy.get('[data-cy="submitBtn_button"]').focus();
+      cy.get(`[data-cy="${uid}_validator-errors"]`).should('not.exist');
+    });
+
     it('should keep the calendar open when keyboard navigation crosses a month boundary', () => {
       mountRangeDatePicker({ data: { myRanges: [juneRange] } });
 

--- a/libs/ui-testing/src/lib/gui-features/rangedatepicker.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangedatepicker.cy.ts
@@ -220,6 +220,27 @@ export const runRangeDatePickerComponentTests = (mountFn: MountComponentFn) => {
       cy.get(sel.dayButton('2026-09-10')).should('exist').and('have.class', 'is-anchor');
     });
 
+    it('should commit a typed range with the click that leaves and submits', () => {
+      const formSubmitHandler = cy.stub().as('formSubmitHandler');
+      mountRangeDatePicker({ data: { myRanges: [juneRange] }, formSubmit: formSubmitHandler });
+
+      typeStart('06', '18', '2026');
+      typeEnd('06', '22', '2026');
+      cy.get(sel.pillText).should('have.length', 1);
+
+      // One click leaves the widget and submits the form. Leaving commits the
+      // finished range, and it has to settle before the form reads its data —
+      // otherwise the range the user typed is silently missing from it.
+      cy.get('[data-cy="submitBtn_button"]').click({ force: true });
+      cy.get('@formSubmitHandler').then((stub: any) => {
+        expect(stub.getCall(0).args[0].data.myRanges).to.deep.equal([
+          juneRange,
+          { start: '2026-06-18', end: '2026-06-22' },
+        ]);
+      });
+      cy.get(sel.pillText).should('have.length', 2);
+    });
+
     it('should report an incomplete range when only the span anchor was picked', () => {
       mountRangeDatePicker({ data: { myRanges: [juneRange] } });
 

--- a/libs/ui-testing/src/lib/gui-features/rangedatepicker.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangedatepicker.cy.ts
@@ -54,6 +54,18 @@ export const runRangeDatePickerComponentTests = (mountFn: MountComponentFn) => {
     const juneRange = { start: '2026-06-10', end: '2026-06-12' };
     const marchRange = { start: '2026-03-05', end: '2026-03-07' };
 
+    // en-US orders the parts month/day/year, and each fill auto-advances.
+    const typeGroup = (group: 'start' | 'end', month: string, day: string, year: string) => {
+      cy.get(`gui-range-date input[data-group="${group}"][data-type="month"]`).click();
+      cy.focused().type(month);
+      cy.focused().type(day);
+      cy.focused().type(year);
+    };
+    const typeStart = (month: string, day: string, year: string) =>
+      typeGroup('start', month, day, year);
+    const typeEnd = (month: string, day: string, year: string) =>
+      typeGroup('end', month, day, year);
+
     it('should not render the calendar initially', () => {
       mountRangeDatePicker({ data: { myRanges: [juneRange] } });
 
@@ -111,6 +123,101 @@ export const runRangeDatePickerComponentTests = (mountFn: MountComponentFn) => {
       cy.get(sel.dayButton('2026-06-20')).click();
       cy.get(sel.pillText).should('have.length', 2);
       cy.get(sel.startDay).should('have.value', '');
+    });
+
+    it('should start a calendar selection from a typed start date and complete it with a click', () => {
+      const formSubmitHandler = cy.stub().as('formSubmitHandler');
+      mountRangeDatePicker({ data: { myRanges: [juneRange] }, formSubmit: formSubmitHandler });
+
+      // Typing a whole endpoint is the same first step as clicking a day: the
+      // calendar picks it up as the in-progress anchor.
+      typeStart('06', '18', '2026');
+      cy.get(sel.calendar).should('exist');
+      cy.get(sel.dayButton('2026-06-18')).should('have.class', 'is-anchor');
+
+      // ...so one click completes the span
+      cy.get(sel.dayButton('2026-06-22')).click();
+      cy.get(sel.pillText).should('have.length', 2);
+      cy.get(sel.startDay).should('have.value', '');
+
+      cy.get('body').click(0, 0);
+      cy.get('[data-cy="submitBtn_button"]').click();
+      cy.get('@formSubmitHandler').then((stub: any) => {
+        expect(stub.getCall(0).args[0].data.myRanges).to.deep.equal([
+          juneRange,
+          { start: '2026-06-18', end: '2026-06-22' },
+        ]);
+      });
+    });
+
+    it('should complete the start date with a click when the end was typed first', () => {
+      const formSubmitHandler = cy.stub().as('formSubmitHandler');
+      mountRangeDatePicker({ data: { myRanges: [juneRange] }, formSubmit: formSubmitHandler });
+
+      // The endpoint keeps the field it was typed into, and the calendar takes
+      // it as the anchor either way — so an EARLIER click completes the start,
+      // ordered by the same reducer that orders a backward two-click pick.
+      // The end year is the last field of the last group, with nothing to
+      // auto-advance into — so the digit that completes it has to commit it.
+      typeEnd('06', '22', '2026');
+      cy.get(sel.dayButton('2026-06-22')).should('have.class', 'is-anchor');
+      cy.get(sel.startDay).should('have.value', '');
+
+      cy.get(sel.dayButton('2026-06-18')).click();
+      cy.get(sel.pillText).should('have.length', 2);
+
+      cy.get('body').click(0, 0);
+      cy.get('[data-cy="submitBtn_button"]').click();
+      cy.get('@formSubmitHandler').then((stub: any) => {
+        expect(stub.getCall(0).args[0].data.myRanges).to.deep.equal([
+          juneRange,
+          { start: '2026-06-18', end: '2026-06-22' },
+        ]);
+      });
+    });
+
+    it('should render a fully typed range as an in-progress selection', () => {
+      mountRangeDatePicker({ data: { myRanges: [juneRange] } });
+
+      typeStart('06', '18', '2026');
+      typeEnd('06', '22', '2026');
+
+      // Both endpoints entered: the whole span highlights, dashed like a hover
+      // preview. It is not a pill until Enter, so it must not wear the solid
+      // committed look of the range beside it.
+      cy.get(sel.dayButton('2026-06-18'))
+        .should('have.class', 'is-selecting')
+        .and('not.have.class', 'range-start');
+      cy.get(sel.dayButton('2026-06-20'))
+        .should('have.class', 'is-selecting')
+        .and('not.have.class', 'in-range');
+      cy.get(sel.dayButton('2026-06-22'))
+        .should('have.class', 'is-selecting')
+        .and('not.have.class', 'range-end');
+      cy.get(sel.pillText).should('have.length', 1);
+    });
+
+    it('should highlight a typed range whose end comes before its start', () => {
+      mountRangeDatePicker({ data: { myRanges: [juneRange] } });
+
+      // Reversed: the commit will reject it, but while it is being entered the
+      // days between the two endpoints still have to show what was typed.
+      typeStart('06', '22', '2026');
+      typeEnd('06', '18', '2026');
+
+      cy.get(sel.dayButton('2026-06-18')).should('have.class', 'is-selecting');
+      cy.get(sel.dayButton('2026-06-20')).should('have.class', 'is-selecting');
+      cy.get(sel.dayButton('2026-06-22')).should('have.class', 'is-selecting');
+    });
+
+    it('should navigate the calendar to a typed date in another month', () => {
+      mountRangeDatePicker({ data: { myRanges: [juneRange] } });
+
+      cy.get(sel.startMonth).click();
+      cy.get(sel.dayButton('2026-06-18')).should('exist');
+
+      typeStart('09', '10', '2026');
+      cy.get(sel.dayButton('2026-09-10')).should('exist').and('have.class', 'is-anchor');
     });
 
     it('should report an incomplete range when only the span anchor was picked', () => {

--- a/libs/ui-testing/src/lib/gui-features/rangedatetimecalendar.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangedatetimecalendar.cy.ts
@@ -318,6 +318,26 @@ export const runRangeDateTimeCalendarComponentTests = (mountFn: MountComponentFn
         cy.get(sel.error).should('be.visible').and('contain', 'Range unavailable');
       });
 
+      it('should commit a range finished with a typed end time when focus leaves', () => {
+        mountCalendar({ props: { allowCustomTime: true } });
+
+        day(13).click();
+        day(15).click();
+        startHour().click();
+        startOption('09:00:00').click();
+
+        // A typed custom time never commits as it is typed — only a list pick
+        // or Enter does — so the fourth piece lands here unclaimed.
+        cy.get(`${sel.endPicker} gui-time input[data-type="hour"]`).click().type('11');
+        cy.get(`${sel.endPicker} gui-time input[data-type="minute"]`).type('30');
+        cy.get(sel.pillText).should('not.exist');
+
+        // Leaving is as deliberate as Enter, and the selection is complete.
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get(sel.pillText).should('have.length', 1);
+        startHour().should('have.value', '');
+      });
+
       it('should disable a fully-blocked day and reject a range stepping over it', () => {
         mountCalendar({
           props: {

--- a/libs/ui-testing/src/lib/gui-features/rangedatetimecalendar.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangedatetimecalendar.cy.ts
@@ -81,30 +81,55 @@ export const runRangeDateTimeCalendarComponentTests = (mountFn: MountComponentFn
     };
 
     describe('selection flow', () => {
-      it('should keep both time pickers disabled until a date range is completed', () => {
+      it('should keep both time pickers usable from the start', () => {
         mountCalendar();
 
-        startHour().should('be.disabled');
-        endHour().should('be.disabled');
-
-        day(13).click();
-        // Anchor only — a range is not complete yet.
-        startHour().should('be.disabled');
+        startHour().should('not.be.disabled');
+        endHour().should('not.be.disabled');
 
         day(13).click();
         startHour().should('not.be.disabled');
-        endHour().should('be.disabled');
+
+        day(13).click();
+        startHour().should('not.be.disabled');
+        endHour().should('not.be.disabled');
       });
 
-      it('should enable the end picker only after a start time is picked', () => {
+      it('should commit a range whose times were picked before the days', () => {
+        const formSubmit = cy.stub().as('formSubmit');
+        mountCalendar({ formSubmit });
+
+        // Times first, no day span yet: nothing commits, both are kept
+        startHour().click();
+        startOption('09:00:00').click();
+        endHour().click();
+        endOption('11:00:00').click();
+        cy.get(sel.pillText).should('have.length', 0);
+
+        // Completing the span commits the whole range
+        day(13).click();
+        day(13).click();
+
+        cy.get(sel.pillText).should('have.length', 1);
+        submitAndGetData('@formSubmit').then((data) => {
+          expect(data.myRanges).to.deep.equal([
+            { start: dt(13, '09:00:00'), end: dt(13, '11:00:00') },
+          ]);
+        });
+      });
+
+      it('should keep the picked times when a new day span is started', () => {
         mountCalendar();
 
-        day(13).click();
-        day(13).click();
         startHour().click();
         startOption('09:00:00').click();
 
-        endHour().should('not.be.disabled');
+        // Restarting the span must not discard a time already chosen
+        day(13).click();
+        day(16).click();
+        day(20).click();
+
+        startHour().should('have.value', '09');
       });
 
       it('should commit a same-day range as a pill and reset the pickers', () => {
@@ -114,12 +139,12 @@ export const runRangeDateTimeCalendarComponentTests = (mountFn: MountComponentFn
         commitRange(13, '09:00:00', 13, '11:00:00');
 
         cy.get(sel.pillText).should('have.length', 1);
-        startHour().should('be.disabled');
-        endHour().should('be.disabled');
         // Both time inputs are cleared after a commit — the end picker must not
-        // keep showing the last picked value.
+        // keep showing the last picked value — and both stay usable.
         startHour().should('have.value', '');
         endHour().should('have.value', '');
+        startHour().should('not.be.disabled');
+        endHour().should('not.be.disabled');
 
         submitAndGetData('@formSubmit').then((data) => {
           expect(data.myRanges).to.deep.equal([

--- a/libs/ui-testing/src/lib/gui-features/rangedatetimecalendar.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangedatetimecalendar.cy.ts
@@ -359,6 +359,54 @@ export const runRangeDateTimeCalendarComponentTests = (mountFn: MountComponentFn
       });
     });
 
+    describe('incomplete selection on focus leave', () => {
+      it('should report a half-typed time as incomplete when focus leaves', () => {
+        // A partial time never emits, so it lives only in the input's parts:
+        // the leave check must still count it as something left behind.
+        mountCalendar({ props: { hourFormat: '24', allowCustomTime: true } });
+
+        startHour().click().type('10');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+
+        cy.get(sel.error).should('contain.text', 'Incomplete date-time');
+      });
+
+      it('should report a lone anchor day as incomplete and keep the pills', () => {
+        mountCalendar({
+          data: { myRanges: [{ start: dt(10, '09:00:00'), end: dt(10, '10:00:00') }] },
+        });
+
+        day(13).click();
+        cy.get('[data-cy="submitBtn_button"]').focus();
+
+        // The committed pill is untouched: only the injected issue flags the field
+        cy.get(sel.error).should('contain.text', 'Incomplete date-time');
+        cy.get(sel.pillText).should('have.length', 1);
+      });
+
+      it('should clear the incomplete error when the emptied selection is left again', () => {
+        mountCalendar({ props: { hourFormat: '24', allowCustomTime: true } });
+
+        startHour().click().type('10');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get(sel.error).should('contain.text', 'Incomplete date-time');
+
+        startHour().type('{selectAll}{backspace}', { force: true });
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get('[data-cy="testSubject_validator-errors"]').should('not.exist');
+      });
+
+      it('should honor the incompleteMessage prop', () => {
+        mountCalendar({ props: { incompleteMessage: 'Half-finished range!' } });
+
+        startHour().click();
+        startOption('09:00:00').click();
+        cy.get('[data-cy="submitBtn_button"]').focus();
+
+        cy.get(sel.error).should('contain.text', 'Half-finished range!');
+      });
+    });
+
     describe('hydration and states', () => {
       it('should hydrate a DateTimeRange[] value into pills and day highlights', () => {
         mountCalendar({

--- a/libs/ui-testing/src/lib/gui-features/rangedatetimeinput.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangedatetimeinput.cy.ts
@@ -316,6 +316,26 @@ export const runRangeDateTimeInputComponentTests = (mountFn: MountComponentFn) =
       cy.get(sel.pillText).should('not.exist');
     });
 
+    it('should clear the incomplete error when the emptied endpoint is left again', () => {
+      // Regression: leave one endpoint behind (incomplete error), come back,
+      // empty its fields and leave again — the error must not outlive fields
+      // that no longer hold anything.
+      mountRangeDateTimeInput();
+
+      typeGroup('start', ['22', '11', '2026', '09', '00']);
+      cy.get('[data-cy="submitBtn_button"]').focus();
+      cy.get('[data-cy="testSubject_validator-error"]').should(
+        'contain.text',
+        'Incomplete date-time',
+      );
+
+      for (const type of ['day', 'month', 'year', 'hour', 'minute']) {
+        cy.get(partSel('start', type)).type('{selectAll}{backspace}');
+      }
+      cy.get('[data-cy="submitBtn_button"]').focus();
+      cy.get('[data-cy="testSubject_validator-errors"]').should('not.exist');
+    });
+
     it('should commit a complete range when focus leaves, without Enter', () => {
       const formSubmitHandler = cy.stub().as('formSubmitHandler');
       mountRangeDateTimeInput({ formSubmit: formSubmitHandler });

--- a/libs/ui-testing/src/lib/gui-features/rangedatetimeinput.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangedatetimeinput.cy.ts
@@ -316,6 +316,25 @@ export const runRangeDateTimeInputComponentTests = (mountFn: MountComponentFn) =
       cy.get(sel.pillText).should('not.exist');
     });
 
+    it('should commit a complete range when focus leaves, without Enter', () => {
+      const formSubmitHandler = cy.stub().as('formSubmitHandler');
+      mountRangeDateTimeInput({ formSubmit: formSubmitHandler });
+
+      typeGroup('start', ['22', '11', '2026', '09', '00']);
+      typeGroup('end', ['22', '11', '2026', '11', '30']);
+      cy.get(sel.pillText).should('not.exist');
+
+      // Leaving acts as Enter: a range the user finished is not abandoned work,
+      // and the click that leaves is the same one that submits, so the commit
+      // has to settle before the form reads its data.
+      submitAndGetData('@formSubmitHandler').then((data: any) => {
+        expect(data).to.deep.equal({
+          myRanges: [{ start: '2026-11-22T09:00:00', end: '2026-11-22T11:30:00' }],
+        });
+      });
+      cy.get(sel.pillText).should('have.length', 1);
+    });
+
     it('should render disabled inputs when disabled', () => {
       mountRangeDateTimeInput({
         data: { myRanges: [{ start: '2026-11-22T09:00:00', end: '2026-11-22T10:00:00' }] },

--- a/libs/ui-testing/src/lib/gui-features/rangedatetimeinput.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangedatetimeinput.cy.ts
@@ -25,6 +25,7 @@ export const runRangeDateTimeInputComponentTests = (mountFn: MountComponentFn) =
       data?: Record<string, any>;
       lang?: string;
       props?: Record<string, any>;
+      validator?: Record<string, any>;
       formSubmit?: (event: any) => void;
       readonly?: boolean;
       disabled?: boolean;
@@ -40,6 +41,7 @@ export const runRangeDateTimeInputComponentTests = (mountFn: MountComponentFn) =
               type: 'rangeDateTimeInput',
               path: 'myRanges',
               ...(options?.props ? { props: options.props } : {}),
+              ...(options?.validator ? { validator: options.validator as any } : {}),
               ...(options?.readonly !== undefined ? { readonly: options.readonly } : {}),
               ...(options?.disabled !== undefined ? { disabled: options.disabled } : {}),
             },
@@ -280,6 +282,38 @@ export const runRangeDateTimeInputComponentTests = (mountFn: MountComponentFn) =
       cy.get(sel.pillText).should('have.length', 2);
       cy.get(sel.pillRemove).first().click({ force: true });
       cy.get(sel.pillText).should('have.length', 1);
+    });
+
+    it('should not validate while moving between the parts of one endpoint', () => {
+      // Filling a part auto-advances to the next one. That hop is not leaving
+      // the widget, so the form must not judge a half-typed entry: a required
+      // field lighting up after the first part is the bug.
+      mountRangeDateTimeInput({ validator: { type: 'array', required: true } });
+
+      cy.get(sel.startDay).click();
+      cy.focused().type('22');
+      cy.get('[data-cy="testSubject_validator-errors"]').should('not.exist');
+      cy.focused().type('11');
+      cy.get('[data-cy="testSubject_validator-errors"]').should('not.exist');
+
+      // Leaving the widget is the one moment the entry is judged
+      cy.get('[data-cy="submitBtn_button"]').focus();
+      cy.get('[data-cy="testSubject_validator-errors"]').should('exist');
+    });
+
+    it('should report an incomplete range when only one endpoint was filled', () => {
+      // A whole endpoint typed with the other left empty is as unfinished as a
+      // half-typed one: the range never became a pill.
+      mountRangeDateTimeInput();
+
+      typeGroup('start', ['22', '11', '2026', '09', '00']);
+      cy.get('[data-cy="submitBtn_button"]').focus();
+
+      cy.get('[data-cy="testSubject_validator-error"]').should(
+        'contain.text',
+        'Incomplete date-time',
+      );
+      cy.get(sel.pillText).should('not.exist');
     });
 
     it('should render disabled inputs when disabled', () => {

--- a/libs/ui-testing/src/lib/gui-features/rangedatetimepicker.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangedatetimepicker.cy.ts
@@ -421,6 +421,35 @@ export const runRangeDateTimePickerComponentTests = (mountFn: MountComponentFn) 
         cy.get(sel.pillText).should('not.exist');
       });
 
+      it('should commit a typed range with the click that leaves and submits', () => {
+        const formSubmit = cy.stub().as('formSubmit');
+        mountPicker({ formSubmit });
+
+        const typeGroup = (group: 'start' | 'end', day: string, hour: string) => {
+          cy.get(sel.triggerPart(group, 'month')).click();
+          cy.focused().type(mm);
+          cy.focused().type(day);
+          cy.focused().type(String(y));
+          cy.focused().type(hour);
+          cy.focused().type('00');
+        };
+
+        typeGroup('start', '13', '09');
+        typeGroup('end', '13', '11');
+        cy.get(sel.pillText).should('not.exist');
+
+        // One click leaves the widget and submits. Leaving commits the finished
+        // range, and it has to settle before the form reads its data —
+        // otherwise the range the user typed is silently missing from it.
+        cy.get('[data-cy="submitBtn_button"]').click({ force: true });
+        cy.get('@formSubmit').then((stub: any) => {
+          expect(stub.getCall(0).args[0].data.myRanges).to.deep.equal([
+            { start: dt(13, '09:00:00'), end: dt(13, '11:00:00') },
+          ]);
+        });
+        cy.get(sel.pillText).should('have.length', 1);
+      });
+
       it('should keep a half-finished range when the popover is closed and reopened', () => {
         mountPicker();
 

--- a/libs/ui-testing/src/lib/gui-features/rangedatetimepicker.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangedatetimepicker.cy.ts
@@ -130,8 +130,7 @@ export const runRangeDateTimePickerComponentTests = (mountFn: MountComponentFn) 
       it('should stay open when clicking a non-interactive area inside the calendar', () => {
         mountPicker();
 
-        // Select a range so the start time picker enables and focus is parked
-        // on the last-clicked day button
+        // Select a range so focus is parked on the last-clicked day button
         cy.get(sel.triggerPart('start', 'day')).click();
         cy.get(sel.dayButton(iso(13))).click();
         cy.get(sel.dayButton(iso(15))).click();
@@ -143,10 +142,9 @@ export const runRangeDateTimePickerComponentTests = (mountFn: MountComponentFn) 
         cy.get(`${cal} .gui-calendar__weekday`).first().click();
         cy.get(sel.calendar).should('exist');
 
-        // The still-disabled end picker is also "inside" (mouse events are
-        // swallowed by disabled controls, pointerdown is not)
-        endHour().should('be.disabled');
-        endHour().click({ force: true });
+        // The end picker is inside the popover too, and now always usable
+        endHour().should('not.be.disabled');
+        endHour().click();
         cy.get(sel.calendar).should('exist');
 
         // Outside clicks still close
@@ -286,6 +284,67 @@ export const runRangeDateTimePickerComponentTests = (mountFn: MountComponentFn) 
     });
 
     describe('committing ranges', () => {
+      it('should fill the trigger fields with every piece picked in the calendar', () => {
+        mountPicker();
+
+        cy.get(sel.triggerPart('start', 'day')).click();
+
+        // The span anchor reads back as a date before the span completes
+        cy.get(sel.dayButton(iso(13))).click();
+        cy.get(sel.triggerPart('start', 'day')).should('have.value', '13');
+        cy.get(sel.triggerPart('end', 'day')).should('have.value', '');
+
+        cy.get(sel.dayButton(iso(15))).click();
+        cy.get(sel.triggerPart('start', 'day')).should('have.value', '13');
+        cy.get(sel.triggerPart('end', 'day')).should('have.value', '15');
+
+        // Times picked in the embedded pickers mirror into the same fields
+        startHour().click();
+        startOption('09:00:00').click();
+        cy.get(sel.triggerPart('start', 'hour')).should('have.value', '09');
+
+        // The last piece completes the range: it commits and the fields empty
+        endHour().click();
+        endOption('11:00:00').click();
+        cy.get(sel.pillText).should('have.length', 1);
+        cy.get(sel.triggerPart('start', 'day')).should('have.value', '');
+        cy.get(sel.triggerPart('end', 'day')).should('have.value', '');
+      });
+
+      it('should report an incomplete range when the popover is left half-finished', () => {
+        mountPicker();
+
+        // A day span with neither time chosen never became a pill
+        cy.get(sel.triggerPart('start', 'day')).click();
+        cy.get(sel.dayButton(iso(13))).click();
+        cy.get(sel.dayButton(iso(15))).click();
+
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get(sel.error).should('contain.text', 'Incomplete date-time');
+        cy.get(sel.pillText).should('not.exist');
+      });
+
+      it('should keep a half-finished range when the popover is closed and reopened', () => {
+        mountPicker();
+
+        // A day span and a start time, but no end time yet
+        cy.get(sel.triggerPart('start', 'day')).click();
+        cy.get(sel.dayButton(iso(13))).click();
+        cy.get(sel.dayButton(iso(15))).click();
+        startHour().click();
+        startOption('09:00:00').click();
+
+        cy.get('body').click(0, 0);
+        cy.get(sel.calendar).should('not.exist');
+
+        // Reopening restores the span and the chosen start time
+        cy.get(sel.triggerPart('start', 'day')).click();
+        cy.get(sel.calendar).should('exist');
+        startHour().should('have.value', '09');
+        cy.get(sel.dayButton(iso(13))).should('have.class', 'range-start');
+        cy.get(sel.dayButton(iso(15))).should('have.class', 'range-end');
+      });
+
       it('should commit a pill into the trigger, keep the popover open, and submit', () => {
         const formSubmit = cy.stub().as('formSubmit');
         mountPicker({ formSubmit });

--- a/libs/ui-testing/src/lib/gui-features/rangedatetimepicker.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangedatetimepicker.cy.ts
@@ -311,6 +311,103 @@ export const runRangeDateTimePickerComponentTests = (mountFn: MountComponentFn) 
         cy.get(sel.triggerPart('end', 'day')).should('have.value', '');
       });
 
+      it('should fill the calendar time picker from a time typed in the trigger', () => {
+        mountPicker();
+
+        cy.get(sel.triggerPart('start', 'day')).click();
+        cy.get(sel.triggerPart('start', 'hour')).click();
+        cy.focused().type('09');
+        cy.focused().type('30');
+
+        startHour().should('have.value', '09');
+      });
+
+      it('should start a calendar selection from a date typed in the trigger', () => {
+        mountPicker();
+
+        cy.get(sel.triggerPart('start', 'month')).click();
+        cy.focused().type(mm);
+        cy.focused().type('13');
+        cy.focused().type(String(y));
+
+        // The typed day is the in-progress anchor, so one click completes the span
+        cy.get(sel.dayButton(iso(13))).should('have.class', 'is-anchor');
+        cy.get(sel.dayButton(iso(15))).click();
+        cy.get(sel.triggerPart('end', 'day')).should('have.value', '15');
+        // Both times are still missing, so the span stays in progress
+        cy.get(sel.dayButton(iso(14)))
+          .should('have.class', 'is-selecting')
+          .and('not.have.class', 'in-range');
+      });
+
+      it('should highlight a typed range whose end comes before its start', () => {
+        mountPicker();
+
+        cy.get(sel.triggerPart('start', 'month')).click();
+        cy.focused().type(mm);
+        cy.focused().type('15');
+        cy.focused().type(String(y));
+
+        cy.get(sel.triggerPart('end', 'month')).click();
+        cy.focused().type(mm);
+        cy.focused().type('13');
+        cy.focused().type(String(y));
+
+        // Reversed: the commit will reject it, but while it is being entered
+        // the days between the two endpoints still show what was typed.
+        cy.get(sel.dayButton(iso(13))).should('have.class', 'is-selecting');
+        cy.get(sel.dayButton(iso(14))).should('have.class', 'is-selecting');
+        cy.get(sel.dayButton(iso(15))).should('have.class', 'is-selecting');
+      });
+
+      it('should keep the working selection while a custom time is typed in the calendar', () => {
+        mountPicker({ props: { allowCustomTime: true } });
+
+        cy.get(sel.triggerPart('start', 'day')).click();
+        cy.get(sel.dayButton(iso(13))).click();
+        cy.get(sel.dayButton(iso(15))).click();
+        cy.get(sel.triggerPart('start', 'day')).should('have.value', '13');
+
+        // The calendar's own time field reports its parts as it goes, and a
+        // half-typed time reports nothing else — which must not read as "the
+        // range lost its days"
+        startHour().click();
+        cy.focused().type('09');
+        cy.get(`${sel.startPicker} gui-time input[data-type="minute"]`).click();
+
+        cy.get(sel.triggerPart('start', 'day')).should('have.value', '13');
+        cy.get(sel.triggerPart('end', 'day')).should('have.value', '15');
+      });
+
+      it('should clear the calendar time pickers when a pill is committed from the trigger', () => {
+        mountPicker();
+
+        // Start time first, then the day span — the end time is still missing,
+        // so nothing commits and the start time sits in the calendar's picker
+        cy.get(sel.triggerPart('start', 'day')).click();
+        startHour().click();
+        startOption('09:00:00').click();
+        cy.get(sel.dayButton(iso(13))).click();
+        cy.get(sel.dayButton(iso(15))).click();
+        startHour().should('have.value', '09');
+
+        // Typing the last piece in the trigger commits the pill from there —
+        // the calendar must not be left holding the range it just became
+        cy.get(sel.triggerPart('end', 'hour')).click();
+        cy.focused().type('11');
+        cy.focused().type('00');
+        cy.focused().type('{enter}');
+
+        cy.get(sel.pillText).should('have.length', 1);
+        startHour().should('have.value', '');
+        endHour().should('have.value', '');
+        cy.get(sel.triggerPart('start', 'day')).should('have.value', '');
+        // The span is now a committed pill, with nothing left in progress
+        cy.get(sel.dayButton(iso(13)))
+          .should('not.have.class', 'is-anchor')
+          .and('not.have.class', 'is-selecting');
+      });
+
       it('should report an incomplete range when the popover is left half-finished', () => {
         mountPicker();
 
@@ -337,12 +434,15 @@ export const runRangeDateTimePickerComponentTests = (mountFn: MountComponentFn) 
         cy.get('body').click(0, 0);
         cy.get(sel.calendar).should('not.exist');
 
-        // Reopening restores the span and the chosen start time
+        // Reopening restores the span and the chosen start time. The end time
+        // is still missing, so the span reads as in progress, not committed.
         cy.get(sel.triggerPart('start', 'day')).click();
         cy.get(sel.calendar).should('exist');
         startHour().should('have.value', '09');
-        cy.get(sel.dayButton(iso(13))).should('have.class', 'range-start');
-        cy.get(sel.dayButton(iso(15))).should('have.class', 'range-end');
+        cy.get(sel.dayButton(iso(13)))
+          .should('have.class', 'is-selecting')
+          .and('not.have.class', 'range-start');
+        cy.get(sel.dayButton(iso(15))).should('have.class', 'is-selecting');
       });
 
       it('should commit a pill into the trigger, keep the popover open, and submit', () => {

--- a/libs/ui-testing/src/lib/gui-features/rangetimeinput.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangetimeinput.cy.ts
@@ -26,6 +26,7 @@ export const runRangeTimeInputComponentTests = (mountFn: MountComponentFn) => {
       data?: Record<string, any>;
       lang?: string;
       props?: Record<string, any>;
+      validator?: Record<string, any>;
       formSubmit?: (event: any) => void;
       readonly?: boolean;
       disabled?: boolean;
@@ -41,6 +42,7 @@ export const runRangeTimeInputComponentTests = (mountFn: MountComponentFn) => {
               type: 'rangeTimeInput',
               path: 'myRanges',
               ...(options?.props ? { props: options.props } : {}),
+              ...(options?.validator ? { validator: options.validator as any } : {}),
               ...(options?.readonly !== undefined ? { readonly: options.readonly } : {}),
               ...(options?.disabled !== undefined ? { disabled: options.disabled } : {}),
             },
@@ -292,6 +294,35 @@ export const runRangeTimeInputComponentTests = (mountFn: MountComponentFn) => {
       cy.get('@inputErrorSpy').then((spy: any) => {
         expect(spy.getCall(0).args[0].detail.message).to.equal('Too late');
       });
+    });
+
+    it('should not validate while moving between the parts of one endpoint', () => {
+      // Filling a part auto-advances to the next one. That hop is not leaving
+      // the widget, so the form must not judge a half-typed entry: a required
+      // field lighting up after the first part is the bug.
+      mountRangeTimeInput({ validator: { type: 'array', required: true } });
+
+      cy.get(sel.start.hour).click();
+      cy.focused().type('09');
+      cy.get('[data-cy="testSubject_validator-errors"]').should('not.exist');
+
+      // Leaving the widget is the one moment the entry is judged
+      cy.get('[data-cy="submitBtn_button"]').focus();
+      cy.get('[data-cy="testSubject_validator-errors"]').should('exist');
+    });
+
+    it('should report an incomplete range when only one endpoint was filled', () => {
+      // A whole endpoint typed with the other left empty is as unfinished as a
+      // half-typed one: the range never became a pill.
+      mountRangeTimeInput();
+
+      cy.get(sel.start.hour).click();
+      cy.focused().type('09');
+      cy.focused().type('00');
+      cy.get('[data-cy="submitBtn_button"]').focus();
+
+      cy.get('[data-cy="testSubject_validator-error"]').should('contain.text', 'Incomplete time');
+      cy.get(sel.pillText).should('not.exist');
     });
 
     it('should render disabled inputs when disabled', () => {

--- a/libs/ui-testing/src/lib/gui-features/rangetimeinput.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangetimeinput.cy.ts
@@ -118,12 +118,12 @@ export const runRangeTimeInputComponentTests = (mountFn: MountComponentFn) => {
       );
     });
 
-    it('should not create a pill until Enter is pressed', () => {
+    it('should not create a pill while the user is still in the fields', () => {
       mountRangeTimeInput();
 
-      // Completing both endpoints is deliberately not enough: the range is only
-      // committed by an explicit Enter, which is what frees the user to correct
-      // the trailing AM/PM toggle first.
+      // Completing both endpoints is deliberately not enough on its own: the
+      // commit waits for Enter or for focus to leave, which is what frees the
+      // user to correct the trailing AM/PM toggle first.
       typeRange(['09', '00'], ['11', '30'], false);
 
       cy.get(sel.pillText).should('have.length', 0);
@@ -323,6 +323,29 @@ export const runRangeTimeInputComponentTests = (mountFn: MountComponentFn) => {
 
       cy.get('[data-cy="testSubject_validator-error"]').should('contain.text', 'Incomplete time');
       cy.get(sel.pillText).should('not.exist');
+    });
+
+    it('should commit a complete range when focus leaves, without Enter', () => {
+      mountRangeTimeInput();
+
+      typeRange(['09', '00'], ['11', '30'], false);
+      cy.get(sel.pillText).should('have.length', 0);
+
+      // Leaving acts as Enter: a range the user finished is not abandoned work,
+      // and making them press a key to keep it loses it silently.
+      cy.get('[data-cy="submitBtn_button"]').focus();
+      cy.get(sel.pillText).should('have.length', 1).and('contain', '09:00');
+      cy.get(sel.start.hour).should('have.value', '');
+    });
+
+    it('should leave no error standing over a range the leave just committed', () => {
+      mountRangeTimeInput({ validator: { type: 'array', required: true } });
+
+      typeRange(['09', '00'], ['11', '30'], false);
+      cy.get('[data-cy="submitBtn_button"]').focus();
+
+      cy.get(sel.pillText).should('have.length', 1);
+      cy.get('[data-cy="testSubject_validator-errors"]').should('not.exist');
     });
 
     it('should render disabled inputs when disabled', () => {

--- a/libs/ui-testing/src/lib/gui-features/rangetimeinput.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangetimeinput.cy.ts
@@ -325,6 +325,24 @@ export const runRangeTimeInputComponentTests = (mountFn: MountComponentFn) => {
       cy.get(sel.pillText).should('not.exist');
     });
 
+    it('should clear the incomplete error when the emptied endpoint is left again', () => {
+      // Regression: leave one endpoint behind (incomplete error), come back,
+      // empty its fields and leave again — the error must not outlive fields
+      // that no longer hold anything.
+      mountRangeTimeInput();
+
+      cy.get(sel.start.hour).click();
+      cy.focused().type('09');
+      cy.focused().type('00');
+      cy.get('[data-cy="submitBtn_button"]').focus();
+      cy.get('[data-cy="testSubject_validator-error"]').should('contain.text', 'Incomplete time');
+
+      cy.get(sel.start.hour).type('{selectAll}{backspace}');
+      cy.get(sel.start.minute).type('{selectAll}{backspace}');
+      cy.get('[data-cy="submitBtn_button"]').focus();
+      cy.get('[data-cy="testSubject_validator-errors"]').should('not.exist');
+    });
+
     it('should commit a complete range when focus leaves, without Enter', () => {
       mountRangeTimeInput();
 

--- a/libs/ui-testing/src/lib/gui-features/rangetimepicker.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangetimepicker.cy.ts
@@ -2,10 +2,10 @@ import { defineForm, identityTranslator } from '@golemui/core';
 import { type MountComponentFn } from '../utils';
 
 // Behavior tests for the gui-range-time-picker: the gui-range-time typed input
-// plus a two-list popover (time-in left, time-out right). The out list stays
-// disabled until an in is chosen, then floors one slot after it so end > start
-// strictly. Committed ranges accumulate as merged pills (value = TimeRange[]).
-// Uses en-GB (24h) so option labels are plain HH:mm.
+// plus a two-list popover (time-in left, time-out right). Both lists are usable
+// from the start, and once an in is chosen the out list floors one slot after
+// it so end > start strictly. Committed ranges accumulate as merged pills
+// (value = TimeRange[]). Uses en-GB (24h) so option labels are plain HH:mm.
 export const runRangeTimePickerComponentTests = (mountFn: MountComponentFn) => {
   describe('RangeTimePicker Component', () => {
     const uid = 'testSubject';
@@ -79,15 +79,51 @@ export const runRangeTimePickerComponentTests = (mountFn: MountComponentFn) => {
       cy.get(sel.panel).should('not.exist');
     });
 
-    it('should open the panel with both lists, the out list disabled until an in is picked', () => {
+    it('should open the panel with both lists usable from the start', () => {
       mountRangeTimePicker({ props: officeProps });
 
       cy.get(sel.startHour).click();
       cy.get(sel.panel).should('exist');
       cy.get(sel.inItems).should('have.length', 7);
-      // Out list renders its slots but every option is disabled up front.
+      // The end list is pickable before a start exists: order is up to the user.
       cy.get(sel.outItems).should('have.length', 7);
-      cy.get(sel.outItems).eq(0).should('have.attr', 'aria-disabled', 'true');
+      cy.get(sel.outItems).eq(0).should('have.attr', 'aria-disabled', 'false');
+    });
+
+    it('should keep an end picked before a start and commit once the start arrives', () => {
+      const formSubmitHandler = cy.stub().as('formSubmitHandler');
+      mountRangeTimePicker({ props: officeProps, formSubmit: formSubmitHandler });
+
+      cy.get(sel.startHour).click();
+      cy.get(sel.outItems).filter('[data-value="11:00:00"]').click();
+
+      // Nothing commits yet, but the end is kept in its field
+      cy.get(sel.pillText).should('have.length', 0);
+      cy.get(sel.endHour).should('have.value', '11');
+
+      cy.get(sel.inItems).filter('[data-value="09:00:00"]').click();
+      cy.get(sel.pillText).should('have.length', 1);
+
+      submitAndGetData('@formSubmitHandler').then((data) => {
+        expect(data).to.deep.equal({ myRanges: [{ start: '09:00:00', end: '11:00:00' }] });
+      });
+    });
+
+    it('should keep a half-picked range when the panel is closed and reopened', () => {
+      mountRangeTimePicker({ props: officeProps });
+
+      cy.get(sel.startHour).click();
+      cy.get(sel.inItems).filter('[data-value="10:00:00"]').click();
+
+      cy.get('body').click(0, 0);
+      cy.get(sel.panel).should('not.exist');
+
+      cy.get(sel.startHour).click();
+      cy.get(sel.panel).should('exist');
+      cy.get(sel.startHour).should('have.value', '10');
+      cy.get(sel.inItems)
+        .filter('.gui-time-list__option--selected')
+        .should('have.attr', 'data-value', '10:00:00');
     });
 
     it('should render localizable start/end column headings from startTimeLabel/endTimeLabel', () => {
@@ -251,11 +287,12 @@ export const runRangeTimePickerComponentTests = (mountFn: MountComponentFn) => {
       cy.focused().type('{enter}');
 
       cy.get(sel.pillText).should('have.length', 1);
-      // The panel stays open, but both lists reset: the start deselects and the
-      // end disables again, ready for the next range.
+      // The panel stays open and both lists reset ready for the next range:
+      // the start deselects and the end list is back to its full window.
       cy.get(sel.panel).should('exist');
       cy.get(sel.inItems).filter('.gui-time-list__option--selected').should('not.exist');
-      cy.get(sel.outItems).eq(0).should('have.attr', 'aria-disabled', 'true');
+      cy.get(sel.outItems).filter('.gui-time-list__option--selected').should('not.exist');
+      cy.get(sel.outItems).eq(0).should('have.attr', 'data-value', '09:00:00');
     });
 
     it('should fill the start/end input fields as options are picked from the lists', () => {
@@ -272,6 +309,19 @@ export const runRangeTimePickerComponentTests = (mountFn: MountComponentFn) => {
       cy.get(sel.pillText).should('have.length', 1).and('contain', '09:00');
       cy.get(sel.startHour).should('have.value', '');
       cy.get(sel.endHour).should('have.value', '');
+    });
+
+    it('should report an incomplete range when only the start time was picked', () => {
+      // One endpoint picked and the other left empty never became a pill, so
+      // leaving the widget must say so instead of dropping the entry silently.
+      mountRangeTimePicker({ props: officeProps });
+
+      cy.get(sel.startHour).click();
+      cy.get(sel.inItems).filter('[data-value="09:00:00"]').click();
+
+      cy.get('[data-cy="submitBtn_button"]').focus();
+      cy.get(`[data-cy="${uid}_validator-error"]`).should('contain.text', 'Incomplete time');
+      cy.get(sel.pillText).should('have.length', 0);
     });
 
     it('should not commit a range that spans a disabled block, keeping the values and showing the error', () => {

--- a/libs/ui-testing/src/lib/gui-features/rangetimepicker.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangetimepicker.cy.ts
@@ -275,6 +275,25 @@ export const runRangeTimePickerComponentTests = (mountFn: MountComponentFn) => {
       cy.get(sel.outItems).eq(0).should('have.attr', 'aria-disabled', 'false');
     });
 
+    it('should highlight the end list slot as soon as the last typed digit lands', () => {
+      mountRangeTimePicker({ props: { ...officeProps, allowCustomTime: true } });
+
+      cy.get(sel.startHour).click();
+      cy.get(sel.inItems).filter('[data-value="09:00:00"]').click();
+
+      // en-GB is 24h, so the end minute is the last field of the last group,
+      // with no day-period toggle after it to advance into. Nothing is clicked
+      // afterwards on purpose: the digit that completes the time is what has to
+      // commit it.
+      cy.get(sel.endHour).click();
+      cy.focused().type('11');
+      cy.focused().type('00');
+
+      cy.get(sel.outItems)
+        .filter('[data-value="11:00:00"]')
+        .should('have.attr', 'aria-selected', 'true');
+    });
+
     it('should reset both lists after a range is committed by typing and Enter', () => {
       mountRangeTimePicker({ props: { ...officeProps, allowCustomTime: true } });
 

--- a/libs/ui-testing/src/lib/gui-features/rangetimepicker.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangetimepicker.cy.ts
@@ -34,6 +34,8 @@ export const runRangeTimePickerComponentTests = (mountFn: MountComponentFn) => {
       data?: Record<string, any>;
       lang?: string;
       props?: Record<string, any>;
+      validator?: Record<string, any>;
+      validateOn?: 'blur' | 'change' | 'submit' | 'eager';
       formSubmit?: (event: any) => void;
       readonly?: boolean;
       disabled?: boolean;
@@ -41,6 +43,7 @@ export const runRangeTimePickerComponentTests = (mountFn: MountComponentFn) => {
       mountFn({
         localization: identityTranslator(options?.lang ?? 'en-GB'),
         data: options?.data,
+        ...(options?.validateOn ? { validateOn: options.validateOn } : {}),
         formDef: defineForm({
           form: [
             {
@@ -49,6 +52,7 @@ export const runRangeTimePickerComponentTests = (mountFn: MountComponentFn) => {
               type: 'rangeTimePicker',
               path: 'myRanges',
               ...(options?.props ? { props: options.props } : {}),
+              ...(options?.validator ? { validator: options.validator as any } : {}),
               ...(options?.readonly !== undefined ? { readonly: options.readonly } : {}),
               ...(options?.disabled !== undefined ? { disabled: options.disabled } : {}),
             },
@@ -341,6 +345,52 @@ export const runRangeTimePickerComponentTests = (mountFn: MountComponentFn) => {
       cy.get('[data-cy="submitBtn_button"]').focus();
       cy.get(`[data-cy="${uid}_validator-error"]`).should('contain.text', 'Incomplete time');
       cy.get(sel.pillText).should('have.length', 0);
+    });
+
+    it('should commit a complete typed range when focus leaves, without Enter', () => {
+      const formSubmit = cy.stub().as('formSubmit');
+      mountRangeTimePicker({
+        props: { ...officeProps, allowCustomTime: true },
+        formSubmit,
+      });
+
+      cy.get(sel.startHour).click();
+      cy.focused().type('09');
+      cy.focused().type('30');
+      cy.get(sel.endHour).click();
+      cy.focused().type('11');
+      cy.focused().type('00');
+      cy.get(sel.pillText).should('have.length', 0);
+
+      // One click leaves the widget and submits: leaving commits the finished
+      // range, and it has to settle before the form reads its data.
+      submitAndGetData('@formSubmit').then((data: any) => {
+        expect(data).to.deep.equal({ myRanges: [{ start: '09:30:00', end: '11:00:00' }] });
+      });
+      cy.get(sel.pillText).should('have.length', 1);
+    });
+
+    it('should not raise a required error over the range the leave just committed', () => {
+      // Under validateOn: 'blur' the blur IS the only validation pass, and
+      // storing a value runs none. So the leave has to commit BEFORE it blurs,
+      // or the pass judges the empty value the commit is about to replace and
+      // `required` ends up standing over a range that is now there.
+      mountRangeTimePicker({
+        props: { ...officeProps, allowCustomTime: true },
+        validator: { type: 'array', required: true },
+        validateOn: 'blur',
+      });
+
+      cy.get(sel.startHour).click();
+      cy.focused().type('09');
+      cy.focused().type('30');
+      cy.get(sel.endHour).click();
+      cy.focused().type('11');
+      cy.focused().type('00');
+
+      cy.get('[data-cy="submitBtn_button"]').focus();
+      cy.get(sel.pillText).should('have.length', 1);
+      cy.get(`[data-cy="${uid}_validator-errors"]`).should('not.exist');
     });
 
     it('should not commit a range that spans a disabled block, keeping the values and showing the error', () => {

--- a/libs/ui-testing/src/lib/gui-features/timeinput.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/timeinput.cy.ts
@@ -491,6 +491,21 @@ export const runTimeInputComponentTests = (mountFn: MountComponentFn) => {
         cy.get(sel.minute).type('30');
         cy.get('[data-cy="testSubject_validator-error"]').should('not.exist');
       });
+
+      it('should clear the incomplete error when the emptied widget is left again', () => {
+        // Regression: leave a partial behind (incomplete error), come back,
+        // empty the field and leave again — the error must not outlive
+        // fields that no longer hold anything.
+        mountTimeInput();
+
+        cy.get(sel.hour).type('09');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get('[data-cy="testSubject_validator-error"]').should('contain.text', 'Incomplete time');
+
+        cy.get(sel.hour).type('{selectAll}{backspace}');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get('[data-cy="testSubject_validator-errors"]').should('not.exist');
+      });
     });
 
     describe('readonly and disabled', () => {

--- a/libs/ui-testing/src/lib/gui-features/timeinput.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/timeinput.cy.ts
@@ -14,6 +14,7 @@ export const runTimeInputComponentTests = (mountFn: MountComponentFn) => {
       lang?: string;
       translator?: MutableI18nTranslator;
       props?: Record<string, any>;
+      validator?: Record<string, any>;
       formSubmit?: (event: any) => void;
       readonly?: boolean;
       disabled?: boolean;
@@ -29,6 +30,7 @@ export const runTimeInputComponentTests = (mountFn: MountComponentFn) => {
               type: 'timeInput',
               path: 'myTime',
               ...(options?.props ? { props: options.props } : {}),
+              ...(options?.validator ? { validator: options.validator as any } : {}),
               ...(options?.readonly !== undefined ? { readonly: options.readonly } : {}),
               ...(options?.disabled !== undefined ? { disabled: options.disabled } : {}),
             },
@@ -438,6 +440,20 @@ export const runTimeInputComponentTests = (mountFn: MountComponentFn) => {
     });
 
     describe('incomplete input on focus leave', () => {
+      it('should not validate while moving between the parts of one entry', () => {
+        // Filling a part auto-advances to the next one. That hop is not
+        // leaving the widget, so the form must not judge a half-typed entry:
+        // a required field lighting up after the first part is the bug.
+        mountTimeInput({ validator: { type: 'string', required: true } });
+
+        cy.get(sel.hour).type('09');
+        cy.get('[data-cy="testSubject_validator-errors"]').should('not.exist');
+
+        // Leaving the widget is the one moment the entry is judged
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get('[data-cy="testSubject_validator-errors"]').should('exist');
+      });
+
       it('should flip a partial time to null with an incomplete error when focus leaves', () => {
         mountTimeInput();
 

--- a/libs/ui-testing/src/lib/gui-features/timeinput.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/timeinput.cy.ts
@@ -415,16 +415,65 @@ export const runTimeInputComponentTests = (mountFn: MountComponentFn) => {
     });
 
     describe('blur', () => {
-      it('should emit a null value when a part is emptied and blurred', () => {
-        const formSubmitHandler = cy.stub().as('formSubmitHandler');
-        mountTimeInput({ data: { myTime: '14:30:00' }, formSubmit: formSubmitHandler });
+      it('should emit a null value and keep the other parts when one part is emptied', () => {
+        mountTimeInput({ data: { myTime: '14:30:00' } });
+
+        const changeSpy = cy.spy().as('changeSpy');
+        cy.get('gui-time').then(($el) => {
+          $el[0].addEventListener('change', changeSpy as unknown as EventListener);
+        });
 
         cy.get(sel.minute).type('{selectAll}{backspace}');
         cy.get(sel.minute).blur();
 
-        submitAndGetData('@formSubmitHandler').then((data) => {
-          expect(data).to.deep.equal({ myTime: null });
+        cy.get('@changeSpy').then((spy: any) => {
+          expect(spy.getCall(0).args[0].detail.value).to.equal(null);
         });
+
+        // Only the emptied part clears: the rest of the entry is not wiped
+        cy.get(sel.minute).should('have.value', '');
+        cy.get(sel.hour).should('have.value', '02');
+        expectDayPeriod('PM');
+      });
+    });
+
+    describe('incomplete input on focus leave', () => {
+      it('should flip a partial time to null with an incomplete error when focus leaves', () => {
+        mountTimeInput();
+
+        const changeSpy = cy.spy().as('changeSpy');
+        cy.get('gui-time').then(($el) => {
+          $el[0].addEventListener('change', changeSpy as unknown as EventListener);
+        });
+
+        cy.get(sel.hour).type('09');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+
+        cy.get('[data-cy="testSubject_validator-error"]').should('contain.text', 'Incomplete time');
+        cy.get('@changeSpy').then((spy: any) => {
+          expect(spy.getCall(0).args[0].detail.value).to.equal(null);
+        });
+      });
+
+      it('should show the incomplete error for a committed value left with an emptied part', () => {
+        mountTimeInput({ data: { myTime: '14:30:00' } });
+
+        cy.get(sel.minute).type('{selectAll}{backspace}');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+
+        cy.get('[data-cy="testSubject_validator-error"]').should('contain.text', 'Incomplete time');
+        cy.get(sel.hour).should('have.value', '02');
+      });
+
+      it('should clear the incomplete error once the time is completed', () => {
+        mountTimeInput();
+
+        cy.get(sel.hour).type('09');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get('[data-cy="testSubject_validator-error"]').should('contain.text', 'Incomplete time');
+
+        cy.get(sel.minute).type('30');
+        cy.get('[data-cy="testSubject_validator-error"]').should('not.exist');
       });
     });
 

--- a/libs/ui-testing/src/lib/gui-features/timepicker.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/timepicker.cy.ts
@@ -246,9 +246,10 @@ export const runTimePickerComponentTests = (mountFn: MountComponentFn) => {
         cy.get(sel.items).eq(2).click({ force: true });
         cy.get(sel.hour).should('have.value', '');
 
-        // Clicking away from the empty hour part emits the empty-part null
+        // The ignored click commits nothing: the value stays undefined (an
+        // empty part blur no longer emits null for a never-committed value)
         submitAndGetData('@formSubmitHandler').then((data) => {
-          expect(data).to.deep.equal({ myTime: null });
+          expect(data.myTime).to.equal(undefined);
         });
       });
 

--- a/libs/ui-testing/src/lib/gui-features/timepicker.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/timepicker.cy.ts
@@ -481,6 +481,52 @@ export const runTimePickerComponentTests = (mountFn: MountComponentFn) => {
           expect(spy.getCall(0).args[0].detail.message).to.equal('err.tooEarly');
         });
       });
+
+      it('should flip a partial typed time to null with an incomplete error when focus leaves', () => {
+        // Non-required field: the null report still marks it invalid, so the
+        // lingering partial is caught without a required validator
+        mountTimePicker({ props: { ...officeProps, allowCustomTime: true } });
+
+        cy.get(sel.hour).type('09');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+
+        cy.get('[data-cy="testSubject_validator-error"]').should(
+          'contain.text',
+          'Incomplete time',
+        );
+      });
+
+      it('should clear the incomplete error when the emptied picker is left again', () => {
+        // Regression: leave a partial behind (incomplete error), come back,
+        // empty the field and leave again — the error must not outlive
+        // fields that no longer hold anything.
+        mountTimePicker({ props: { ...officeProps, allowCustomTime: true } });
+
+        cy.get(sel.hour).type('09');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get('[data-cy="testSubject_validator-error"]').should(
+          'contain.text',
+          'Incomplete time',
+        );
+
+        cy.get(sel.hour).type('{selectAll}{backspace}', { force: true });
+        cy.get('[data-cy="submitBtn_button"]').focus();
+        cy.get('[data-cy="testSubject_validator-errors"]').should('not.exist');
+      });
+
+      it('should honor the incompleteMessage prop', () => {
+        mountTimePicker({
+          props: { ...officeProps, allowCustomTime: true, incompleteMessage: 'Incomplete time!' },
+        });
+
+        cy.get(sel.hour).type('09');
+        cy.get('[data-cy="submitBtn_button"]').focus();
+
+        cy.get('[data-cy="testSubject_validator-error"]').should(
+          'contain.text',
+          'Incomplete time!',
+        );
+      });
     });
 
     describe('readonly and disabled', () => {

--- a/skills/golemui/references/forms-dx.md
+++ b/skills/golemui/references/forms-dx.md
@@ -171,11 +171,16 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/currency.md
 Call: `gui.inputs.dateInput(path, { label, minDate?, maxDate?, validator? })`
 
 ```ts
-gui.inputs.dateInput('startDate', { label: 'Start date', validator: { required: true } });
+gui.inputs.dateInput('startDate', {
+  label: 'Start date',
+  incompleteMessage: 'Incomplete date!',
+  validator: { required: true },
+});
 ```
 
 - Typed date entry, NO calendar UI — use only when keyboard-first entry is wanted. For most dates use `datePicker` (popover calendar) instead. Accepts the loose `{ required: true }`.
 - `minDate` / `maxDate` (ISO `YYYY-MM-DD` strings) constrain the accepted range — see `datePicker`.
+- `incompleteMessage` overrides the "incomplete" error surfaced when focus leaves a partial entry — see `datePicker`.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/dateinput.md
 
@@ -193,6 +198,7 @@ gui.inputs.datePicker('startDate', {
 
 - THE DEFAULT single-date field: a text field with a popover calendar (click to open). Prefer this for most dates. (`calendar` = always-visible inline calendar; `dateInput` = typed entry, no calendar UI.) Accepts the loose `{ required: true }` validator.
 - Bound the selectable range with **`minDate`** / **`maxDate`** — ISO `YYYY-MM-DD` strings. For "today or later" set `minDate` to today’s date; for "not in the future" set `maxDate` to today. Same `minDate`/`maxDate` on `calendar`, `dateInput`, and the range date widgets.
+- A partially typed date abandoned on focus leave flips the value to null — flagging the field even when optional — and surfaces an "incomplete" error; **`incompleteMessage`** overrides its wording. The same prop exists on every typed date/time widget (the inputs, the pickers, `dateTimeCalendar` and the range inputs/pickers), and an emptied widget clears the error on the next focus leave.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/date-picker.md
 
@@ -210,7 +216,7 @@ gui.inputs.dateTimeCalendar('appointmentAt', {
 
 - An INLINE calendar with an embedded time picker: a segmented time input between the header and the days grid opens a time grid in place of the days (like the year selector).
 - Emits a local ISO date-time (`YYYY-MM-DDTHH:mm:ss`) only when BOTH day and time are selected — pair with a `{ type: 'string', format: 'date-time' }` validator. The time picker is usable before a day is picked, and picking a different day KEEPS the chosen time (re-emitting the full value), so the two halves can be chosen in either order.
-- Half-finished entries never emit: the value goes to null — flagging the field even when it is optional — only once focus leaves the widget with one half missing, which surfaces an "incomplete" message.
+- Half-finished entries never emit: the value goes to null — flagging the field even when it is optional — only once focus leaves the widget with one half missing, which surfaces an "incomplete" message (`incompleteMessage` overrides its wording).
 - `disabledTimeRanges` entries take `start`/`end` ISO times plus optional `date` (ISO date) and/or `weekdays` (getDay() numbering: 0=Sunday … 6=Saturday) to scope the range to specific days.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/datetimecalendar.md
@@ -224,6 +230,7 @@ gui.inputs.dateTimeInput('meetingAt', { label: 'Meeting at' });
 ```
 
 - Typed date+time entry in one locale-ordered row. Emits a local ISO date-time (`YYYY-MM-DDTHH:mm:ss`) — pair with the `{ format: 'date-time' }` validator. `hourFormat`/`minuteStep` as in `timeInput`.
+- `incompleteMessage` overrides the "incomplete" error surfaced when focus leaves a partial entry — see `datePicker`.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/datetimeinput.md
 
@@ -241,7 +248,7 @@ gui.inputs.dateTimePicker('appointmentAt', {
 
 - A compact date-time FIELD that opens a `dateTimeCalendar` POPOVER on focus — the space-saving counterpart to the inline `dateTimeCalendar`, like `datePicker` is to `calendar`.
 - Emits a local ISO date-time (`YYYY-MM-DDTHH:mm:ss`); the popover closes only when BOTH day and time are selected. Pair with a `{ type: 'string', format: 'date-time' }` validator.
-- Takes the same time props as `dateTimeCalendar` (`minTime`/`maxTime`/`minuteStep`/`disabledTimeRanges` with per-date/weekday scoping/`allowCustomTime`) plus `icon` and `invalidDateMessage` for the typed input.
+- Takes the same time props as `dateTimeCalendar` (`minTime`/`maxTime`/`minuteStep`/`disabledTimeRanges` with per-date/weekday scoping/`allowCustomTime`) plus `icon`, `invalidDateMessage` and `incompleteMessage` for the typed input.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/datetimepicker.md
 
@@ -437,6 +444,7 @@ gui.inputs.rangeDateInput('stayDates', { label: 'Stay dates' });
 ```
 
 - Typed start–end date **range** entry (the range sibling of `dateInput`).
+- `incompleteMessage` overrides the "incomplete" error surfaced when focus leaves with only one endpoint filled — see `datePicker`.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/range-date-input.md
 
@@ -448,7 +456,7 @@ Call: `gui.inputs.rangeDatePicker(path, { label? })`
 gui.inputs.rangeDatePicker('stayDates', { label: 'Stay dates' });
 ```
 
-- Popover calendar for a start–end date **range** (the range sibling of `datePicker`). A span with only its first day picked is held by the picker, so it survives closing and reopening the popover.
+- Popover calendar for a start–end date **range** (the range sibling of `datePicker`). A span with only its first day picked is held by the picker, so it survives closing and reopening the popover. Leaving it that way surfaces an "incomplete" error (`incompleteMessage` overrides its wording).
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/range-date-picker.md
 
@@ -483,6 +491,7 @@ gui.inputs.rangeDateTimeInput('window', {
 
 - Typed start–end date-time **range** entry (the range sibling of `dateTimeInput`); value is `DateTimeRange[]`. A backward selection reorders (swaps) instead of erroring.
 - Each endpoint is an instant, so it is bounded by instants: use **`minDateTime`** / **`maxDateTime`** (ISO `YYYY-MM-DDTHH:mm:ss`), not `minDate`/`maxDate`. There is no `minTime`/`maxTime` here — a per-day time window is a different constraint from an instant bound.
+- `incompleteMessage` overrides the "incomplete" error surfaced when focus leaves with only one endpoint filled — see `datePicker`.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/range-datetime-input.md
 
@@ -498,7 +507,7 @@ gui.inputs.rangeDateTimePicker('stay', {
 });
 ```
 
-- POPOVER date-time range picker: the typed `rangeDateTimeInput` as the trigger (pills live there) with the `rangeDateTimeCalendar` in a dropdown. Value is `DateTimeRange[]`. Committing a pill keeps the popover open so several ranges can be added; it closes on outside-click, blur or Escape. A half-finished selection is held by the picker, so it survives closing and reopening the popover.
+- POPOVER date-time range picker: the typed `rangeDateTimeInput` as the trigger (pills live there) with the `rangeDateTimeCalendar` in a dropdown. Value is `DateTimeRange[]`. Committing a pill keeps the popover open so several ranges can be added; it closes on outside-click, blur or Escape. A half-finished selection is held by the picker, so it survives closing and reopening the popover. Leaving it that way surfaces an "incomplete" error (`incompleteMessage` overrides its wording).
 - Everything is in instant-space: bounds are **`minDateTime`** / **`maxDateTime`** and **`disabledRanges`** are `DateTimeRange[]` instant spans (block a whole day with `00:00:00`–`23:59:59`). There is no `minDate`/`maxDate`/`minTime`/`maxTime`/`disabledTimeRanges`.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/range-datetime-picker.md
@@ -512,6 +521,7 @@ gui.inputs.rangeTimeInput('shift', { label: 'Shift', minTime: '06:00:00', maxTim
 ```
 
 - Typed start–end time **range** entry (the range sibling of `timeInput`); value is `TimeRange[]`. End time must be after start time.
+- `incompleteMessage` overrides the "incomplete" error surfaced when focus leaves with only one endpoint filled — see `datePicker`.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/range-time-input.md
 
@@ -524,6 +534,7 @@ gui.inputs.rangeTimePicker('shift', { label: 'Shift', minTime: '06:00:00', maxTi
 ```
 
 - Two-list popover for a start–end time **range** (the range sibling of `timePicker`); value is `TimeRange[]`. Either list can be used first — an end picked before a start simply waits — and the range commits once both are set. Once an in is chosen the out list floors one slot after it so end is strictly after start.
+- `incompleteMessage` overrides the "incomplete" error surfaced when focus leaves with only one endpoint set — see `datePicker`.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/range-time-picker.md
 
@@ -629,6 +640,7 @@ gui.inputs.timeInput('meetingTime', { label: 'Meeting time', minuteStep: 15 });
 ```
 
 - Typed time entry (hh:mm segments). Emits an ISO time string (`HH:mm:ss`) — pair with the `{ format: 'time' }` validator. `hourFormat` forces '12'/'24' (default: locale); `minuteStep` sets the arrow-key minute increment.
+- `incompleteMessage` overrides the "incomplete" error surfaced when focus leaves a partial entry — see `datePicker`.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/timeinput.md
 
@@ -646,6 +658,7 @@ gui.inputs.timePicker('meetingTime', {
 ```
 
 - Time field with a popover list of slots built from `minTime`..`maxTime` stepping `minuteStep` (default 30). `disabledRanges` (`{ start, end }[]`, inclusive) greys slots out. Typing is off unless `allowCustomTime: true`. Emits `HH:mm:ss` — pair with the `{ format: 'time' }` validator.
+- `incompleteMessage` overrides the "incomplete" error surfaced when focus leaves a partial typed entry — see `datePicker`.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/timepicker.md
 

--- a/skills/golemui/references/forms-dx.md
+++ b/skills/golemui/references/forms-dx.md
@@ -73,7 +73,9 @@ Every `gui.*` factory and its calling convention. Look up the detail below for t
 Call: `gui.layouts.accordion(sections)`
 
 ```ts
-gui.layouts.accordion([ { label: 'Billing', children: [ gui.inputs.textInput('card', { label: 'Card' }) ] } ])
+gui.layouts.accordion([
+  { label: 'Billing', children: [gui.inputs.textInput('card', { label: 'Card' })] },
+]);
 ```
 
 - Takes `sections: { label, children, uid? }[]` — same shape as `tabs`, rendered as collapsible panels.
@@ -85,7 +87,7 @@ Reference: https://golemui.com/dx/widgets-reference/layout-fields/accordion.md
 Call: `gui.displays.alert({ text })`
 
 ```ts
-gui.displays.alert({ text: 'Please review your details before submitting.' })
+gui.displays.alert({ text: 'Please review your details before submitting.' });
 ```
 
 - Static, non-input callout. Uses **`text`** (not `content`). Displays do not take a `path`.
@@ -97,7 +99,7 @@ Reference: https://golemui.com/dx/widgets-reference/display-fields/alert.md
 Call: `gui.inputs.booleanInput(path, { label, defaultValue? })`
 
 ```ts
-gui.inputs.booleanInput('newsletter', { label: 'Subscribe to newsletter', defaultValue: false })
+gui.inputs.booleanInput('newsletter', { label: 'Subscribe to newsletter', defaultValue: false });
 ```
 
 - The on/off toggle for a single boolean. Use `checkbox` for a checkbox presentation.
@@ -109,7 +111,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/toggle.md
 Call: `gui.actions.button({ label, actionType?: 'submit', onClick? })`
 
 ```ts
-gui.actions.button({ label: 'Sign up', actionType: 'submit' })
+gui.actions.button({ label: 'Sign up', actionType: 'submit' });
 ```
 
 - Submit button: `gui.actions.button({ label, actionType: 'submit' })`.
@@ -123,7 +125,7 @@ Reference: https://golemui.com/dx/widgets-reference/interactive-fields/button.md
 Call: `gui.inputs.calendar(path, { label, minDate?, maxDate? })`
 
 ```ts
-gui.inputs.calendar('day', { label: 'Pick a day', minDate: '2025-01-01' })
+gui.inputs.calendar('day', { label: 'Pick a day', minDate: '2025-01-01' });
 ```
 
 - An always-visible INLINE calendar (no popover) — use when the calendar should be shown on the page. For a compact single-date field use `datePicker` instead.
@@ -136,7 +138,14 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/calendar.md
 Call: `gui.inputs.checkbox(path, { label, defaultValue?, validator? })`
 
 ```ts
-gui.inputs.checkbox('terms', { label: 'I accept the terms', validator: { required: true, const: true, messages: { invalid: 'You must accept the terms', const: 'You must accept the terms' } } })
+gui.inputs.checkbox('terms', {
+  label: 'I accept the terms',
+  validator: {
+    required: true,
+    const: true,
+    messages: { invalid: 'You must accept the terms', const: 'You must accept the terms' },
+  },
+});
 ```
 
 - A single boolean rendered as a checkbox.
@@ -150,7 +159,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/checkbox.md
 Call: `gui.inputs.currency(path, { label, validator? })`
 
 ```ts
-gui.inputs.currency('price', { label: 'Price', validator: { required: true, minimum: 0 } })
+gui.inputs.currency('price', { label: 'Price', validator: { required: true, minimum: 0 } });
 ```
 
 - Numeric money input; number-style validator.
@@ -162,7 +171,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/currency.md
 Call: `gui.inputs.dateInput(path, { label, minDate?, maxDate?, validator? })`
 
 ```ts
-gui.inputs.dateInput('startDate', { label: 'Start date', validator: { required: true } })
+gui.inputs.dateInput('startDate', { label: 'Start date', validator: { required: true } });
 ```
 
 - Typed date entry, NO calendar UI — use only when keyboard-first entry is wanted. For most dates use `datePicker` (popover calendar) instead. Accepts the loose `{ required: true }`.
@@ -175,7 +184,11 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/dateinput.md
 Call: `gui.inputs.datePicker(path, { label, minDate?, maxDate?, validator? })`
 
 ```ts
-gui.inputs.datePicker('startDate', { label: 'Coverage start', minDate: '2025-01-01', validator: { required: true } })
+gui.inputs.datePicker('startDate', {
+  label: 'Coverage start',
+  minDate: '2025-01-01',
+  validator: { required: true },
+});
 ```
 
 - THE DEFAULT single-date field: a text field with a popover calendar (click to open). Prefer this for most dates. (`calendar` = always-visible inline calendar; `dateInput` = typed entry, no calendar UI.) Accepts the loose `{ required: true }` validator.
@@ -188,7 +201,11 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/date-picker.md
 Call: `gui.inputs.dateTimeCalendar(path, { label, minDate?, maxDate?, minTime?, maxTime?, minuteStep?, disabledTimeRanges?, allowCustomTime? })`
 
 ```ts
-gui.inputs.dateTimeCalendar('appointmentAt', { label: 'Appointment', minTime: '09:00', maxTime: '18:00' })
+gui.inputs.dateTimeCalendar('appointmentAt', {
+  label: 'Appointment',
+  minTime: '09:00',
+  maxTime: '18:00',
+});
 ```
 
 - An INLINE calendar with an embedded time picker: a segmented time input between the header and the days grid opens a time grid in place of the days (like the year selector).
@@ -202,7 +219,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/datetimecalenda
 Call: `gui.inputs.dateTimeInput(path, { label, hourFormat?, minuteStep?, validator? })`
 
 ```ts
-gui.inputs.dateTimeInput('meetingAt', { label: 'Meeting at' })
+gui.inputs.dateTimeInput('meetingAt', { label: 'Meeting at' });
 ```
 
 - Typed date+time entry in one locale-ordered row. Emits a local ISO date-time (`YYYY-MM-DDTHH:mm:ss`) — pair with the `{ format: 'date-time' }` validator. `hourFormat`/`minuteStep` as in `timeInput`.
@@ -214,7 +231,11 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/datetimeinput.m
 Call: `gui.inputs.dateTimePicker(path, { label, minDate?, maxDate?, minTime?, maxTime?, minuteStep?, disabledTimeRanges?, allowCustomTime? })`
 
 ```ts
-gui.inputs.dateTimePicker('appointmentAt', { label: 'Appointment', minTime: '09:00', maxTime: '18:00' })
+gui.inputs.dateTimePicker('appointmentAt', {
+  label: 'Appointment',
+  minTime: '09:00',
+  maxTime: '18:00',
+});
 ```
 
 - A compact date-time FIELD that opens a `dateTimeCalendar` POPOVER on focus — the space-saving counterpart to the inline `dateTimeCalendar`, like `datePicker` is to `calendar`.
@@ -228,7 +249,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/datetimepicker.
 Call: `gui.displays.display(render)`
 
 ```ts
-gui.displays.display(() => 'Order summary')
+gui.displays.display(() => 'Order summary');
 ```
 
 - **The go-to for a static heading or any standalone/formatted block.** Return your framework’s own content from the render function — React: `gui.displays.display(() => <h2>Member enrollment</h2>)`; Vue/Angular/Lit: return that framework’s node. It renders immediately with **zero registration and no parser dependency** — this is how you put a heading or any static block in a form (GolemUI itself never renders content for display).
@@ -241,7 +262,14 @@ Reference: https://golemui.com/dx/widgets-reference/display-fields/renderer.md
 Call: `gui.inputs.dropdown(path, { label, items, validator? })`
 
 ```ts
-gui.inputs.dropdown('country', { label: 'Country', items: [{ value: 'us', label: 'United States' }, { value: 'ca', label: 'Canada' }], validator: { type: 'string', required: true } })
+gui.inputs.dropdown('country', {
+  label: 'Country',
+  items: [
+    { value: 'us', label: 'United States' },
+    { value: 'ca', label: 'Canada' },
+  ],
+  validator: { type: 'string', required: true },
+});
 ```
 
 - Choice list uses **`items`** (`{ value, label }[]`).
@@ -254,7 +282,10 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/dropdown.md
 Call: `gui.layouts.flex(children, props?)`
 
 ```ts
-gui.layouts.flex([ gui.inputs.textInput('firstName', { label: 'First name' }), gui.inputs.textInput('lastName', { label: 'Last name' }) ])
+gui.layouts.flex([
+  gui.inputs.textInput('firstName', { label: 'First name' }),
+  gui.inputs.textInput('lastName', { label: 'Last name' }),
+]);
 ```
 
 - Layouts take the **children array first**, then optional props — unlike inputs (path first).
@@ -267,7 +298,10 @@ Reference: https://golemui.com/dx/widgets-reference/layout-fields/flex.md
 Call: `gui.layouts.grid(children, props?)`
 
 ```ts
-gui.layouts.grid([ gui.inputs.textInput('a', { label: 'A' }), gui.inputs.textInput('b', { label: 'B' }) ])
+gui.layouts.grid([
+  gui.inputs.textInput('a', { label: 'A' }),
+  gui.inputs.textInput('b', { label: 'B' }),
+]);
 ```
 
 - Grid layout; `horizontalGrid` / `verticalGrid` lock the direction.
@@ -279,7 +313,10 @@ Reference: https://golemui.com/dx/widgets-reference/layout-fields/grid.md
 Call: `gui.layouts.horizontalFlex(children, props?)`
 
 ```ts
-gui.layouts.horizontalFlex([ gui.inputs.textInput('a', { label: 'A' }), gui.inputs.textInput('b', { label: 'B' }) ])
+gui.layouts.horizontalFlex([
+  gui.inputs.textInput('a', { label: 'A' }),
+  gui.inputs.textInput('b', { label: 'B' }),
+]);
 ```
 
 - A `flex` with direction fixed to horizontal.
@@ -291,7 +328,10 @@ Reference: https://golemui.com/dx/widgets-reference/layout-fields/flex.md
 Call: `gui.layouts.horizontalGrid(children, props?)`
 
 ```ts
-gui.layouts.horizontalGrid([ gui.inputs.textInput('a', { label: 'A' }), gui.inputs.textInput('b', { label: 'B' }) ])
+gui.layouts.horizontalGrid([
+  gui.inputs.textInput('a', { label: 'A' }),
+  gui.inputs.textInput('b', { label: 'B' }),
+]);
 ```
 
 - A `grid` with direction fixed to horizontal.
@@ -303,7 +343,12 @@ Reference: https://golemui.com/dx/widgets-reference/layout-fields/grid.md
 Call: `gui.inputs.list(path, { label, items, height?, itemHeight? })`
 
 ```ts
-gui.inputs.list('selection', { label: 'Pick an option', items: ['Option 1', 'Option 2', 'Option 3'], height: 200, itemHeight: 40 })
+gui.inputs.list('selection', {
+  label: 'Pick an option',
+  items: ['Option 1', 'Option 2', 'Option 3'],
+  height: 200,
+  itemHeight: 40,
+});
 ```
 
 - A scrolling selection list. `items` is a string array (or `{ value, label }[]`).
@@ -316,10 +361,10 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/list.md
 Call: `gui.inputs.markdown(path, { label })`
 
 ```ts
-gui.inputs.markdown('notes', { label: 'Notes (markdown)' })
+gui.inputs.markdown('notes', { label: 'Notes (markdown)' });
 ```
 
-- A markdown *editor input* — the user types markdown and the value IS that markdown string. This is the ONLY use of markdown in GolemUI: there is no markdown-for-display. For a heading or static block, use `gui.displays.display(() => <node>)` (your host renders it), never a markdown widget.
+- A markdown _editor input_ — the user types markdown and the value IS that markdown string. This is the ONLY use of markdown in GolemUI: there is no markdown-for-display. For a heading or static block, use `gui.displays.display(() => <node>)` (your host renders it), never a markdown widget.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/markdown.md
 
@@ -328,7 +373,10 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/markdown.md
 Call: `gui.inputs.numberInput(path, { label, defaultValue?, validator? })`
 
 ```ts
-gui.inputs.numberInput('age', { label: 'Age', validator: { required: true, minimum: 0, maximum: 120 } })
+gui.inputs.numberInput('age', {
+  label: 'Age',
+  validator: { required: true, minimum: 0, maximum: 120 },
+});
 ```
 
 - Number validator: `{ required, minimum, maximum, exclusiveMinimum, exclusiveMaximum, multipleOf }`.
@@ -340,7 +388,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/number.md
 Call: `gui.inputs.password(path, { label, validator? })`
 
 ```ts
-gui.inputs.password('password', { label: 'Password', validator: { required: true, minLength: 8 } })
+gui.inputs.password('password', { label: 'Password', validator: { required: true, minLength: 8 } });
 ```
 
 - Masked text input; loose string validator.
@@ -352,7 +400,14 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/password.md
 Call: `gui.inputs.radiogroup(path, { label, options, defaultValue?, validator? })`
 
 ```ts
-gui.inputs.radiogroup('accountType', { label: 'Account type', defaultValue: 'personal', options: [{ value: 'personal', label: 'Personal' }, { value: 'business', label: 'Business' }] })
+gui.inputs.radiogroup('accountType', {
+  label: 'Account type',
+  defaultValue: 'personal',
+  options: [
+    { value: 'personal', label: 'Personal' },
+    { value: 'business', label: 'Business' },
+  ],
+});
 ```
 
 - Radio group uses **`options`** (`{ value, label }[]`) — note the asymmetry: `dropdown` uses `items`, `radiogroup` uses `options`.
@@ -365,7 +420,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/radiogroup.md
 Call: `gui.inputs.rangeCalendar(path, { label? })`
 
 ```ts
-gui.inputs.rangeCalendar('stayDates', { label: 'Stay dates' })
+gui.inputs.rangeCalendar('stayDates', { label: 'Stay dates' });
 ```
 
 - Inline calendar for a start–end date **range** (the value is a date range). For a single date use `calendar`.
@@ -377,7 +432,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/range-calendar.
 Call: `gui.inputs.rangeDateInput(path, { label? })`
 
 ```ts
-gui.inputs.rangeDateInput('stayDates', { label: 'Stay dates' })
+gui.inputs.rangeDateInput('stayDates', { label: 'Stay dates' });
 ```
 
 - Typed start–end date **range** entry (the range sibling of `dateInput`).
@@ -389,7 +444,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/range-date-inpu
 Call: `gui.inputs.rangeDatePicker(path, { label? })`
 
 ```ts
-gui.inputs.rangeDatePicker('stayDates', { label: 'Stay dates' })
+gui.inputs.rangeDatePicker('stayDates', { label: 'Stay dates' });
 ```
 
 - Popover calendar for a start–end date **range** (the range sibling of `datePicker`).
@@ -401,7 +456,11 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/range-date-pick
 Call: `gui.inputs.rangeDateTimeCalendar(path, { label?, minDateTime?, maxDateTime?, disabledRanges?, startTimeLabel?, endTimeLabel? })`
 
 ```ts
-gui.inputs.rangeDateTimeCalendar('stay', { label: 'Stay', startTimeLabel: 'Check-in', endTimeLabel: 'Check-out' })
+gui.inputs.rangeDateTimeCalendar('stay', {
+  label: 'Stay',
+  startTimeLabel: 'Check-in',
+  endTimeLabel: 'Check-out',
+});
 ```
 
 - INLINE range calendar with TWO embedded time pickers (start/end); value is `DateTimeRange[]`, rendered as pills. Pick a date range, then a start time (enables the end time), then an end time to commit a pill. A day holding more than one range shows a count badge.
@@ -414,7 +473,11 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/range-datetime-
 Call: `gui.inputs.rangeDateTimeInput(path, { label?, minDateTime?, maxDateTime? })`
 
 ```ts
-gui.inputs.rangeDateTimeInput('window', { label: 'Window', minDateTime: '2026-03-01T06:00:00', maxDateTime: '2026-03-31T22:00:00' })
+gui.inputs.rangeDateTimeInput('window', {
+  label: 'Window',
+  minDateTime: '2026-03-01T06:00:00',
+  maxDateTime: '2026-03-31T22:00:00',
+});
 ```
 
 - Typed start–end date-time **range** entry (the range sibling of `dateTimeInput`); value is `DateTimeRange[]`. A backward selection reorders (swaps) instead of erroring.
@@ -427,7 +490,11 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/range-datetime-
 Call: `gui.inputs.rangeDateTimePicker(path, { label?, minDateTime?, maxDateTime?, disabledRanges?, startTimeLabel?, endTimeLabel? })`
 
 ```ts
-gui.inputs.rangeDateTimePicker('stay', { label: 'Stay', startTimeLabel: 'Check-in', endTimeLabel: 'Check-out' })
+gui.inputs.rangeDateTimePicker('stay', {
+  label: 'Stay',
+  startTimeLabel: 'Check-in',
+  endTimeLabel: 'Check-out',
+});
 ```
 
 - POPOVER date-time range picker: the typed `rangeDateTimeInput` as the trigger (pills live there) with the `rangeDateTimeCalendar` in a dropdown. Value is `DateTimeRange[]`. Committing a pill keeps the popover open so several ranges can be added; it closes on outside-click, blur or Escape.
@@ -440,7 +507,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/range-datetime-
 Call: `gui.inputs.rangeTimeInput(path, { label?, minTime?, maxTime? })`
 
 ```ts
-gui.inputs.rangeTimeInput('shift', { label: 'Shift', minTime: '06:00:00', maxTime: '22:00:00' })
+gui.inputs.rangeTimeInput('shift', { label: 'Shift', minTime: '06:00:00', maxTime: '22:00:00' });
 ```
 
 - Typed start–end time **range** entry (the range sibling of `timeInput`); value is `TimeRange[]`. End time must be after start time.
@@ -452,7 +519,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/range-time-inpu
 Call: `gui.inputs.rangeTimePicker(path, { label?, minTime?, maxTime? })`
 
 ```ts
-gui.inputs.rangeTimePicker('shift', { label: 'Shift', minTime: '06:00:00', maxTime: '22:00:00' })
+gui.inputs.rangeTimePicker('shift', { label: 'Shift', minTime: '06:00:00', maxTime: '22:00:00' });
 ```
 
 - Two-list popover for a start–end time **range** (the range sibling of `timePicker`); value is `TimeRange[]`. The out list floors one slot after the chosen in so end is strictly after start.
@@ -464,7 +531,11 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/range-time-pick
 Call: `gui.inputs.repeater(path, { label?, addLabel?, removeLabel?, limit?, template })`
 
 ```ts
-gui.inputs.repeater('attendees', { label: 'Attendees', addLabel: 'Add attendee', template: [ gui.inputs.textInput('attendees.items.name', { label: 'Name' }) ] })
+gui.inputs.repeater('attendees', {
+  label: 'Attendees',
+  addLabel: 'Add attendee',
+  template: [gui.inputs.textInput('attendees.items.name', { label: 'Name' })],
+});
 ```
 
 - The variable-length array field: the user adds/removes rows at runtime, each rendering the `template`. This is the idiomatic way to collect an UNKNOWN number of items — do NOT hand-roll N pre-generated copies gated by `include.when` (a common but wrong workaround).
@@ -478,7 +549,14 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/repeater.md
 Call: `gui.inputs.select(path, { label, options, validator? })`
 
 ```ts
-gui.inputs.select('plan', { label: 'Plan', options: [{ value: 'free', label: 'Free' }, { value: 'pro', label: 'Pro' }], validator: { type: 'string', required: true } })
+gui.inputs.select('plan', {
+  label: 'Plan',
+  options: [
+    { value: 'free', label: 'Free' },
+    { value: 'pro', label: 'Pro' },
+  ],
+  validator: { type: 'string', required: true },
+});
 ```
 
 - Choice widget that uses **`options`** (like `radiogroup`) — NOT `items` (which `dropdown` uses).
@@ -491,7 +569,10 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/select.md
 Call: `gui.layouts.tabs(sections)`
 
 ```ts
-gui.layouts.tabs([ { label: 'Account', children: [ gui.inputs.textInput('email', { label: 'Email' }) ] }, { label: 'Profile', children: [ gui.inputs.textInput('name', { label: 'Name' }) ] } ])
+gui.layouts.tabs([
+  { label: 'Account', children: [gui.inputs.textInput('email', { label: 'Email' })] },
+  { label: 'Profile', children: [gui.inputs.textInput('name', { label: 'Name' })] },
+]);
 ```
 
 - Takes `sections: { label, children, uid? }[]` — each section is a tab with its own children.
@@ -503,7 +584,7 @@ Reference: https://golemui.com/dx/widgets-reference/layout-fields/tabs.md
 Call: `gui.inputs.tags(path, { label })`
 
 ```ts
-gui.inputs.tags('skills', { label: 'Skills' })
+gui.inputs.tags('skills', { label: 'Skills' });
 ```
 
 - Free-form multi-value tag input; the value is a string array.
@@ -515,7 +596,10 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/tags.md
 Call: `gui.inputs.textInput(path, { label, placeholder?, defaultValue?, validator? })`
 
 ```ts
-gui.inputs.textInput('fullName', { label: 'Full name', validator: { required: true, minLength: 2 } })
+gui.inputs.textInput('fullName', {
+  label: 'Full name',
+  validator: { required: true, minLength: 2 },
+});
 ```
 
 - Text fields accept a loose validator: `{ required, minLength, maxLength, pattern, format }` (no `type` needed).
@@ -528,7 +612,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/textinput.md
 Call: `gui.inputs.textarea(path, { label, placeholder?, validator? })`
 
 ```ts
-gui.inputs.textarea('bio', { label: 'Bio', validator: { maxLength: 500 } })
+gui.inputs.textarea('bio', { label: 'Bio', validator: { maxLength: 500 } });
 ```
 
 - Multi-line text; same loose string validator as `textInput`.
@@ -540,7 +624,7 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/textarea.md
 Call: `gui.inputs.timeInput(path, { label, hourFormat?, minuteStep?, validator? })`
 
 ```ts
-gui.inputs.timeInput('meetingTime', { label: 'Meeting time', minuteStep: 15 })
+gui.inputs.timeInput('meetingTime', { label: 'Meeting time', minuteStep: 15 });
 ```
 
 - Typed time entry (hh:mm segments). Emits an ISO time string (`HH:mm:ss`) — pair with the `{ format: 'time' }` validator. `hourFormat` forces '12'/'24' (default: locale); `minuteStep` sets the arrow-key minute increment.
@@ -552,7 +636,12 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/timeinput.md
 Call: `gui.inputs.timePicker(path, { label, minTime?, maxTime?, minuteStep?, disabledRanges?, allowCustomTime?, validator? })`
 
 ```ts
-gui.inputs.timePicker('meetingTime', { label: 'Meeting time', minTime: '09:00', maxTime: '18:00', minuteStep: 30 })
+gui.inputs.timePicker('meetingTime', {
+  label: 'Meeting time',
+  minTime: '09:00',
+  maxTime: '18:00',
+  minuteStep: 30,
+});
 ```
 
 - Time field with a popover list of slots built from `minTime`..`maxTime` stepping `minuteStep` (default 30). `disabledRanges` (`{ start, end }[]`, inclusive) greys slots out. Typing is off unless `allowCustomTime: true`. Emits `HH:mm:ss` — pair with the `{ format: 'time' }` validator.
@@ -564,7 +653,10 @@ Reference: https://golemui.com/dx/widgets-reference/input-fields/timepicker.md
 Call: `gui.layouts.verticalFlex(children, props?)`
 
 ```ts
-gui.layouts.verticalFlex([ gui.inputs.textInput('a', { label: 'A' }), gui.inputs.textInput('b', { label: 'B' }) ])
+gui.layouts.verticalFlex([
+  gui.inputs.textInput('a', { label: 'A' }),
+  gui.inputs.textInput('b', { label: 'B' }),
+]);
 ```
 
 - A `flex` with direction fixed to vertical.
@@ -576,7 +668,10 @@ Reference: https://golemui.com/dx/widgets-reference/layout-fields/flex.md
 Call: `gui.layouts.verticalGrid(children, props?)`
 
 ```ts
-gui.layouts.verticalGrid([ gui.inputs.textInput('a', { label: 'A' }), gui.inputs.textInput('b', { label: 'B' }) ])
+gui.layouts.verticalGrid([
+  gui.inputs.textInput('a', { label: 'A' }),
+  gui.inputs.textInput('b', { label: 'B' }),
+]);
 ```
 
 - A `grid` with direction fixed to vertical.
@@ -590,7 +685,10 @@ Cross-cutting patterns that apply to every factory (not a factory themselves).
 ## Show or hide a field conditionally (hide-when)
 
 ```ts
-gui.inputs.textInput('promoCode', { label: 'Promo code', include: { when: '$form.hasPromoCode === true' } })
+gui.inputs.textInput('promoCode', {
+  label: 'Promo code',
+  include: { when: '$form.hasPromoCode === true' },
+});
 ```
 
 - `include` and `exclude` are common config fields on EVERY `gui.*` item — pass them inside the factory's config argument (the same object as `label`): `gui.inputs.textInput('promoCode', { label, include: { when: '$form.hasPromoCode === true' } })`. `include` shows the field only while the expression is true; `exclude` hides it while true.
@@ -600,7 +698,7 @@ gui.inputs.textInput('promoCode', { label: 'Promo code', include: { when: '$form
 ## Declare named form-level states (and gate fields by them)
 
 ```ts
-gui.inputs.textInput('spouseName', { label: 'Spouse name', include: { in: ['familyCoverage'] } })
+gui.inputs.textInput('spouseName', { label: 'Spouse name', include: { in: ['familyCoverage'] } });
 ```
 
 - Named states are form-level: declare them in `formConfig.states`, a sibling of `formDef` on the `<GuiForm>` config — NOT a wrapper around the array. `formConfig.states` maps each state name to a `ReactiveExpression` string, e.g. `{ familyCoverage: '$form.coverageType === \'family\'' }`. Then any item references it by name: `include: { in: ['familyCoverage'] }` (show while true) / `exclude: { from: ['familyCoverage'] }` (hide while true).
@@ -610,7 +708,11 @@ gui.inputs.textInput('spouseName', { label: 'Spouse name', include: { in: ['fami
 ## Conditional & state-driven props (enable/disable, show/hide, readonly)
 
 ```ts
-gui.actions.button({ label: 'Submit', actionType: 'submit', disabled: { when: '$formIsInvalid || $form.email === undefined' } })
+gui.actions.button({
+  label: 'Submit',
+  actionType: 'submit',
+  disabled: { when: '$formIsInvalid || $form.email === undefined' },
+});
 ```
 
 - ENABLE/DISABLE & READONLY: `disabled` and `readonly` are typed `boolean | { when: <expr> }`. `$formIsInvalid` is a built-in validity flag — do not declare it as a state.
@@ -621,11 +723,21 @@ gui.actions.button({ label: 'Submit', actionType: 'submit', disabled: { when: '$
 ## Validation rules & custom error messages (required, const, messages)
 
 ```ts
-gui.inputs.textInput('email', { label: 'Email', validator: { required: true, format: 'email', messages: { invalid: 'Email is required', required: 'Email is required', format: 'Enter a valid email address' } } })
+gui.inputs.textInput('email', {
+  label: 'Email',
+  validator: {
+    required: true,
+    format: 'email',
+    messages: {
+      invalid: 'Email is required',
+      required: 'Email is required',
+      format: 'Enter a valid email address',
+    },
+  },
+});
 ```
 
 - Every validator accepts a `messages` map from rule name to custom error text (string or i18n `{ key, params?, default? }`). Keys per type — string: `invalid`, `required`, `minLength`, `maxLength`, `pattern`, `format`, `enum`, `const`; number: `invalid`, `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`, `enum`, `const`; boolean: `invalid`, `const`; array: `invalid`, `required`, `minItems`, `maxItems`. The special key `invalid` customizes the base type check. Set custom messages for every rule you use — the library defaults (e.g. "Invalid input: expected string, received undefined") are developer-facing, not user-facing.
 - ALWAYS pair `messages.required` with `messages.invalid` (same text): an `undefined`/`null` value — the pristine or cleared field, the most common empty state — fails the base TYPE check and shows the `invalid` message; the `required` rule only fires on present-but-empty values (`""`, `[]`). That is also why number/boolean validators have NO `required` message key — for them `messages.invalid` is the only way to word the missing-value error. `null` is never valid, even on non-required fields.
 - MANDATORY CHECKBOX: boolean `required: true` does NOT force it checked (`false` is a valid boolean) and `const: true` alone lets the pristine `undefined` pass. Use both plus paired messages — see the `gui.inputs.checkbox` entry for the full recipe.
 - WHEN VALIDATION RUNS: only on user interaction, per `formConfig.validateOn` — `"eager"` (default: first change or blur anywhere validates the whole form), `"change"`, `"blur"`, `"submit"`, or an array. NOTHING validates at mount, which is why `$formIsInvalid` starts `false` — see the conditional-and-state-props pattern for gating the submit button correctly. Submit clicks always re-validate everything and the runtime blocks the submit event while invalid.
-

--- a/skills/golemui/references/forms-dx.md
+++ b/skills/golemui/references/forms-dx.md
@@ -209,7 +209,8 @@ gui.inputs.dateTimeCalendar('appointmentAt', {
 ```
 
 - An INLINE calendar with an embedded time picker: a segmented time input between the header and the days grid opens a time grid in place of the days (like the year selector).
-- Emits a local ISO date-time (`YYYY-MM-DDTHH:mm:ss`) only when BOTH day and time are selected — pair with a `{ type: 'string', format: 'date-time' }` validator. Picking a different day clears the time and resets the value to null.
+- Emits a local ISO date-time (`YYYY-MM-DDTHH:mm:ss`) only when BOTH day and time are selected — pair with a `{ type: 'string', format: 'date-time' }` validator. The time picker is usable before a day is picked, and picking a different day KEEPS the chosen time (re-emitting the full value), so the two halves can be chosen in either order.
+- Half-finished entries never emit: the value goes to null — flagging the field even when it is optional — only once focus leaves the widget with one half missing, which surfaces an "incomplete" message.
 - `disabledTimeRanges` entries take `start`/`end` ISO times plus optional `date` (ISO date) and/or `weekdays` (getDay() numbering: 0=Sunday … 6=Saturday) to scope the range to specific days.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/datetimecalendar.md
@@ -447,7 +448,7 @@ Call: `gui.inputs.rangeDatePicker(path, { label? })`
 gui.inputs.rangeDatePicker('stayDates', { label: 'Stay dates' });
 ```
 
-- Popover calendar for a start–end date **range** (the range sibling of `datePicker`).
+- Popover calendar for a start–end date **range** (the range sibling of `datePicker`). A span with only its first day picked is held by the picker, so it survives closing and reopening the popover.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/range-date-picker.md
 
@@ -463,7 +464,7 @@ gui.inputs.rangeDateTimeCalendar('stay', {
 });
 ```
 
-- INLINE range calendar with TWO embedded time pickers (start/end); value is `DateTimeRange[]`, rendered as pills. Pick a date range, then a start time (enables the end time), then an end time to commit a pill. A day holding more than one range shows a count badge.
+- INLINE range calendar with TWO embedded time pickers (start/end); value is `DateTimeRange[]`, rendered as pills. A day span and the two times can be chosen in ANY order — both time pickers are usable from the start — and the pill is committed once all four pieces are present. Starting a new day span keeps the times already chosen. A day holding more than one range shows a count badge.
 - Everything is in instant-space: bounds are **`minDateTime`** / **`maxDateTime`** and **`disabledRanges`** are `DateTimeRange[]` instant spans (block a whole day with `00:00:00`–`23:59:59`). There is no `minDate`/`maxDate`/`minTime`/`maxTime`/`disabledTimeRanges` — a time-of-day constraint cannot bound a multi-day span.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/range-datetime-calendar.md
@@ -497,7 +498,7 @@ gui.inputs.rangeDateTimePicker('stay', {
 });
 ```
 
-- POPOVER date-time range picker: the typed `rangeDateTimeInput` as the trigger (pills live there) with the `rangeDateTimeCalendar` in a dropdown. Value is `DateTimeRange[]`. Committing a pill keeps the popover open so several ranges can be added; it closes on outside-click, blur or Escape.
+- POPOVER date-time range picker: the typed `rangeDateTimeInput` as the trigger (pills live there) with the `rangeDateTimeCalendar` in a dropdown. Value is `DateTimeRange[]`. Committing a pill keeps the popover open so several ranges can be added; it closes on outside-click, blur or Escape. A half-finished selection is held by the picker, so it survives closing and reopening the popover.
 - Everything is in instant-space: bounds are **`minDateTime`** / **`maxDateTime`** and **`disabledRanges`** are `DateTimeRange[]` instant spans (block a whole day with `00:00:00`–`23:59:59`). There is no `minDate`/`maxDate`/`minTime`/`maxTime`/`disabledTimeRanges`.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/range-datetime-picker.md
@@ -522,7 +523,7 @@ Call: `gui.inputs.rangeTimePicker(path, { label?, minTime?, maxTime? })`
 gui.inputs.rangeTimePicker('shift', { label: 'Shift', minTime: '06:00:00', maxTime: '22:00:00' });
 ```
 
-- Two-list popover for a start–end time **range** (the range sibling of `timePicker`); value is `TimeRange[]`. The out list floors one slot after the chosen in so end is strictly after start.
+- Two-list popover for a start–end time **range** (the range sibling of `timePicker`); value is `TimeRange[]`. Either list can be used first — an end picked before a start simply waits — and the range commits once both are set. Once an in is chosen the out list floors one slot after it so end is strictly after start.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/range-time-picker.md
 

--- a/skills/golemui/references/forms-dx.md
+++ b/skills/golemui/references/forms-dx.md
@@ -198,7 +198,7 @@ gui.inputs.datePicker('startDate', {
 
 - THE DEFAULT single-date field: a text field with a popover calendar (click to open). Prefer this for most dates. (`calendar` = always-visible inline calendar; `dateInput` = typed entry, no calendar UI.) Accepts the loose `{ required: true }` validator.
 - Bound the selectable range with **`minDate`** / **`maxDate`** — ISO `YYYY-MM-DD` strings. For "today or later" set `minDate` to today’s date; for "not in the future" set `maxDate` to today. Same `minDate`/`maxDate` on `calendar`, `dateInput`, and the range date widgets.
-- A partially typed date abandoned on focus leave flips the value to null — flagging the field even when optional — and surfaces an "incomplete" error; **`incompleteMessage`** overrides its wording. The same prop exists on every typed date/time widget (the inputs, the pickers, `dateTimeCalendar` and the range inputs/pickers), and an emptied widget clears the error on the next focus leave.
+- A partially typed date abandoned on focus leave flips the value to null — flagging the field even when optional — and surfaces an "incomplete" error; **`incompleteMessage`** overrides its wording. The same prop exists on every typed date/time widget (the inputs, the pickers, the range inputs/pickers, and the inline `dateTimeCalendar`/`rangeDateTimeCalendar`), and an emptied widget clears the error on the next focus leave.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/date-picker.md
 
@@ -472,7 +472,7 @@ gui.inputs.rangeDateTimeCalendar('stay', {
 });
 ```
 
-- INLINE range calendar with TWO embedded time pickers (start/end); value is `DateTimeRange[]`, rendered as pills. A day span and the two times can be chosen in ANY order — both time pickers are usable from the start — and the pill is committed once all four pieces are present. Starting a new day span keeps the times already chosen. A day holding more than one range shows a count badge.
+- INLINE range calendar with TWO embedded time pickers (start/end); value is `DateTimeRange[]`, rendered as pills. A day span and the two times can be chosen in ANY order — both time pickers are usable from the start — and the pill is committed once all four pieces are present. Starting a new day span keeps the times already chosen. A day holding more than one range shows a count badge. Leaving the widget with a half-finished selection surfaces an "incomplete" error over the untouched pills (`incompleteMessage` overrides its wording); leaving it emptied clears the error.
 - Everything is in instant-space: bounds are **`minDateTime`** / **`maxDateTime`** and **`disabledRanges`** are `DateTimeRange[]` instant spans (block a whole day with `00:00:00`–`23:59:59`). There is no `minDate`/`maxDate`/`minTime`/`maxTime`/`disabledTimeRanges` — a time-of-day constraint cannot bound a multi-day span.
 
 Reference: https://golemui.com/dx/widgets-reference/input-fields/range-datetime-calendar.md

--- a/skills/golemui/references/widgets-index.md
+++ b/skills/golemui/references/widgets-index.md
@@ -58,4 +58,3 @@ Every widget’s exhaustive reference page (props, per-prop examples, CSS variab
 - `gui.layouts.grid`, `gui.layouts.horizontalGrid`, `gui.layouts.verticalGrid` — https://golemui.com/dx/widgets-reference/layout-fields/grid.md (json: https://golemui.com/json/widgets-reference/layout-fields/grid.md)
 - `gui.layouts.tabs` — https://golemui.com/dx/widgets-reference/layout-fields/tabs.md (json: https://golemui.com/json/widgets-reference/layout-fields/tabs.md)
 - Category overview — https://golemui.com/dx/widgets-reference/layout-fields/overview.md
-


### PR DESCRIPTION
- Scalar and range date/time/datetime inputs, pickers and calendars now stay enabled at all times
- Add live-sync partial values in inputs
- Keep the chosen time when the day changes
- Retain partial selections across popover close
- Report partials as null with an incomplete inputError when focus leaves the widget
- Commit values when focus leaves the widget