### PR TITLE
fix(gui-components): follow programmatic value changes on dirty inputs

### DIFF
--- a/libs/gui/components/src/lib/components/checkbox.ts
+++ b/libs/gui/components/src/lib/components/checkbox.ts
@@ -1,6 +1,7 @@
 import { GUIAriaController } from '../controllers/aria.controller';
 import { html, LitElement, nothing } from 'lit';
 import { property } from 'lit/decorators.js';
+import { live } from 'lit/directives/live.js';
 import { safeDefine } from '@golemui/lit/internals';
 import { addErrors, requiredMarker, type ControlTemplateData } from '../utils/templates';
 import type { CheckboxProps } from '@golemui/gui-shared/internals';
@@ -78,7 +79,7 @@ export class GuiCheckbox extends LitElement {
             type="checkbox"
             id=${this.uid}
             data-cy=${`${this.uid}_checkbox`}
-            ?checked=${this.value}
+            .checked=${live(this.value ?? false)}
             ?required=${this.required}
             ?disabled=${this.disabled || this.readOnly}
             @change=${this.valueChanged}

--- a/libs/gui/components/src/lib/components/number.ts
+++ b/libs/gui/components/src/lib/components/number.ts
@@ -98,7 +98,6 @@ export class GuiNumber extends LitElement {
           data-cy=${`${this.uid}_number`}
           class="gui-widget-input"
           style=${styleMap(inputStyles)}
-          value=${this.value}
           ?required=${this.required}
           ?disabled=${this.disabled}
           ?readonly=${this.readOnly}
@@ -140,6 +139,35 @@ export class GuiNumber extends LitElement {
 
       ${addErrors(this.uid as string, templateData)}
     `;
+  }
+
+  /**
+   * Owns the native input value instead of a template binding. An attribute binding is
+   * ignored once the user typed, and the Number converter turns the `''` some frameworks
+   * assign into a phantom 0. The comparison is numeric so a draft like `1.` that already
+   * parses to the store value survives, and a focused input is left alone while typing.
+   */
+  protected override updated(): void {
+    const input = this.querySelector(`input[id="${this.uid}"]`) as HTMLInputElement | null;
+    if (input === null) {
+      return;
+    }
+    if (document.activeElement === input) {
+      return;
+    }
+    const storeValue =
+      typeof this.value === 'number' && !Number.isNaN(this.value) ? this.value : undefined;
+    const shownValue = input.valueAsNumber;
+    const bothEmpty = Number.isNaN(shownValue) && storeValue === undefined;
+    const sameNumber = !Number.isNaN(shownValue) && shownValue === storeValue;
+    if (bothEmpty || sameNumber) {
+      return;
+    }
+    if (storeValue === undefined) {
+      input.value = '';
+    } else {
+      input.valueAsNumber = storeValue;
+    }
   }
 
   keyDown(event: KeyboardEvent) {

--- a/libs/gui/components/src/lib/components/password.ts
+++ b/libs/gui/components/src/lib/components/password.ts
@@ -1,5 +1,6 @@
 import { html, LitElement, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
+import { live } from 'lit/directives/live.js';
 import { safeDefine } from '@golemui/lit/internals';
 import { classMap } from 'lit/directives/class-map.js';
 import { GUIAriaController } from '../controllers/aria.controller';
@@ -91,7 +92,7 @@ export class GuiPassword extends LitElement {
           id=${this.uid}
           data-cy=${`${this.uid}_password`}
           class=${classMap(fieldClasses)}
-          value=${this.value}
+          .value=${live(this.value ?? '')}
           ?required=${this.required}
           ?disabled=${this.disabled}
           ?readonly=${this.readOnly}

--- a/libs/gui/components/src/lib/components/radiogroup.ts
+++ b/libs/gui/components/src/lib/components/radiogroup.ts
@@ -7,6 +7,7 @@ import type {
 import { html, LitElement, nothing } from 'lit';
 import { repeat } from 'lit-html/directives/repeat.js';
 import { property } from 'lit/decorators.js';
+import { live } from 'lit/directives/live.js';
 import { safeDefine } from '@golemui/lit/internals';
 import { GUIAriaController } from '../controllers/aria.controller';
 import { addErrors, addLabel, type ControlTemplateData } from '../utils/templates';
@@ -103,7 +104,7 @@ export class GuiRadiogroup extends LitElement {
                   data-cy=${`${this.uid}_radiogroup_${index}`}
                   name=${this.uid!}
                   value=${opt.value}
-                  ?checked=${isChecked}
+                  .checked=${live(isChecked)}
                   ?required=${templateData.required}
                   ?disabled=${templateData.disabled || templateData.readonly}
                   @change=${this.valueChanged}

--- a/libs/gui/components/src/lib/components/select.ts
+++ b/libs/gui/components/src/lib/components/select.ts
@@ -2,6 +2,7 @@ import type { OneOfProps, Option, OptionValue, SelectProps } from '@golemui/gui-
 import { html, LitElement, nothing } from 'lit';
 import { repeat } from 'lit-html/directives/repeat.js';
 import { property } from 'lit/decorators.js';
+import { live } from 'lit/directives/live.js';
 import { safeDefine } from '@golemui/lit/internals';
 import { classMap } from 'lit/directives/class-map.js';
 import { GUIAriaController } from '../controllers/aria.controller';
@@ -93,7 +94,7 @@ export class GuiSelect extends LitElement {
     const options = this.optionsLoading
       ? html`<span>Loading...</span>`
       : html`
-          <option value="" disabled selected=${this.hasMatchingValue ? nothing : ''}>
+          <option value="" disabled .selected=${live(!this.hasMatchingValue)}>
             ${this.placeholder ?? 'Select an option'}
           </option>
           ${repeat(
@@ -102,7 +103,7 @@ export class GuiSelect extends LitElement {
             (opt: any) =>
               html`<option
                 value=${opt.value}
-                selected=${this.hasMatchingValue && opt.value === this.value ? '' : nothing}
+                .selected=${live(this.hasMatchingValue && opt.value === this.value)}
               >
                 ${opt.label}
               </option>`,

--- a/libs/gui/components/src/lib/components/textinput.ts
+++ b/libs/gui/components/src/lib/components/textinput.ts
@@ -1,5 +1,6 @@
 import { html, LitElement, nothing } from 'lit';
 import { property } from 'lit/decorators.js';
+import { live } from 'lit/directives/live.js';
 import { safeDefine } from '@golemui/lit/internals';
 import { classMap } from 'lit/directives/class-map.js';
 import { GUIAriaController } from '../controllers/aria.controller';
@@ -81,7 +82,7 @@ export class GuiTextinput extends LitElement {
           id=${this.uid}
           data-cy=${`${this.uid}_textinput`}
           class=${classMap(fieldClasses)}
-          value=${this.value}
+          .value=${live(this.value ?? '')}
           ?required=${this.required}
           ?disabled=${this.disabled}
           ?readonly=${this.readOnly}

--- a/libs/gui/components/src/lib/components/toggle.ts
+++ b/libs/gui/components/src/lib/components/toggle.ts
@@ -1,6 +1,7 @@
 import { GUIAriaController } from '../controllers/aria.controller';
 import { html, LitElement, nothing } from 'lit';
 import { property } from 'lit/decorators.js';
+import { live } from 'lit/directives/live.js';
 import { safeDefine } from '@golemui/lit/internals';
 import { addErrors, requiredMarker, type ControlTemplateData } from '../utils/templates';
 import type { ToggleProps } from '@golemui/gui-shared/internals';
@@ -79,7 +80,7 @@ export class GuiToggle extends LitElement {
             role="switch"
             id=${this.uid}
             data-cy=${`${this.uid}_toggle`}
-            ?checked=${templateData.value}
+            .checked=${live(templateData.value ?? false)}
             ?required=${templateData.required}
             ?disabled=${templateData.disabled || templateData.readonly}
             @change=${this.valueChanged}

--- a/libs/gui/vue/src/lib/components/NumberInput.vue
+++ b/libs/gui/vue/src/lib/components/NumberInput.vue
@@ -14,6 +14,9 @@ const { uid, errors, value, isTouched, templateData, onValueChanged, onBlur } = 
 
 const handleInput = (e: Event) => onValueChanged((e as CustomEvent).detail.value);
 const required = computed(() => (templateData.value.validator as Validator)?.required);
+// Vue writes 0 into a custom element property that currently holds a number when the bound
+// value is undefined. gui-number reads NaN as "no value", so pass that instead.
+const elementValue = computed(() => value.value ?? Number.NaN);
 </script>
 
 <template>
@@ -27,7 +30,7 @@ const required = computed(() => (templateData.value.validator as Validator)?.req
       :required="required"
       :disabled="templateData.disabled"
       :readOnly="templateData.readonly"
-      :value="value"
+      :value="elementValue"
       :step="templateData.step"
       :minimum="templateData.minimum"
       :maximum="templateData.maximum"

--- a/libs/ui-testing/src/lib/core-features/set-data-set-meta.cy.ts
+++ b/libs/ui-testing/src/lib/core-features/set-data-set-meta.cy.ts
@@ -1,4 +1,4 @@
-import { defineForm } from '@golemui/core';
+import { defineForm, identityTranslator } from '@golemui/core';
 import { type FormHandle, type MountComponentFn } from '../utils';
 
 export const runSetDataSetMetaTests = (mountFn: MountComponentFn) => {
@@ -39,6 +39,335 @@ export const runSetDataSetMetaTests = (mountFn: MountComponentFn) => {
         cy.then(() => handle.setData({ firstName: 'Jane', lastName: 'Smith' }));
         cy.get('[data-cy="firstName_textinput"]').should('have.value', 'Jane');
         cy.get('[data-cy="lastName_textinput"]').should('have.value', 'Smith');
+      });
+    });
+
+    describe('setData reaches controls the user already changed', () => {
+      // One input per case. Interact first so the native control is dirty, then setData
+      // and assert the store value replaced what the user did.
+      const mountControl = (options: {
+        type: string;
+        data: Record<string, any>;
+        props?: Record<string, any>;
+        onFormReady: (handle: FormHandle) => void;
+      }) => {
+        mountFn({
+          localization: identityTranslator('en-US'),
+          data: options.data,
+          formDef: defineForm({
+            form: [
+              {
+                uid: 'field',
+                kind: 'input',
+                type: options.type as any,
+                path: 'value',
+                ...(options.props ? { props: options.props } : {}),
+              },
+            ],
+          }),
+          onFormReady: options.onFormReady,
+        });
+      };
+
+      it('textinput', () => {
+        let handle!: FormHandle;
+        mountControl({
+          type: 'textinput',
+          data: { value: 'initial' },
+          onFormReady: (h) => (handle = h),
+        });
+        cy.get('[data-cy="field_textinput"]').clear().type('abc');
+        cy.then(() => handle.setData({ value: 'from store' }));
+        cy.get('[data-cy="field_textinput"]').should('have.value', 'from store');
+      });
+
+      it('password', () => {
+        let handle!: FormHandle;
+        mountControl({
+          type: 'password',
+          data: { value: 'initial' },
+          onFormReady: (h) => (handle = h),
+        });
+        cy.get('[data-cy="field_password"]').clear().type('abc');
+        cy.then(() => handle.setData({ value: 'from store' }));
+        cy.get('[data-cy="field_password"]').should('have.value', 'from store');
+      });
+
+      it('number', () => {
+        let handle!: FormHandle;
+        mountControl({ type: 'number', data: { value: 1 }, onFormReady: (h) => (handle = h) });
+        cy.get('[data-cy="field_number"]').clear().type('12').blur();
+        cy.then(() => handle.setData({ value: 5 }));
+        cy.get('[data-cy="field_number"]').should('have.value', '5');
+      });
+
+      it('number leaves a focused draft alone and syncs it on blur', () => {
+        let handle!: FormHandle;
+        mountControl({ type: 'number', data: { value: 3 }, onFormReady: (h) => (handle = h) });
+        cy.get('[data-cy="field_number"]').clear().type('12');
+        cy.then(() => handle.setData({ value: 5 }));
+        cy.get('[data-cy="field_number"]').should('have.value', '12');
+        cy.get('[data-cy="field_number"]').blur();
+        cy.get('[data-cy="field_number"]').should('have.value', '5');
+      });
+
+      it('number clears when the store value is removed', () => {
+        let handle!: FormHandle;
+        mountControl({ type: 'number', data: { value: 1 }, onFormReady: (h) => (handle = h) });
+        cy.get('[data-cy="field_number"]').clear().type('12').blur();
+        cy.then(() => handle.setData({}));
+        cy.get('[data-cy="field_number"]').should('have.value', '');
+      });
+
+      it('checkbox', () => {
+        let handle!: FormHandle;
+        mountControl({
+          type: 'checkbox',
+          data: { value: false },
+          onFormReady: (h) => (handle = h),
+        });
+        cy.get('[data-cy="field_checkbox"]').click().should('be.checked');
+        cy.then(() => handle.setData({ value: false }));
+        cy.get('[data-cy="field_checkbox"]').should('not.be.checked');
+      });
+
+      it('toggle', () => {
+        let handle!: FormHandle;
+        mountControl({ type: 'toggle', data: { value: false }, onFormReady: (h) => (handle = h) });
+        cy.get('[data-cy="field_toggle"]').click({ force: true }).should('be.checked');
+        cy.then(() => handle.setData({ value: false }));
+        cy.get('[data-cy="field_toggle"]').should('not.be.checked');
+      });
+
+      it('radiogroup', () => {
+        let handle!: FormHandle;
+        mountControl({
+          type: 'radiogroup',
+          data: { value: 'a' },
+          props: { options: ['a', 'b'] },
+          onFormReady: (h) => (handle = h),
+        });
+        cy.get('[data-cy="field_radiogroup_1"]').click().should('be.checked');
+        cy.then(() => handle.setData({ value: 'a' }));
+        cy.get('[data-cy="field_radiogroup_0"]').should('be.checked');
+        cy.get('[data-cy="field_radiogroup_1"]').should('not.be.checked');
+      });
+
+      it('select', () => {
+        let handle!: FormHandle;
+        mountControl({
+          type: 'select',
+          data: { value: 'a' },
+          props: { options: ['a', 'b'] },
+          onFormReady: (h) => (handle = h),
+        });
+        cy.get('[data-cy="field_select"]').select('b').should('have.value', 'b');
+        cy.then(() => handle.setData({ value: 'a' }));
+        cy.get('[data-cy="field_select"]').should('have.value', 'a');
+      });
+
+      it('textarea', () => {
+        let handle!: FormHandle;
+        mountControl({
+          type: 'textarea',
+          data: { value: 'initial' },
+          onFormReady: (h) => (handle = h),
+        });
+        cy.get('[data-cy="field_textarea"]').clear().type('abc');
+        cy.then(() => handle.setData({ value: 'from store' }));
+        cy.get('[data-cy="field_textarea"]').should('have.value', 'from store');
+      });
+
+      it('currency', () => {
+        let handle!: FormHandle;
+        mountControl({ type: 'currency', data: { value: 1 }, onFormReady: (h) => (handle = h) });
+        cy.get('[data-cy="field_currency"]').clear().type('12').blur();
+        cy.then(() => handle.setData({ value: 5 }));
+        cy.get('[data-cy="field_currency"]').should('have.value', '5');
+      });
+
+      it('tags', () => {
+        let handle!: FormHandle;
+        mountControl({ type: 'tags', data: { value: ['one'] }, onFormReady: (h) => (handle = h) });
+        cy.get('[data-cy="field_tags-input"]').type('two{enter}');
+        cy.get('gui-tags .gui-pills__pill-text').should('have.length', 2);
+        cy.then(() => handle.setData({ value: ['three'] }));
+        cy.get('gui-tags .gui-pills__pill-text').should('have.length', 1).and('contain', 'three');
+      });
+
+      it('list', () => {
+        let handle!: FormHandle;
+        mountControl({
+          type: 'list',
+          data: { value: 'React' },
+          props: { items: ['React', 'Angular', 'Vue'] },
+          onFormReady: (h) => (handle = h),
+        });
+        cy.get('gui-list .gui-list__item-wrapper').eq(1).click();
+        cy.get('gui-list .gui-list__item-wrapper')
+          .eq(1)
+          .should('have.attr', 'aria-selected', 'true');
+        cy.then(() => handle.setData({ value: 'Vue' }));
+        cy.get('gui-list .gui-list__item-wrapper')
+          .eq(2)
+          .should('have.attr', 'aria-selected', 'true');
+        cy.get('gui-list .gui-list__item-wrapper')
+          .eq(1)
+          .should('have.attr', 'aria-selected', 'false');
+      });
+
+      it('dateInput', () => {
+        let handle!: FormHandle;
+        mountControl({
+          type: 'dateInput',
+          data: { value: '2026-06-15' },
+          onFormReady: (h) => (handle = h),
+        });
+        cy.get('gui-date input[data-type="day"]').clear().type('20');
+        cy.get('gui-date input[data-type="day"]').should('have.value', '20');
+        cy.then(() => handle.setData({ value: '2025-01-02' }));
+        cy.get('gui-date input[data-type="month"]').should('have.value', '01');
+        cy.get('gui-date input[data-type="day"]').should('have.value', '02');
+        cy.get('gui-date input[data-type="year"]').should('have.value', '2025');
+      });
+
+      it('timeInput', () => {
+        let handle!: FormHandle;
+        mountControl({
+          type: 'timeInput',
+          data: { value: '14:30:00' },
+          onFormReady: (h) => (handle = h),
+        });
+        cy.get('gui-time input[data-type="hour"]').clear().type('09');
+        cy.get('gui-time input[data-type="hour"]').should('have.value', '09');
+        cy.then(() => handle.setData({ value: '11:45:00' }));
+        cy.get('gui-time input[data-type="hour"]').should('have.value', '11');
+        cy.get('gui-time input[data-type="minute"]').should('have.value', '45');
+      });
+
+      it('dateTimeInput', () => {
+        let handle!: FormHandle;
+        mountControl({
+          type: 'dateTimeInput',
+          data: { value: '2026-06-15T14:30:00' },
+          onFormReady: (h) => (handle = h),
+        });
+        cy.get('gui-date-time input[data-type="day"]').clear().type('20');
+        cy.then(() => handle.setData({ value: '2025-01-02T11:45:00' }));
+        cy.get('gui-date-time input[data-type="month"]').should('have.value', '01');
+        cy.get('gui-date-time input[data-type="day"]').should('have.value', '02');
+        cy.get('gui-date-time input[data-type="year"]').should('have.value', '2025');
+        cy.get('gui-date-time input[data-type="hour"]').should('have.value', '11');
+        cy.get('gui-date-time input[data-type="minute"]').should('have.value', '45');
+      });
+
+      it('rangeDateInput', () => {
+        let handle!: FormHandle;
+        mountControl({
+          type: 'rangeDateInput',
+          data: { value: [{ start: '2026-06-15', end: '2026-06-18' }] },
+          onFormReady: (h) => (handle = h),
+        });
+        cy.get('gui-range-date input[data-group="start"][data-type="month"]').type('07');
+        cy.focused().type('01');
+        cy.focused().type('2026');
+        cy.get('gui-range-date .gui-pills__pill-text').should('have.length', 1);
+        cy.then(() => handle.setData({ value: [{ start: '2025-01-02', end: '2025-01-05' }] }));
+        cy.get('gui-range-date .gui-pills__pill-text')
+          .should('have.length', 1)
+          .and('contain.text', '01/02/2025 - 01/05/2025');
+      });
+
+      it('datePicker', () => {
+        let handle!: FormHandle;
+        mountControl({
+          type: 'datePicker',
+          data: { value: '2026-06-15' },
+          onFormReady: (h) => (handle = h),
+        });
+        cy.get('gui-date-picker gui-date input[data-type="day"]').click();
+        cy.get('gui-calendar button[data-date="2026-06-20"]').click();
+        cy.get('gui-date-picker gui-date input[data-type="day"]').should('have.value', '20');
+        cy.then(() => handle.setData({ value: '2025-01-02' }));
+        cy.get('gui-date-picker gui-date input[data-type="month"]').should('have.value', '01');
+        cy.get('gui-date-picker gui-date input[data-type="day"]').should('have.value', '02');
+        cy.get('gui-date-picker gui-date input[data-type="year"]').should('have.value', '2025');
+      });
+
+      it('dateTimePicker', () => {
+        let handle!: FormHandle;
+        mountControl({
+          type: 'dateTimePicker',
+          data: { value: '2026-06-15T09:30:00' },
+          onFormReady: (h) => (handle = h),
+        });
+        cy.get('gui-date-time-picker gui-date-time input[data-type="day"]').click();
+        cy.get('gui-date-time-picker gui-date-time-calendar').should('exist');
+        cy.get('gui-date-time-calendar button[data-date="2026-06-20"]').click();
+        cy.then(() => handle.setData({ value: '2025-01-02T11:45:00' }));
+        cy.get('gui-date-time-picker gui-date-time input[data-type="month"]').should(
+          'have.value',
+          '01',
+        );
+        cy.get('gui-date-time-picker gui-date-time input[data-type="day"]').should(
+          'have.value',
+          '02',
+        );
+        cy.get('gui-date-time-picker gui-date-time input[data-type="year"]').should(
+          'have.value',
+          '2025',
+        );
+        cy.get('gui-date-time-picker gui-date-time input[data-type="hour"]').should(
+          'have.value',
+          '11',
+        );
+        cy.get('gui-date-time-picker gui-date-time input[data-type="minute"]').should(
+          'have.value',
+          '45',
+        );
+      });
+
+      it('rangeDatePicker', () => {
+        let handle!: FormHandle;
+        mountControl({
+          type: 'rangeDatePicker',
+          data: { value: [{ start: '2026-06-15', end: '2026-06-18' }] },
+          onFormReady: (h) => (handle = h),
+        });
+        cy.get('gui-range-date input[data-group="start"][data-type="month"]').click();
+        cy.get('gui-range-calendar button[data-date="2026-06-20"]').click();
+        cy.get('gui-range-calendar button[data-date="2026-06-22"]').click();
+        cy.get('gui-range-date .gui-pills__pill-text').should('have.length', 2);
+        cy.then(() => handle.setData({ value: [{ start: '2025-01-02', end: '2025-01-05' }] }));
+        cy.get('gui-range-date .gui-pills__pill-text')
+          .should('have.length', 1)
+          .and('contain.text', '01/02/2025 - 01/05/2025');
+      });
+
+      it('calendar', () => {
+        let handle!: FormHandle;
+        mountControl({
+          type: 'calendar',
+          data: { value: '2026-06-15' },
+          onFormReady: (h) => (handle = h),
+        });
+        cy.get('gui-calendar button[data-date="2026-06-20"]').click();
+        cy.get('gui-calendar button[data-date="2026-06-20"]').should(
+          'have.attr',
+          'aria-selected',
+          'true',
+        );
+        cy.then(() => handle.setData({ value: '2026-06-10' }));
+        cy.get('gui-calendar button[data-date="2026-06-10"]').should(
+          'have.attr',
+          'aria-selected',
+          'true',
+        );
+        cy.get('gui-calendar button[data-date="2026-06-20"]').should(
+          'have.attr',
+          'aria-selected',
+          'false',
+        );
       });
     });
 

--- a/libs/ui-testing/src/lib/gui-features/repeater.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/repeater.cy.ts
@@ -1,4 +1,4 @@
-import { defineForm } from '@golemui/core';
+import { defineForm, identityTranslator } from '@golemui/core';
 import { type MountComponentFn } from '../utils';
 
 export const runRepeaterComponentTests = (mountFn: MountComponentFn) => {
@@ -259,6 +259,108 @@ export const runRepeaterComponentTests = (mountFn: MountComponentFn) => {
       cy.get('[data-cy="firstName[0][0]_textinput"]').should('have.value', 'Second');
       cy.get('[data-cy="firstName[0][1]_textinput"]').should('have.value', 'Third');
       cy.get('[data-cy="firstName[0][2]_textinput"]').should('not.exist');
+    });
+
+    it('removing the first row shifts the remaining values into the reused rows', () => {
+      const ROWS_PATH = 'rows';
+      const item = (field: string) => `${ROWS_PATH}.items.${field}`;
+      mountFn({
+        localization: identityTranslator('en-US'),
+        data: {
+          rows: [
+            {
+              name: 'Alice',
+              age: 30,
+              active: true,
+              color: 'red',
+              day: '2026-06-10',
+              pick: '2026-06-11',
+            },
+            {
+              name: 'Bob',
+              age: 40,
+              active: false,
+              color: 'green',
+              day: '2026-06-12',
+              pick: '2026-06-13',
+            },
+            {
+              name: 'Carol',
+              age: 50,
+              active: true,
+              color: 'blue',
+              day: '2026-06-14',
+              pick: '2026-06-15',
+            },
+          ],
+        },
+        formDef: defineForm({
+          form: [
+            {
+              uid: 'rowsRepeater',
+              kind: 'input',
+              type: 'repeater',
+              path: ROWS_PATH,
+              props: {
+                addLabel: 'Add row',
+                removeLabel: 'Remove row',
+                template: {
+                  kind: 'layout',
+                  type: 'flex',
+                  children: [
+                    { uid: 'name', kind: 'input', type: 'textinput', path: item('name') },
+                    { uid: 'age', kind: 'input', type: 'number', path: item('age') },
+                    { uid: 'active', kind: 'input', type: 'checkbox', path: item('active') },
+                    {
+                      uid: 'color',
+                      kind: 'input',
+                      type: 'select',
+                      path: item('color'),
+                      props: { options: ['red', 'green', 'blue'] },
+                    },
+                    { uid: 'day', kind: 'input', type: 'dateInput', path: item('day') },
+                    { uid: 'pick', kind: 'input', type: 'datePicker', path: item('pick') },
+                  ],
+                },
+              },
+            },
+          ],
+        }),
+      });
+
+      // The picker renders its own gui-date, so keep the two families apart
+      const plainDateDay = 'gui-date:not(gui-date-picker gui-date) input[data-type="day"]';
+      const pickerDateDay = 'gui-date-picker gui-date input[data-type="day"]';
+
+      // Make every control in rows 1 and 2 dirty so a reused DOM node has to follow the store
+      cy.get('[data-cy="name[1]_textinput"]').clear().type('Bob typed');
+      cy.get('[data-cy="name[2]_textinput"]').clear().type('Carol typed');
+      cy.get('[data-cy="age[1]_number"]').clear().type('41');
+      cy.get('[data-cy="age[2]_number"]').clear().type('51').blur();
+      cy.get('[data-cy="active[1]_checkbox"]').click();
+      cy.get('[data-cy="active[2]_checkbox"]').click();
+      cy.get('[data-cy="color[1]_select"]').select('blue');
+      cy.get('[data-cy="color[2]_select"]').select('red');
+      cy.get(plainDateDay).eq(1).clear().type('20');
+      cy.get(plainDateDay).eq(2).clear().type('21');
+      cy.get(pickerDateDay).eq(1).clear().type('22');
+      cy.get(pickerDateDay).eq(2).clear().type('23').blur();
+
+      cy.get('.gui-button').contains('Remove row').first().click();
+
+      cy.get('[data-cy="name[0]_textinput"]').should('have.value', 'Bob typed');
+      cy.get('[data-cy="name[1]_textinput"]').should('have.value', 'Carol typed');
+      cy.get('[data-cy="name[2]_textinput"]').should('not.exist');
+      cy.get('[data-cy="age[0]_number"]').should('have.value', '41');
+      cy.get('[data-cy="age[1]_number"]').should('have.value', '51');
+      cy.get('[data-cy="active[0]_checkbox"]').should('be.checked');
+      cy.get('[data-cy="active[1]_checkbox"]').should('not.be.checked');
+      cy.get('[data-cy="color[0]_select"]').should('have.value', 'blue');
+      cy.get('[data-cy="color[1]_select"]').should('have.value', 'red');
+      cy.get(plainDateDay).eq(0).should('have.value', '20');
+      cy.get(plainDateDay).eq(1).should('have.value', '21');
+      cy.get(pickerDateDay).eq(0).should('have.value', '22');
+      cy.get(pickerDateDay).eq(1).should('have.value', '23');
     });
 
     it('should expose $formIsInvalid as true when a repeater item field has a validation error', () => {


### PR DESCRIPTION
## Description

Form controls now display the store value even after the user edited them.

- `gui-textinput`, `gui-password`, `gui-checkbox`, `gui-toggle`, `gui-radiogroup`, `gui-select`: the native `value` / `checked` / `selected` are bound as properties with `live()` instead of attributes.
- `gui-number`: the attribute binding is removed. The element writes the native value itself in `updated()`, comparing numerically so a draft like `1.` is kept, and skipping the focused input (the blur re-render catches up).
- `NumberInput.vue`: binds `value ?? Number.NaN`. Vue writes `0` into a custom element number property when the binding is `undefined`, and `gui-number` reads `NaN` as "no value".

## Why

The browser copies the `value` attribute into the property only until the user types (or the property is set by hand). After that the attribute is ignored, so a store change after user interaction (for example `setData`) never reached the screen. A property binding with `live()` compares against the real DOM instead of Lit's last written value, which makes the store the single source of truth for what an input shows. **This is also a precondition for reusing repeater row DOM nodes instead of re-creating them.**
