### PR TITLE
fix(react): emit the load event once per widget across row changes

### DIFF
--- a/libs/react/src/lib/hooks/useActionWidget.ts
+++ b/libs/react/src/lib/hooks/useActionWidget.ts
@@ -1,5 +1,5 @@
 import { type ActionWidget, widgetViewModel$ } from '@golemui/core';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useReactFormContext } from '../ReactFormContext';
 import { mergeViewModelIntoTemplateData, type WithFlattenedProps } from './internal/template-data';
 
@@ -24,7 +24,14 @@ export function useActionWidget<ExtraProps extends Record<string, any>>(
     return () => sub.unsubscribe();
   }, [widget, formContext]);
 
+  // A repeater row widget arrives as a new object whenever the row set changes, so emit
+  // `load` once per uid and store, not once per widget object identity.
+  const lastLoad = useRef<{ store: unknown; uid: string } | undefined>(undefined);
   useEffect(() => {
+    if (lastLoad.current?.store === formContext.store && lastLoad.current?.uid === widget.uid) {
+      return;
+    }
+    lastLoad.current = { store: formContext.store, uid: widget.uid };
     formContext.emitEvent('load', widget);
   }, [formContext, widget]);
 

--- a/libs/react/src/lib/hooks/useInputWidget.ts
+++ b/libs/react/src/lib/hooks/useInputWidget.ts
@@ -1,5 +1,5 @@
 import { type InputWidget, type NonFunctionWidget, widgetViewModel$ } from '@golemui/core';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useReactFormContext } from '../ReactFormContext';
 import { mergeViewModelIntoTemplateData, type WithFlattenedProps } from './internal/template-data';
 
@@ -37,7 +37,14 @@ export function useInputWidget<T, ExtraProps extends Record<string, any>>(
     return () => sub.unsubscribe();
   }, [widget, formContext]);
 
+  // A repeater row widget arrives as a new object whenever the row set changes, so emit
+  // `load` once per uid and store, not once per widget object identity.
+  const lastLoad = useRef<{ store: unknown; uid: string } | undefined>(undefined);
   useEffect(() => {
+    if (lastLoad.current?.store === formContext.store && lastLoad.current?.uid === widget.uid) {
+      return;
+    }
+    lastLoad.current = { store: formContext.store, uid: widget.uid };
     formContext.emitEvent('load', widget);
   }, [formContext, widget]);
 

--- a/libs/ui-testing/src/lib/core-features/events.cy.ts
+++ b/libs/ui-testing/src/lib/core-features/events.cy.ts
@@ -68,6 +68,61 @@ export const runEventsComponentTests = (mountFn: MountComponentFn) => {
       cy.get('[data-cy="eventSelect_select"] option').should('have.length', 4);
     });
 
+    it('Should emit load once per row widget across row changes', () => {
+      const formEventHandler = cy.stub().as('formEventHandler');
+
+      mountFn({
+        formDef: defineForm({
+          form: [
+            {
+              uid: 'users',
+              kind: 'input',
+              type: 'repeater',
+              path: 'users',
+              props: {
+                addLabel: 'Add user',
+                removeLabel: 'Remove user',
+                template: {
+                  kind: 'layout',
+                  type: 'flex',
+                  children: [
+                    {
+                      uid: 'name',
+                      kind: 'input',
+                      type: 'textinput',
+                      label: 'Name',
+                      path: 'users.items.name',
+                      on: { load: 'rowInputLoaded' },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        }),
+        data: { users: [{ name: 'Ada' }, { name: 'Linus' }] },
+        formEvent: formEventHandler,
+      });
+
+      const loadCallCount = () =>
+        formEventHandler.getCalls().filter((call) => call.args[0].name === 'rowInputLoaded').length;
+
+      // One load per row input on mount.
+      cy.get('[data-cy="name[1]_textinput"]').should('exist');
+      cy.get('@formEventHandler').should(() => expect(loadCallCount()).to.equal(2));
+
+      // A new row loads once, the surviving rows do not load again.
+      cy.get('.gui-button').contains('Add user').click();
+      cy.get('[data-cy="name[2]_textinput"]').should('exist');
+      cy.get('@formEventHandler').should(() => expect(loadCallCount()).to.equal(3));
+
+      // Removing a row reuses the remaining row components, so nothing loads again.
+      cy.get('.gui-button').contains('Remove user').first().click();
+      cy.get('[data-cy="name[2]_textinput"]').should('not.exist');
+      cy.get('[data-cy="name[0]_textinput"]').should('have.value', 'Linus');
+      cy.get('@formEventHandler').should(() => expect(loadCallCount()).to.equal(3));
+    });
+
     it('Should execute form events on change', () => {
       const mockCountries: any = {
         europe: ['Spain', 'France', 'Italy'],


### PR DESCRIPTION
Repeater row nodes are rebuilt as new objects whenever the row set changes, and the load effect re-ran whenever the widget object identity changed. Every row that stayed after an add or remove therefore emitted load again. A row input with an on.load handler (for example fetching options) re-ran it for every row. The other three bindings emit load once per component.

The effect now records the last emitted uid and store in a ref and emits once per widget. After a form reinitialization the store is a new object, so the event is emitted again, same as before this change.

New shared Cypress test added: load is emitted exactly once per row widget across an add and a remove.