### PR TITLE
perf(core): reuse widget references when a recompute produces equal content

### DIFF
--- a/libs/core/src/lib/store/reducer.spec.ts
+++ b/libs/core/src/lib/store/reducer.spec.ts
@@ -1852,4 +1852,110 @@ describe('reducer end-to-end baseline', () => {
       ).toThrow(TypeError);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // 20. Reference stability across recomputes
+  // ---------------------------------------------------------------------------
+
+  describe('reference stability across recomputes', () => {
+    /** A row display widget whose only prop is rebuilt from the row on every recompute. */
+    const makeRowTagsWidget = () => ({
+      uid: 'rowTags',
+      kind: 'display',
+      type: 'heading',
+      props: { tags: ({ $item }: { $item: any }) => [$item.name] },
+    });
+
+    const makeRefFormDef = (rowTags: ReturnType<typeof makeRowTagsWidget>) => ({
+      form: [
+        {
+          uid: 'firstName',
+          kind: 'input',
+          type: 'textinput',
+          path: 'firstName',
+          props: { hint: 'Hi {{$form.firstName}}' },
+        },
+        {
+          uid: 'users',
+          kind: 'input',
+          type: 'repeater',
+          path: 'users',
+          props: {
+            template: { uid: 'usersRow', kind: 'layout', type: 'flex', children: [rowTags] },
+          },
+        },
+      ],
+    });
+
+    it('keeps a row widget reference when an unrelated input changes', () => {
+      const rowTags = makeRowTagsWidget();
+      const formDef = makeRefFormDef(rowTags);
+      const initialized = drive([init(formDef)]);
+
+      const mounted = drive([
+        init(formDef),
+        setData({ firstName: 'Joan', users: [{ name: 'Ada' }, { name: 'Linus' }] }),
+        addWidget(initialized.flatForm['firstName']),
+        mountRow(rowTags as unknown as FormWidget<string>, [0]),
+        mountRow(rowTags as unknown as FormWidget<string>, [1]),
+      ]);
+
+      const reduce = makeReducer();
+      const state = reduce(
+        mounted,
+        setData({ firstName: 'Grace', users: [{ name: 'Ada' }, { name: 'Linus' }] }),
+      );
+
+      // The prop function returns a new array every run, so only its content can decide this.
+      expect(propsOf(state, 'rowTags[0]')['tags']).toEqual(['Ada']);
+      expect(state.calculatedWidgets['rowTags[0]']).toBe(mounted.calculatedWidgets['rowTags[0]']);
+      expect(state.calculatedWidgets['rowTags[1]']).toBe(mounted.calculatedWidgets['rowTags[1]']);
+
+      // The widget that does depend on the changed value gets a new reference.
+      expect(state.calculatedWidgets['firstName']).not.toBe(mounted.calculatedWidgets['firstName']);
+      expect(propsOf(state, 'firstName')['hint']).toBe('Hi Grace');
+    });
+
+    it('gives a row widget a new reference when its own row data changes', () => {
+      const rowTags = makeRowTagsWidget();
+      const formDef = makeRefFormDef(rowTags);
+
+      const mounted = drive([
+        init(formDef),
+        setData({ firstName: 'Joan', users: [{ name: 'Ada' }] }),
+        mountRow(rowTags as unknown as FormWidget<string>, [0]),
+      ]);
+
+      const reduce = makeReducer();
+      const state = reduce(mounted, setData({ firstName: 'Joan', users: [{ name: 'Grace' }] }));
+
+      expect(state.calculatedWidgets['rowTags[0]']).not.toBe(
+        mounted.calculatedWidgets['rowTags[0]'],
+      );
+      expect(propsOf(state, 'rowTags[0]')['tags']).toEqual(['Grace']);
+    });
+
+    it('keeps a row function widget reference when it returns an equal config', () => {
+      const rowName = makeRowNameFunctionWidget();
+      const formDef = makeRowFunctionFormDef();
+
+      const mounted = drive([
+        init(formDef),
+        setData({ users: [{ name: 'Ada' }] }),
+        mountRow(rowName, [0]),
+      ]);
+
+      const reduce = makeReducer();
+      const unchanged = reduce(mounted, setData({ users: [{ name: 'Ada' }] }));
+      const changed = reduce(unchanged, setData({ users: [{ name: 'Grace' }] }));
+
+      expect(unchanged.calculatedWidgets['rowName[0]']).toBe(
+        mounted.calculatedWidgets['rowName[0]'],
+      );
+      expect(changed.calculatedWidgets['rowName[0]']).not.toBe(
+        unchanged.calculatedWidgets['rowName[0]'],
+      );
+      expect(propsOf(changed, 'rowName[0]')['seenItemName']).toBe('Grace');
+    });
+  });
 });

--- a/libs/core/src/lib/store/reducers/calculate-widget-props.spec.ts
+++ b/libs/core/src/lib/store/reducers/calculate-widget-props.spec.ts
@@ -135,8 +135,7 @@ describe('calculateWidgetProps', () => {
       expect(current.disabled).toBe(false);
       expect(current.readonly).toBe(false);
       expect(current.defaultValue).toBe('initial');
-      // validator is a function on source — it gets invoked by resolvePropValue,
-      // returning its result.
+      // validator is a function on source, so it gets invoked by resolvePropValue, returning its result
       expect(current.validator).toBeUndefined();
     });
 
@@ -181,7 +180,7 @@ describe('calculateWidgetProps', () => {
     });
 
     it('does not set a core field absent from source', () => {
-      // Input widget without `label` — `current.label` should be entirely absent.
+      // Input widget without `label`: `current.label` should be entirely absent.
       const source = {
         kind: 'input',
         uid: 'i2',
@@ -212,7 +211,7 @@ describe('calculateWidgetProps', () => {
         'label.register:adult': 'REGISTER_ADULT',
       }) satisfies ActionWidget<string>;
 
-    it('no matching state → uses base', () => {
+    it('no matching state -> uses base', () => {
       seed(state, 'a', baseSource());
       state.currentStates = [];
 
@@ -221,7 +220,7 @@ describe('calculateWidgetProps', () => {
       expect((next.calculatedWidgets['a'].current as ActionWidget<string>).label).toBe('BASE');
     });
 
-    it('one matching state → uses that state suffix', () => {
+    it('one matching state -> uses that state suffix', () => {
       seed(state, 'a', baseSource());
       state.currentStates = ['register'];
 
@@ -230,7 +229,7 @@ describe('calculateWidgetProps', () => {
       expect((next.calculatedWidgets['a'].current as ActionWidget<string>).label).toBe('REGISTER');
     });
 
-    it('non-matching state → falls back to base', () => {
+    it('non-matching state -> falls back to base', () => {
       seed(state, 'a', baseSource());
       state.currentStates = ['unknown'];
 
@@ -543,7 +542,7 @@ describe('calculateWidgetProps', () => {
       const next = run(state);
 
       const text = (next.calculatedWidgets['d'].current as DisplayWidget<string>).props?.['text'];
-      // Errors serialize via String() inside the template replace → "[object Object]"-ish
+      // Errors serialize via String() inside the template replace -> "[object Object]"-ish
       // but that's the current behavior; we just assert resolution happened.
       expect(text.startsWith('Err: ')).toBe(true);
       expect(text).not.toContain('{{');
@@ -702,7 +701,7 @@ describe('calculateWidgetProps', () => {
   // ---------------------------------------------------------------------------
 
   describe('FunctionWidget', () => {
-    it('is invoked on each call, current is fresh, source ref is preserved, uid is set', () => {
+    it('is invoked on each call, source ref is preserved, uid is set', () => {
       const source: FunctionWidget<string> = Object.assign(
         () =>
           ({
@@ -720,8 +719,29 @@ describe('calculateWidgetProps', () => {
 
       expect(first.calculatedWidgets['f'].source).toBe(source);
       expect(first.calculatedWidgets['f'].current.uid).toBe('f');
-      // FunctionWidget always yields a fresh `current` — no ref preservation.
+      // An equal config keeps the reference, see the ref preservation section.
+      expect(second.calculatedWidgets['f']).toBe(first.calculatedWidgets['f']);
+    });
+
+    it('a config that differs from the previous one yields a new DerivedWidget ref', () => {
+      const source: FunctionWidget<string> = Object.assign(
+        (api: { $form: any } | undefined) =>
+          ({
+            kind: 'display',
+            uid: 'ignored',
+            type: 'heading',
+            props: { text: api?.$form.title },
+          }) satisfies DisplayWidget<string>,
+        { uid: 'f', type: 'heading' },
+      );
+      seed(state, 'f', source);
+      state.data = { title: 'first' };
+
+      const first = run(state);
+      const second = run({ ...first, data: { title: 'second' } });
+
       expect(second.calculatedWidgets['f']).not.toBe(first.calculatedWidgets['f']);
+      expect(second.calculatedWidgets['f'].current.props?.['text']).toBe('second');
     });
   });
 
@@ -850,7 +870,7 @@ describe('calculateWidgetProps', () => {
       ).toEqual(['b', 'a']);
     });
 
-    it('core-field change on a layout with structurally stable children → new DerivedWidget ref', () => {
+    it('core-field change on a layout with structurally stable children -> new DerivedWidget ref', () => {
       // Source has size=1 but previous.current has no size. Core loop marks
       // changed=true; children are structurally stable (both empty), so the
       // children branch must NOT clobber that signal - change detection ORs.
@@ -901,7 +921,7 @@ describe('calculateWidgetProps', () => {
   // ---------------------------------------------------------------------------
 
   describe('ref preservation', () => {
-    it('widget with identical resolved values across calls → same DerivedWidget ref', () => {
+    it('widget with identical resolved values across calls -> same DerivedWidget ref', () => {
       const source = {
         kind: 'action',
         uid: 'a',
@@ -917,7 +937,48 @@ describe('calculateWidgetProps', () => {
       expect(second.calculatedWidgets['a']).toBe(first.calculatedWidgets['a']);
     });
 
-    it('layout with stable structure → same DerivedWidget ref across calls', () => {
+    it('a prop function returning a fresh but equal array keeps the DerivedWidget ref', () => {
+      const source = {
+        kind: 'input',
+        uid: 'i',
+        type: 'select',
+        path: 'choice',
+        props: {
+          options: ({ $form }: { $form: any }) => [{ label: $form.name, value: 1 }],
+        },
+      } satisfies InputWidget<any, string>;
+      seed(state, 'i', source);
+      state.data = { name: 'joan' };
+
+      const first = run(state);
+      const second = run(first);
+
+      expect(second.calculatedWidgets['i']).toBe(first.calculatedWidgets['i']);
+    });
+
+    it('a prop function returning a different array yields a new DerivedWidget ref', () => {
+      const source = {
+        kind: 'input',
+        uid: 'i',
+        type: 'select',
+        path: 'choice',
+        props: {
+          options: ({ $form }: { $form: any }) => [{ label: $form.name, value: 1 }],
+        },
+      } satisfies InputWidget<any, string>;
+      seed(state, 'i', source);
+      state.data = { name: 'joan' };
+
+      const first = run(state);
+      const second = run({ ...first, data: { name: 'ada' } });
+
+      expect(second.calculatedWidgets['i']).not.toBe(first.calculatedWidgets['i']);
+      expect(
+        (second.calculatedWidgets['i'].current as InputWidget<any, string>).props?.['options'],
+      ).toEqual([{ label: 'ada', value: 1 }]);
+    });
+
+    it('layout with stable structure -> same DerivedWidget ref across calls', () => {
       const child = { kind: 'display', uid: 'c', type: 'heading' } satisfies DisplayWidget<string>;
       const source = {
         kind: 'layout',

--- a/libs/core/src/lib/store/reducers/calculate-widget-props.ts
+++ b/libs/core/src/lib/store/reducers/calculate-widget-props.ts
@@ -24,7 +24,7 @@ import { normalizeArrayIndexes } from '../../utils/justin';
 import { get, set } from '../../utils/object';
 import { extractRepeaterIndexes } from '../../utils/repeater';
 import { type DerivedWidget, type RepeaterItemScope, type State } from '../model';
-import { hasWhen } from './utils';
+import { deepEqual, hasWhen } from './utils';
 import { errorCodes } from '../../errors';
 
 // -----------------------------------------------------------------------------
@@ -79,7 +79,7 @@ function calculateAll(
     }
 
     if (isFunctionWidget(source)) {
-      result[uid] = computeFunctionWidget(uid, source, state, localization, itemScope);
+      result[uid] = computeFunctionWidget(prev, uid, source, state, localization, itemScope);
       continue;
     }
 
@@ -104,6 +104,7 @@ function calculateAll(
 // -----------------------------------------------------------------------------
 
 function computeFunctionWidget(
+  prev: DerivedWidget<FormWidget<string>>,
   uid: string,
   source: FunctionWidget<string>,
   state: State,
@@ -119,7 +120,13 @@ function computeFunctionWidget(
     $index: itemScope?.index,
   });
   current.uid = uid;
-  // TODO: structural comparison to preserve ref when equal?
+
+  // A function widget builds a new config object on every call, so compare the content
+  // to avoid handing subscribers a new reference for an unchanged widget.
+  if (prev.current && deepEqual(prev.current, current)) {
+    return prev;
+  }
+
   return { source, current };
 }
 
@@ -506,13 +513,17 @@ class ChangeTracker<F extends NonFunctionWidget<string> = NonFunctionWidget<stri
   }
 
   write(dotPath: string, value: unknown): void {
-    set(this.current as Record<string, unknown>, dotPath, value);
-    // TODO: only primitive-level reference equality; structurally equivalent
-    // objects/arrays will still trip `changed`.
     const prev = get(this.previous as Record<string, unknown>, dotPath);
-    if (prev !== value) {
-      this._changed = true;
+
+    // An expression that rebuilds an equal object or array must not count as a change,
+    // so keep the previous reference and leave `changed` alone.
+    if (deepEqual(prev, value)) {
+      set(this.current as Record<string, unknown>, dotPath, prev);
+      return;
     }
+
+    set(this.current as Record<string, unknown>, dotPath, value);
+    this._changed = true;
   }
 }
 

--- a/libs/core/src/lib/store/reducers/utils.spec.ts
+++ b/libs/core/src/lib/store/reducers/utils.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { deepEqual } from './utils';
+
+describe('deepEqual', () => {
+  it('compares arrays by their elements, at any depth', () => {
+    expect(deepEqual([1, { a: [2] }], [1, { a: [2] }])).toBe(true);
+    expect(deepEqual([1, 2], [2, 1])).toBe(false);
+    expect(deepEqual([1], [1, 2])).toBe(false);
+  });
+
+  it('compares plain objects by their properties, and counts the keys', () => {
+    expect(deepEqual({ a: 1, b: { c: 'x' } }, { b: { c: 'x' }, a: 1 })).toBe(true);
+    expect(deepEqual({ a: 1 }, { a: 1, b: undefined })).toBe(false);
+    expect(deepEqual({ a: 1 }, { a: 2 })).toBe(false);
+  });
+
+  it('compares everything else by reference', () => {
+    const fn = () => undefined;
+    expect(deepEqual(fn, fn)).toBe(true);
+    expect(deepEqual(fn, () => undefined)).toBe(false);
+    expect(deepEqual(new Date(0), new Date(0))).toBe(false);
+  });
+
+  it('does not treat an array and an object with the same entries as equal', () => {
+    expect(deepEqual([1], { 0: 1 })).toBe(false);
+  });
+});

--- a/libs/core/src/lib/store/reducers/utils.ts
+++ b/libs/core/src/lib/store/reducers/utils.ts
@@ -37,3 +37,39 @@ export const reduceIf =
 export const hasWhen = (val: unknown): val is { when: string } => {
   return val !== undefined && typeof val === 'object' && val !== null && 'when' in val;
 };
+
+// -----------------------------------------------------------------------------
+// Structural comparsion
+// -----------------------------------------------------------------------------
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+/**
+ * Compares arrays by their elements and plain objects by their properties,
+ * everything else is comppared by reference using `===`.
+ */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((item, index) => deepEqual(item, b[index]));
+  }
+
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const keys = Object.keys(a);
+    if (keys.length !== Object.keys(b).length) {
+      return false;
+    }
+    return keys.every((key) => key in b && deepEqual(a[key], b[key]));
+  }
+
+  return false;
+}


### PR DESCRIPTION
`calculateWidgetProps` rebuilt a widget's `current` object on every pass, so an expression returning a fresh but equal array or object handed the bindings a new reference and made them re-render for nothing. 

Property writes and the function widget path now compare content with a new internal `deepEqual` and keep the previous reference when nothing changed
