### PR TITLE
fix(gui-components): use arrow-key and Enter commit in rangeTimePicker

### DIFF
--- a/libs/gui/components/src/lib/components/range-time-picker.ts
+++ b/libs/gui/components/src/lib/components/range-time-picker.ts
@@ -9,6 +9,7 @@ import './time-list';
 import { GUIFocusLeaveController } from '../controllers/focus-leave.controller';
 import { GUIPopupController } from '../controllers/popup.controller';
 import {
+  buildTimeOptions,
   compareISOTimes,
   isTimeRangeDisabled,
   oneStepAfterISOTime,
@@ -419,8 +420,13 @@ export class GuiRangeTimePicker extends LitElement {
   }
 
   private _inListRef() {
+    return this.listRefFor('start');
+  }
+
+  private listRefFor(group: 'start' | 'end') {
+    const column = group === 'start' ? 'first-child' : 'last-child';
     return this.querySelector<HTMLElement & { scrollToSelectedValue?: () => void }>(
-      '.gui-range-time-picker__column:first-child gui-time-list',
+      `.gui-range-time-picker__column:${column} gui-time-list`,
     );
   }
 
@@ -487,13 +493,64 @@ export class GuiRangeTimePicker extends LitElement {
 
   /**
    * Escape layering: an open panel consumes the key first (closing it), then
-   * the embedded input's edit session gets its turn — cancel an open session,
-   * then clear the selection.
+   * the select-like keyboard behavior gets its turn, then the embedded
+   * input's edit session — cancel an open session, then clear the selection.
    */
   private onWidgetKeyDown = (e: KeyboardEvent) => {
     if (this._popup.onAnchorKeyDown(e)) return;
+    if (this.onSelectLikeKeyDown(e)) return;
     this._inputRef?.handleSessionEscape(e);
   };
+
+  private onSelectLikeKeyDown(e: KeyboardEvent): boolean {
+    if (this.allowCustomTime || this.readOnly || this.disabled) return false;
+
+    const target = e.target as HTMLElement;
+    const group = target.closest('[data-group]')?.getAttribute('data-group');
+    if (group !== 'start' && group !== 'end') return false;
+
+    if (e.key === 'Enter') {
+      this._inputRef?.commitFromParts();
+      return true;
+    }
+
+    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return false;
+    e.preventDefault();
+    this.stepEndpoint(group, e.key === 'ArrowDown' ? 1 : -1);
+    return true;
+  }
+
+  /** Moves one endpoint to the adjacent enabled slot of its list. */
+  private stepEndpoint(group: 'start' | 'end', direction: 1 | -1) {
+    const bounds =
+      group === 'start' ? { minTime: this.minTime, maxTime: this.maxTime } : this.outListBounds;
+    const options = buildTimeOptions({
+      minTime: bounds.minTime,
+      maxTime: bounds.maxTime,
+      minuteStep: this.minuteStep,
+      disabledRanges: this.disabledRanges,
+    });
+    if (!options.length) return;
+
+    const current = group === 'start' ? this._workingIn : this._workingOut;
+    const currentIndex = options.findIndex((option) => option.value === current);
+    let index =
+      currentIndex === -1 ? (direction === 1 ? 0 : options.length - 1) : currentIndex + direction;
+    while (index >= 0 && index < options.length && options[index].disabled) {
+      index += direction;
+    }
+    if (index < 0 || index >= options.length) return;
+
+    const value = options[index].value;
+    if (group === 'start') {
+      this._workingIn = value;
+    } else {
+      this._workingOut = value;
+    }
+    this._inputRef?.fillGroup(group, value);
+    this._popup.show();
+    this.updateComplete.then(() => this.listRefFor(group)?.scrollToSelectedValue?.());
+  }
 
   private closePillsDropdown() {
     const pills = this.querySelector('gui-pills') as

--- a/libs/ui-testing/src/lib/gui-features/rangetimepicker.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/rangetimepicker.cy.ts
@@ -608,5 +608,97 @@ export const runRangeTimePickerComponentTests = (mountFn: MountComponentFn) => {
         });
       });
     });
+
+    describe('select-like keyboard entry (allowCustomTime off)', () => {
+      // The segments are readonly (typed digits are rejected), but arrows step
+      // each endpoint through its list's enabled slots and Enter commits, like
+      // the single time picker. force: Cypress refuses typing into readonly
+      // inputs, and the keys must still reach the picker's keydown handler.
+      const key = (selector: string, stroke: string) =>
+        cy.get(selector).type(stroke, { force: true });
+
+      it('should step the endpoints with arrows and commit with Enter, rejecting digits', () => {
+        const formSubmitHandler = cy.stub().as('formSubmitHandler');
+        mountRangeTimePicker({ props: officeProps, formSubmit: formSubmitHandler });
+
+        // The segments are natively readonly — typed digits bounce off. (A
+        // forced Cypress .type() would bypass the readonly attribute, so the
+        // attribute itself is the honest assertion here.)
+        cy.get(sel.startHour).should('have.attr', 'readonly');
+        cy.get(sel.endMinute).should('have.attr', 'readonly');
+
+        // First ArrowDown lands on the first slot; the panel opens on it.
+        key(sel.startHour, '{downarrow}');
+        cy.get(sel.panel).should('exist');
+        cy.get(sel.startHour).should('have.value', '09');
+        cy.get(sel.startMinute).should('have.value', '00');
+        cy.get(sel.inItems)
+          .filter('[data-value="09:00:00"]')
+          .should('have.class', 'gui-time-list__option--selected');
+
+        // Arrowing is continuous editing: step down, step back up, no commit.
+        key(sel.startHour, '{downarrow}');
+        cy.get(sel.startMinute).should('have.value', '30');
+        key(sel.startHour, '{uparrow}');
+        cy.get(sel.startMinute).should('have.value', '00');
+        cy.get(sel.pillText).should('have.length', 0);
+
+        // The end endpoint steps through its own floored list (> start).
+        key(sel.endHour, '{downarrow}');
+        cy.get(sel.endHour).should('have.value', '09');
+        cy.get(sel.endMinute).should('have.value', '30');
+        cy.get(sel.pillText).should('have.length', 0);
+
+        // Enter commits the completed range exactly like a typed entry.
+        key(sel.endHour, '{enter}');
+        cy.get(sel.pillText).should('have.length', 1).and('contain', '09:00 - 09:30');
+        submitAndGetData('@formSubmitHandler').then((data) => {
+          expect(data.myRanges).to.deep.equal([{ start: '09:00:00', end: '09:30:00' }]);
+        });
+      });
+
+      it('should skip disabled slots when stepping', () => {
+        mountRangeTimePicker({
+          props: {
+            ...officeProps,
+            disabledRanges: [{ start: '09:30:00', end: '09:59:59' }],
+          },
+        });
+
+        key(sel.startHour, '{downarrow}');
+        cy.get(sel.startMinute).should('have.value', '00');
+        // 09:30 is disabled → the next enabled slot is 10:00.
+        key(sel.startHour, '{downarrow}');
+        cy.get(sel.startHour).should('have.value', '10');
+        cy.get(sel.startMinute).should('have.value', '00');
+      });
+
+      it('should reshape an edit session with arrows and confirm it with Enter', () => {
+        forcePillsStripMode('.gui-range-time-input');
+        const formSubmitHandler = cy.stub().as('formSubmitHandler');
+        mountRangeTimePicker({
+          data: { myRanges: [{ start: '09:00:00', end: '11:00:00' }] },
+          props: { ...officeProps, allowEdit: true },
+          formSubmit: formSubmitHandler,
+        });
+
+        cy.get('gui-range-time .gui-pills__pill').first().click();
+        cy.get(`.gui-pills__pill--selected [data-cy="${uid}_pill-edit"]`).click();
+
+        // Arrows reshape the loaded range; the pill's label follows live.
+        key(sel.startHour, '{downarrow}');
+        cy.get('gui-range-time .gui-pills__pill')
+          .first()
+          .should('have.class', 'gui-pills__pill--editing')
+          .and('contain.text', '09:30 - 11:00');
+
+        key(sel.startHour, '{enter}');
+        cy.get('.gui-pills__pill--editing').should('not.exist');
+        submitAndGetData('@formSubmitHandler').then((data) => {
+          expect(data.myRanges).to.deep.equal([{ start: '09:30:00', end: '11:00:00' }]);
+        });
+        clearPillsWidthOverride();
+      });
+    });
   });
 };


### PR DESCRIPTION
Fix missing arrow-key selection and commit with Enter in rangeTimePicker when `allowCustomTime` is false.