### PR TITLE
fix(schemas): implementation-neutral size wording and init starter-example note

### DIFF
--- a/libs/gui/schemas/src/lib/core/common.schema.json
+++ b/libs/gui/schemas/src/lib/core/common.schema.json
@@ -192,7 +192,7 @@
         },
         "size": {
           "type": "number",
-          "description": "Column span in the form grid (1-12). Defaults to full width when omitted.",
+          "description": "Relative width of the widget inside its layout, from 1 to 12, where 12 is the full width. Defaults to full width when omitted. gui maps it to a 12-column grid, other widget sets may map it to a flex ratio.",
           "minimum": 1,
           "maximum": 12
         },

--- a/libs/schemas/src/cli/run.ts
+++ b/libs/schemas/src/cli/run.ts
@@ -11,7 +11,7 @@ import { createInterface } from 'node:readline/promises';
 import { pathToFileURL } from 'node:url';
 import { generateImplementationSchemas } from '../lib/generator/generate-implementation-schemas.js';
 import type { ImplementationSchemaConfig } from '../lib/manifest.types.js';
-import { starterFiles } from './templates.js';
+import { exampleInputWidgetType, starterFiles } from './templates.js';
 
 const CONFIG_FILE = 'schemas.config.mjs';
 
@@ -153,6 +153,8 @@ Next:
   1. Add @golemui/schemas to the project's dependencies.
   2. Write one component schema per widget under src/lib/components/, and list each one
      in ${CONFIG_FILE}. src/lib/components/example-input.schema.json is the pattern to copy.
+     examples/example.form.json uses the starter type ${exampleInputWidgetType(name)}, so
+     replace it together with the manifest or test/schemas.spec.ts fails.
   3. Rerun \`npx @golemui/schemas generate\` after every edit to a component schema, to
      ${CONFIG_FILE} or to validators.schema.json. A CI step that regenerates and then runs
      \`git diff --exit-code\` catches a forgotten rerun.

--- a/libs/schemas/src/lib/core/common.schema.json
+++ b/libs/schemas/src/lib/core/common.schema.json
@@ -192,7 +192,7 @@
         },
         "size": {
           "type": "number",
-          "description": "Column span in the form grid (1-12). Defaults to full width when omitted.",
+          "description": "Relative width of the widget inside its layout, from 1 to 12, where 12 is the full width. Defaults to full width when omitted. gui maps it to a 12-column grid, other widget sets may map it to a flex ratio.",
           "minimum": 1,
           "maximum": 12
         },


### PR DESCRIPTION
## Changes

- `baseWidget.size` in the core schema now describes a relative width from 1 to 12 instead of a column span in the form grid. gui maps it to a 12-column grid, other widget sets may map it to a flex ratio. The description is vendored into every implementation tree and shown by editors on hover, so it must not assume gui. The gui vendored copy is regenerated.
- `golemui-schemas init` now says in its next steps that `examples/example.form.json` uses the starter type `<name>-input` and has to be replaced together with the manifest, because `test/schemas.spec.ts` validates it.
