### PR TITLE
fix(core): copy data containers on write instead of mutating the previous state

### DIFF
--- a/libs/core/src/lib/store/reducer.spec.ts
+++ b/libs/core/src/lib/store/reducer.spec.ts
@@ -2139,4 +2139,90 @@ describe('reducer end-to-end', () => {
       expect(revealed.isFormValid).toBe(false);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // 22. Data copy-on-write
+  // ---------------------------------------------------------------------------
+
+  describe('data copy-on-write', () => {
+    /** Two inputs under one parent object, a repeater, and an input with a default. */
+    const makeNestedPathsFormDef = () => ({
+      form: [
+        { uid: 'street', kind: 'input', type: 'textinput', path: 'address.street' },
+        { uid: 'city', kind: 'input', type: 'textinput', path: 'address.city' },
+        {
+          uid: 'theme',
+          kind: 'input',
+          type: 'textinput',
+          path: 'settings.theme',
+          defaultValue: 'dark',
+        },
+        {
+          uid: 'users',
+          kind: 'input',
+          type: 'repeater',
+          path: 'users',
+          props: {
+            template: {
+              uid: 'usersRow',
+              kind: 'layout',
+              type: 'flex',
+              children: [
+                { uid: 'name', kind: 'input', type: 'textinput', path: 'users.items.name' },
+              ],
+            },
+          },
+        },
+      ],
+    });
+
+    const driveNestedPaths = (): State =>
+      drive([
+        init(makeNestedPathsFormDef()),
+        setData({ address: { street: 'a', city: 'b' }, users: [{ name: 'Ada' }] }),
+      ]);
+
+    it('SET_WIDGET_DATA copies the containers along the path and keeps the rest by reference', () => {
+      const initial = driveNestedPaths();
+
+      const reduce = makeReducer();
+      const state = reduce(initial, setWidgetData('address.street', 'x'));
+
+      expect(state.data['address']['street']).toBe('x');
+      expect(state.data).not.toBe(initial.data);
+      expect(state.data['address']).not.toBe(initial.data['address']);
+      expect(state.data['users']).toBe(initial.data['users']);
+
+      // The previous state keeps its content: nothing wrote into it.
+      expect(initial.data['address']['street']).toBe('a');
+    });
+
+    it('SET_WIDGET_DATA on a row path gives the repeater array a new identity', () => {
+      const initial = drive([
+        init(makeNestedPathsFormDef()),
+        setData({
+          address: { street: 'a', city: 'b' },
+          users: [{ name: 'Ada' }, { name: 'Linus' }],
+        }),
+      ]);
+
+      const reduce = makeReducer();
+      const state = reduce(initial, setWidgetData('users.1.name', 'Torvalds'));
+
+      expect(state.data['users']).not.toBe(initial.data['users']);
+      expect(state.data['users'][0]).toBe(initial.data['users'][0]);
+      expect(state.data['users'][1]).not.toBe(initial.data['users'][1]);
+      expect(initial.data['users'][1]['name']).toBe('Linus');
+    });
+
+    it('a written default keeps the references of the subtrees it does not touch', () => {
+      const payload = { address: { street: 'a', city: 'b' }, users: [{ name: 'Ada' }] };
+      const state = drive([init(makeNestedPathsFormDef()), setData(payload)]);
+
+      expect(state.data['settings']['theme']).toBe('dark');
+      expect(state.data['address']).toBe(payload.address);
+      expect(state.data['users']).toBe(payload.users);
+      expect(payload).not.toHaveProperty('settings');
+    });
+  });
 });

--- a/libs/core/src/lib/store/reducers/apply-default-values.ts
+++ b/libs/core/src/lib/store/reducers/apply-default-values.ts
@@ -1,5 +1,5 @@
 import { isInputWidget } from '../../form-widget';
-import { cloneObject, pathExists, set } from '../../utils/object';
+import { cloneObject, copyOnWriteSet, pathExists } from '../../utils/object';
 import { expandSources } from '../../utils/repeater';
 import { type State } from '../model';
 
@@ -30,10 +30,8 @@ export const applyDefaultValues = (state: State): State => {
       if (!isInputWidget(widget) || pathExists(data, widget.path)) {
         continue;
       }
-      if (data === state.data) {
-        data = cloneObject(state.data);
-      }
-      set(data, widget.path, cloneObject(widget.defaultValue));
+      // The default is cloned so an edit can never write back into the widget definition.
+      data = copyOnWriteSet(data, widget.path, cloneObject(widget.defaultValue));
       if (widget.defaultValue !== undefined) {
         wroteDefinedValue = true;
       }

--- a/libs/core/src/lib/store/reducers/set-widget-data.ts
+++ b/libs/core/src/lib/store/reducers/set-widget-data.ts
@@ -1,8 +1,8 @@
-import { set } from '../../utils/object';
+import { copyOnWriteSet } from '../../utils/object';
 import type { SET_WIDGET_DATA } from '../actions';
 import { type State } from '../model';
 
 export const setWidgetData = (state: State, action: SET_WIDGET_DATA): State => ({
   ...state,
-  data: { ...set(state.data, action.payload.path, action.payload.data) },
+  data: copyOnWriteSet(state.data, action.payload.path, action.payload.data),
 });

--- a/libs/core/src/lib/store/view-model.spec.ts
+++ b/libs/core/src/lib/store/view-model.spec.ts
@@ -420,6 +420,21 @@ describe('createWidgetViewModelReader', () => {
     expect(read(state, 'users')).toBe(before);
   });
 
+  it('rebuilds the rows when a row is appended through a container path write', () => {
+    const reduce = makeReducer();
+    let state = drive([init(makeBaseFormDef()), setData({ users: [{ name: 'Ada' }] })]);
+    const read = createWidgetViewModelReader();
+
+    const before = read(state, 'users');
+    expect(uidsOf(before.rows)).toEqual(['usersRow[0]']);
+
+    state = reduce(state, setWidgetData('users.1', { name: 'Grace' }));
+    const after = read(state, 'users');
+
+    expect(after).not.toBe(before);
+    expect(uidsOf(after.rows)).toEqual(['usersRow[0]', 'usersRow[1]']);
+  });
+
   it('reuses the rows array when only the form-invalid flag changed', () => {
     const reduce = makeReducer();
     let state = drive([

--- a/libs/core/src/lib/utils/object.spec.ts
+++ b/libs/core/src/lib/utils/object.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { cloneObject, get, pathExists, set, unset } from './object';
+import { cloneObject, copyOnWriteSet, get, pathExists, set, unset } from './object';
 
 describe('object.set', () => {
   it('sets dot notation paths', () => {
@@ -113,6 +113,54 @@ describe('object.set', () => {
         items: ['a', 'b', undefined, undefined, undefined, 'f'],
       });
     });
+  });
+});
+
+describe('object.copyOnWriteSet', () => {
+  it('sets the value without modifying the input', () => {
+    const obj = { a: { b: 'old' } };
+    const next = copyOnWriteSet(obj, 'a.b', 'new');
+    expect(next).toEqual({ a: { b: 'new' } });
+    expect(obj).toEqual({ a: { b: 'old' } });
+  });
+
+  it('copies the containers along the path and keeps siblings by reference', () => {
+    const obj = { a: { b: 1 }, c: { d: 2 } };
+    const next = copyOnWriteSet(obj, 'a.b', 3);
+    expect(next).not.toBe(obj);
+    expect(next['a']).not.toBe(obj.a);
+    expect(next['c']).toBe(obj.c);
+  });
+
+  it('copies an array container and keeps the untouched entries by reference', () => {
+    const obj = { items: [{ name: 'a' }, { name: 'b' }] };
+    const next = copyOnWriteSet(obj, 'items.1.name', 'c');
+    expect(next['items']).not.toBe(obj.items);
+    expect(next['items'][0]).toBe(obj.items[0]);
+    expect(next['items'][1]).toEqual({ name: 'c' });
+    expect(obj.items[1]).toEqual({ name: 'b' });
+  });
+
+  it('creates missing containers like set does', () => {
+    expect(copyOnWriteSet({}, 'a.b.c', 'value')).toEqual({ a: { b: { c: 'value' } } });
+    expect(copyOnWriteSet({}, 'items.0.name', 'test')).toEqual({ items: [{ name: 'test' }] });
+    expect(copyOnWriteSet({ a: 'string' }, 'a.b.c', 'nested')).toEqual({
+      a: { b: { c: 'nested' } },
+    });
+  });
+
+  it('keeps array holes as holes, so pathExists still reports them as absent', () => {
+    const obj: Record<string, any> = { items: [] };
+    obj['items'][2] = 'c';
+    const next = copyOnWriteSet(obj, 'items.2', 'x');
+    expect(pathExists(next, 'items.0')).toBe(false);
+    expect(next['items'][2]).toBe('x');
+  });
+
+  it('throws like set on a null object, an undefined object and an empty path', () => {
+    expect(() => copyOnWriteSet(null as any, 'a', 'value')).toThrow();
+    expect(() => copyOnWriteSet(undefined as any, 'a', 'value')).toThrow();
+    expect(() => copyOnWriteSet({}, '', 'value')).toThrow();
   });
 });
 

--- a/libs/core/src/lib/utils/object.ts
+++ b/libs/core/src/lib/utils/object.ts
@@ -219,6 +219,61 @@ export const set = (object: Record<string, any>, path: DotPath, value: any) => {
 };
 
 /**
+ * Returns a copy of `object` with `value` set at `path`, copying only the containers along
+ * the path. Untouched siblings keep their references and `object` is never modified, so the
+ * result can be compared to the input by reference at any level. Missing containers are
+ * created like {@link set}: an array when the next key is an index, an object otherwise.
+ * @param object - The object to copy and write into.
+ * @param path - Dot-separated path, array indexes as numeric segments.
+ * @param value - The value to set at the path.
+ * @returns A new root object with the value set.
+ * @example
+ * const next = copyOnWriteSet({ a: { b: 1 }, c: { d: 2 } }, 'a.b', 3);
+ * next.a.b;           // 3
+ * next.c;             // the input's c, by reference
+ */
+export const copyOnWriteSet = (
+  object: Record<string, any>,
+  path: DotPath,
+  value: any,
+): Record<string, any> => {
+  if (object === null) {
+    throw new Error('object is null');
+  }
+  if (object === undefined) {
+    throw new Error('object is undefined');
+  }
+  if (path === '') {
+    throw new Error('path cannot be empty');
+  }
+
+  const pathArray = path.split('.');
+  const root = copyContainer(object);
+
+  let current = root;
+  for (let i = 0; i < pathArray.length - 1; i++) {
+    const key = pathArray[i];
+    const nextKey = pathArray[i + 1];
+
+    if (current[key] == null || typeof current[key] !== 'object') {
+      current[key] = isIndex(nextKey) ? [] : {};
+    } else {
+      current[key] = copyContainer(current[key]);
+    }
+
+    current = current[key];
+  }
+
+  current[pathArray[pathArray.length - 1]] = value;
+  return root;
+};
+
+// `slice` keeps array holes, a spread would turn them into own `undefined` entries and
+// `pathExists` would then report a hole as an existing path.
+const copyContainer = (container: any): any =>
+  Array.isArray(container) ? container.slice() : { ...container };
+
+/**
  * Removes the property at the given dot-path from object by mutation.
  * After deletion, any ancestor plain objects that become empty are also removed.
  * Ancestor arrays that become empty are left in place, upward pruning stops as


### PR DESCRIPTION
setWidgetData wrote into the previous state's data tree and only spread the root, so every container along the written path kept its reference.
The view model compares value slices by identity, so a write to a container path (for example appending a row at users.2) never rendered, and subscribers holding the previous state saw its content change.

The new copyOnWriteSet in utils/object.ts copies only the containers along the written path, keeps siblings by reference, and never modifies the input. setWidgetData uses it, and applyDefaultValues uses it too and drops its whole-tree clone, so a written default no longer gives every subtree a new identity. 