### PR TITLE
fix: recreate the widget tree when the form reinitializes

### DIFF
--- a/libs/angular/src/lib/components/form/form.component.html
+++ b/libs/angular/src/lib/components/form/form.component.html
@@ -11,7 +11,11 @@
   (submit)="onFormSubmit($event)"
 >
   @if (formState && formState.formDef && context.widgetRegistry.ready) {
-    <ng-container guiWidget [widget]="formState.formDef.form" />
+    <!-- Tracking the generation destroys and recreates the widget tree on every
+         initialization, so every widget subscribes to the store INITIALIZE ran on. -->
+    @for (generation of [storeGeneration()]; track generation) {
+      <ng-container guiWidget [widget]="formState.formDef.form" />
+    }
   } @else if (health().status !== 'errored') {
     <div>Loading form...</div>
   }

--- a/libs/angular/src/lib/components/form/form.component.ts
+++ b/libs/angular/src/lib/components/form/form.component.ts
@@ -24,7 +24,7 @@ import {
   type ValidatorFn,
   type WithWidget,
 } from '@golemui/core';
-import { share, switchMap, tap } from 'rxjs';
+import { combineLatest, share, switchMap, tap } from 'rxjs';
 import { AngularFormContext } from '../../context/form.context';
 import { WidgetDirective } from '../../directives/widget.directive';
 import { DefaultFormHealthBoundaryComponent } from './default-form-health-boundary.component';
@@ -68,22 +68,26 @@ export class FormCoreComponent implements OnInit, OnDestroy {
   private destroyRef = inject(DestroyRef);
   private unsubscribeI18n: () => void = () => undefined;
   protected readonly _defaultFormName = shortUUID();
+  // Keys the widget tree in the template. Every initialization bumps it, so the whole tree
+  // is destroyed and recreated and every widget subscribes to the store INITIALIZE ran on.
+  protected storeGeneration = signal(0);
 
   // `tap()` runs synchronously before `switchMap` accesses the new store, ensuring
   // that `context.initialize()` always fires before we resubscribe to `formHealth`
-  private config$ = toObservable(this.config).pipe(
-    tap((c) => {
+  private config$ = combineLatest([toObservable(this.config), toObservable(this.validators)]).pipe(
+    tap(([c, validators]) => {
       this.unsubscribeI18n();
       this.context.initialize(
         c.widgetLoaders,
         c.middlewares ?? [],
-        this.validators(),
+        validators,
         c.validateOn ?? 'eager',
         c.itemRenderers ?? {},
         c.localization,
         c.dependencies ?? {},
         c.functions ?? {},
       );
+      this.storeGeneration.update((generation) => generation + 1);
       this.context.store.dispatch({
         type: 'INITIALIZE',
         payload: {

--- a/libs/gui/angular/cypress/support/mount.ts
+++ b/libs/gui/angular/cypress/support/mount.ts
@@ -78,9 +78,23 @@ export const mountFramework = (options: MountOptions) => {
     // made by mount(). A second call flushes it so config$ emits and the store is initialized
     // before onFormReady exposes the handle to the test.
     fixture.detectChanges();
+    let currentConfig = config;
     options.onFormReady?.({
       setData: (data) => fixture.componentRef.instance.setData(data),
       setMeta: (meta) => fixture.componentRef.instance.setMeta(meta),
+      setConfig: (next) => {
+        currentConfig = {
+          ...currentConfig,
+          formDef: next.formDef,
+          data: next.data,
+          meta: next.meta,
+        };
+        fixture.componentRef.setInput('config', currentConfig);
+        // Two runs for the same reason as above: the first schedules the toObservable effect,
+        // the second flushes it.
+        fixture.detectChanges();
+        fixture.detectChanges();
+      },
     });
   });
 };

--- a/libs/gui/angular/cypress/test/core-features/reinit.cy.ts
+++ b/libs/gui/angular/cypress/test/core-features/reinit.cy.ts
@@ -1,0 +1,4 @@
+import { runReinitComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runReinitComponentTests(mountFramework);

--- a/libs/gui/lit/cypress/support/mount.ts
+++ b/libs/gui/lit/cypress/support/mount.ts
@@ -66,10 +66,17 @@ export const mountFramework = (options: MountOptions) => {
       @formSubmit=${handleFormSubmit}
     ></gui-form>`,
   ).then(() => {
-    const el = document.querySelector('gui-form') as HTMLElement & FormHandle;
+    const el = document.querySelector('gui-form') as HTMLElement & {
+      config: GuiFormInitConfig;
+      setData: FormHandle['setData'];
+      setMeta: FormHandle['setMeta'];
+    };
     options.onFormReady?.({
       setData: (data) => el.setData(data),
       setMeta: (meta) => el.setMeta(meta),
+      setConfig: (next) => {
+        el.config = { ...el.config, formDef: next.formDef, data: next.data, meta: next.meta };
+      },
     });
   });
 };

--- a/libs/gui/lit/cypress/test/core-features/reinit.cy.ts
+++ b/libs/gui/lit/cypress/test/core-features/reinit.cy.ts
@@ -1,0 +1,4 @@
+import { runReinitComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runReinitComponentTests(mountFramework);

--- a/libs/gui/lit/cypress/test/lit-only/wrapper-properties.cy.ts
+++ b/libs/gui/lit/cypress/test/lit-only/wrapper-properties.cy.ts
@@ -1,0 +1,43 @@
+import { defineForm } from '@golemui/core';
+import type { GuiFormInitConfig } from '@golemui/gui-shared';
+import { html } from 'lit';
+import '../../../src/lib/components/form.element';
+
+// Lit-local: pokes reactive properties of the gui-form element directly, which the shared
+// mount contract cannot express.
+describe('Widget set form element properties', () => {
+  it('changing a non-config property keeps the form state', () => {
+    const config: GuiFormInitConfig = {
+      formDef: defineForm({
+        form: [
+          {
+            uid: 'firstName',
+            kind: 'input',
+            type: 'textinput',
+            path: 'firstName',
+            label: 'First name',
+          },
+        ],
+      }),
+      data: { firstName: 'Ada' },
+      middlewares: [],
+      validateOn: 'eager',
+      customWidgetLoaders: {},
+    };
+
+    cy.mount(html`<gui-form .config=${config}></gui-form>`);
+
+    cy.get('[data-cy="firstName_textinput"]').clear();
+    cy.get('[data-cy="firstName_textinput"]').type('Grace');
+
+    cy.then(() => {
+      const el = document.querySelector('gui-form') as HTMLElement & { autocomplete?: string };
+      el.autocomplete = 'off';
+    });
+
+    // The property change re-renders the wrapper. That must not rebuild the config,
+    // so the form keeps its state instead of resetting to the config data.
+    cy.get('form').should('have.attr', 'autocomplete', 'off');
+    cy.get('[data-cy="firstName_textinput"]').should('have.value', 'Grace');
+  });
+});

--- a/libs/gui/react/cypress/support/mount.tsx
+++ b/libs/gui/react/cypress/support/mount.tsx
@@ -1,10 +1,62 @@
-import type { WidgetLoaders, WithWidget } from '@golemui/core';
+import type {
+  FormEvent,
+  FormHealth,
+  FormSubmitEvent,
+  WidgetLoaders,
+  WithWidget,
+} from '@golemui/core';
 import { type Dependencies, type GuiFormInitConfig } from '@golemui/gui-shared';
 import type { FormComponentHandle } from '@golemui/react';
-import { type MountOptions } from '@golemui/ui-testing';
+import { type MountOptions, type SetConfigInput } from '@golemui/ui-testing';
 import { mount } from 'cypress/react';
-import { type ComponentType, createRef } from 'react';
+import {
+  type ComponentType,
+  createRef,
+  forwardRef,
+  type Ref,
+  useImperativeHandle,
+  useState,
+} from 'react';
 import { GuiForm } from '../../src/lib/components/Form';
+
+interface ConfigHarnessHandle {
+  setConfig: (next: SetConfigInput) => void;
+}
+
+interface ConfigHarnessProps {
+  initialConfig: GuiFormInitConfig;
+  formRef: Ref<FormComponentHandle>;
+  formEvent: (event: FormEvent) => void | Promise<void>;
+  formHealth: (health: FormHealth) => void | Promise<void>;
+  formSubmit: (event: FormSubmitEvent) => void;
+}
+
+// Holds the config in state so a test can replace it, which is how a host app
+// triggers a form reinitialization.
+const ConfigHarness = forwardRef<ConfigHarnessHandle, ConfigHarnessProps>(function ConfigHarness(
+  { initialConfig, formRef, formEvent, formHealth, formSubmit },
+  ref,
+) {
+  const [config, setConfig] = useState(initialConfig);
+  useImperativeHandle(ref, () => ({
+    setConfig: (next) =>
+      setConfig((current) => ({
+        ...current,
+        formDef: next.formDef,
+        data: next.data,
+        meta: next.meta,
+      })),
+  }));
+  return (
+    <GuiForm
+      ref={formRef}
+      config={config}
+      formEvent={formEvent}
+      formHealth={formHealth}
+      formSubmit={formSubmit}
+    />
+  );
+});
 
 export const mountFramework = (options: MountOptions) => {
   const customWidgetLoaders: WidgetLoaders<ComponentType<WithWidget>> = options.withCustomComponent
@@ -36,11 +88,13 @@ export const mountFramework = (options: MountOptions) => {
   };
 
   const formRef = createRef<FormComponentHandle>();
+  const harnessRef = createRef<ConfigHarnessHandle>();
 
   mount(
-    <GuiForm
-      ref={formRef}
-      config={config}
+    <ConfigHarness
+      ref={harnessRef}
+      initialConfig={config}
+      formRef={formRef}
       formEvent={handleFormEvent}
       formHealth={handleFormHealth}
       formSubmit={handleFormSubmit}
@@ -58,6 +112,7 @@ export const mountFramework = (options: MountOptions) => {
         options.onFormReady!({
           setData: (data) => formRef.current!.setData(data),
           setMeta: (meta) => formRef.current!.setMeta(meta),
+          setConfig: (next) => harnessRef.current!.setConfig(next),
         });
       });
   }

--- a/libs/gui/react/cypress/test/core-features/reinit.cy.ts
+++ b/libs/gui/react/cypress/test/core-features/reinit.cy.ts
@@ -1,0 +1,4 @@
+import { runReinitComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runReinitComponentTests(mountFramework);

--- a/libs/gui/vue/cypress/support/mount.ts
+++ b/libs/gui/vue/cypress/support/mount.ts
@@ -1,7 +1,7 @@
 import type { FormSubmitEvent, WidgetLoaders, WithWidget } from '@golemui/core';
 import type { Dependencies, GuiFormInitConfig } from '@golemui/gui-shared';
 import type { MountOptions } from '@golemui/ui-testing';
-import { h, ref, type Component } from 'vue';
+import { h, ref, shallowRef, type Component } from 'vue';
 import GuiForm from '../../src/lib/components/Form';
 import type { GuiFormHandle } from '../../src/lib/components/Form.types';
 
@@ -34,13 +34,16 @@ export const mountFramework = (options: MountOptions) => {
   };
 
   const formRef = ref<GuiFormHandle | null>(null);
+  // `shallowRef` so the config object is handed to the form as it is, not wrapped in a
+  // deep reactive proxy. Replacing `.value` is what triggers the re-render.
+  const configRef = shallowRef<GuiFormInitConfig>(config);
 
   // Use the render-function variant of cy.mount so we can attach a template ref
   // (defineExpose) to the GuiForm instance for setData / setMeta access.
   cy.mount(() =>
     h(GuiForm as Component, {
       ref: formRef,
-      config,
+      config: configRef.value,
       'onForm-event': handleFormEvent,
       'onForm-health': handleFormHealth,
       'onForm-submit': handleFormSubmit,
@@ -60,6 +63,14 @@ export const mountFramework = (options: MountOptions) => {
         onFormReady({
           setData: (data) => handle.setData(data),
           setMeta: (meta) => handle.setMeta(meta),
+          setConfig: (next) => {
+            configRef.value = {
+              ...configRef.value,
+              formDef: next.formDef,
+              data: next.data,
+              meta: next.meta,
+            };
+          },
         });
       });
   }

--- a/libs/gui/vue/cypress/test/core-features/reinit.cy.ts
+++ b/libs/gui/vue/cypress/test/core-features/reinit.cy.ts
@@ -1,0 +1,4 @@
+import { runReinitComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runReinitComponentTests(mountFramework);

--- a/libs/lit/src/lib/components/form/createFormComponent.ts
+++ b/libs/lit/src/lib/components/form/createFormComponent.ts
@@ -4,7 +4,7 @@ import {
   type WidgetSetDefinition,
   type WidgetSetFormInitConfig,
 } from '@golemui/dx';
-import { html, LitElement } from 'lit';
+import { html, LitElement, type PropertyValues } from 'lit';
 import type { Type } from '../../utils/type';
 import type { FormElement as CoreFormElement } from './form.element';
 import './form.element';
@@ -88,8 +88,20 @@ export function createFormComponent<
       return this;
     }
 
+    // Rebuilt only when the config property changes. Building it in render() would hand
+    // the core form a new config identity on every re-render, and each one would
+    // reinitialize the store and reset the form data.
+    private bundle!: ReturnType<typeof buildWidgetSetForm>;
+
+    override willUpdate(changed: PropertyValues) {
+      super.willUpdate(changed);
+      if (changed.has('config')) {
+        this.bundle = buildWidgetSetForm(widgetSet, this.config);
+      }
+    }
+
     override render() {
-      const { initConfig, validators, resolved } = buildWidgetSetForm(widgetSet, this.config);
+      const { initConfig, validators, resolved } = this.bundle;
 
       // The bundle is built with untyped loaders. This widget set's loaders
       // resolve to Lit element classes, so the config is a Lit init config.

--- a/libs/lit/src/lib/components/form/form.element.ts
+++ b/libs/lit/src/lib/components/form/form.element.ts
@@ -15,6 +15,7 @@ import {
 import { provide } from '@lit/context';
 import { html, LitElement, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
+import { keyed } from 'lit/directives/keyed.js';
 import { when } from 'lit/directives/when.js';
 import { type Subscription } from 'rxjs';
 import { formContext, LitFormContext } from '../../context/form.context';
@@ -43,6 +44,9 @@ export class FormElement extends LitElement {
   // Subscriptions replaced on each config change (store is recreated on init).
   private stateSub: Subscription | undefined;
   private healthSub: Subscription | undefined;
+  // Keys the widget tree. Every initialization bumps it, so the whole tree is destroyed
+  // and recreated and every widget subscribes to the store INITIALIZE ran on.
+  private storeGeneration = 0;
   // Subscriptions stable for the element lifetime.
   private eventSub: Subscription[] = [];
   private unsubscribeI18n: () => void = () => undefined;
@@ -85,7 +89,7 @@ export class FormElement extends LitElement {
 
   override updated(changed: Map<string, unknown>) {
     super.updated(changed);
-    if (changed.has('config') && this.config) {
+    if ((changed.has('config') || changed.has('validators')) && this.config) {
       this._reinitialize(this.config);
     }
   }
@@ -95,6 +99,7 @@ export class FormElement extends LitElement {
     this.unsubscribeI18n();
     this.stateSub?.unsubscribe();
     this.healthSub?.unsubscribe();
+    this.storeGeneration += 1;
 
     this.context.initialize(
       c.widgetLoaders as WidgetLoaders<WithWidget>,
@@ -160,7 +165,11 @@ export class FormElement extends LitElement {
       >
         ${when(
           ready,
-          () => html` <gui-widget .widget=${this.formState?.formDef.form}></gui-widget>`,
+          () =>
+            keyed(
+              this.storeGeneration,
+              html` <gui-widget .widget=${this.formState?.formDef.form}></gui-widget>`,
+            ),
           () => (isErrored ? nothing : html` <div>Loading form...</div>`),
         )}
       </form>

--- a/libs/react/src/lib/FormComponent.tsx
+++ b/libs/react/src/lib/FormComponent.tsx
@@ -43,6 +43,9 @@ export const FormComponent = forwardRef<FormComponentHandle, FormComponentProps>
     const [formLayoutField, setFormLayoutField] = useState<LayoutWidget<string> | null>(null);
     const [healthError, setHealthError] = useState<FormHealth | null>(null);
     const [direction, setDirection] = useState<'ltr' | 'rtl'>('ltr');
+    // Keys the widget tree. Every initialization bumps it, so the whole tree is destroyed
+    // and recreated and every widget subscribes to the store INITIALIZE ran on.
+    const [treeGeneration, setTreeGeneration] = useState(0);
 
     const callbacksRef = useRef({ formHealth, formEvent, formSubmit });
     callbacksRef.current = { formHealth, formEvent, formSubmit };
@@ -65,6 +68,7 @@ export const FormComponent = forwardRef<FormComponentHandle, FormComponentProps>
       });
       context.store.dispatch({ type: 'SET_DATA', payload: { data: config.data ?? {} } });
       context.store.dispatch({ type: 'SET_META', payload: { meta: config.meta ?? {} } });
+      setTreeGeneration((generation) => generation + 1);
       setDirection(getDirectionFromLanguage(context.localization.lang));
 
       const stateSub = context.store.state$.subscribe((state) => {
@@ -137,7 +141,7 @@ export const FormComponent = forwardRef<FormComponentHandle, FormComponentProps>
               onSubmit={onFormSubmit}
             >
               {formLayoutField && (
-                <WidgetErrorBoundary widget={formLayoutField}>
+                <WidgetErrorBoundary key={treeGeneration} widget={formLayoutField}>
                   <WidgetRenderer widget={formLayoutField} />
                 </WidgetErrorBoundary>
               )}

--- a/libs/ui-testing/src/index.ts
+++ b/libs/ui-testing/src/index.ts
@@ -12,6 +12,7 @@ export * from './lib/core-features/label.cy';
 export * from './lib/core-features/middlewares.cy';
 export * from './lib/core-features/reactive-functions.cy';
 export * from './lib/core-features/readonly.cy';
+export * from './lib/core-features/reinit.cy';
 export * from './lib/core-features/required.cy';
 export * from './lib/core-features/set-data-set-meta.cy';
 export * from './lib/core-features/states.cy';

--- a/libs/ui-testing/src/lib/core-features/reinit.cy.ts
+++ b/libs/ui-testing/src/lib/core-features/reinit.cy.ts
@@ -1,0 +1,92 @@
+import { defineForm } from '@golemui/core';
+import { type FormHandle, type MountComponentFn } from '../utils';
+
+export const runReinitComponentTests = (mountFn: MountComponentFn) => {
+  describe('Config replacement', () => {
+    const firstNameFormDef = () =>
+      defineForm({
+        form: [
+          {
+            uid: 'firstName',
+            kind: 'input',
+            type: 'textinput',
+            path: 'firstName',
+            label: 'First name',
+          },
+        ],
+      });
+
+    const lastNameFormDef = () =>
+      defineForm({
+        form: [
+          {
+            uid: 'lastName',
+            kind: 'input',
+            type: 'textinput',
+            path: 'lastName',
+            label: 'Last name',
+          },
+          {
+            uid: 'submitBtn',
+            kind: 'action',
+            type: 'button',
+            label: 'Submit',
+            actionType: 'submit',
+          },
+        ],
+      });
+
+    it('renders the new form and routes edits to the new store', () => {
+      let handle: FormHandle;
+      mountFn({
+        formDef: firstNameFormDef(),
+        data: { firstName: 'Ada' },
+        onFormReady: (h) => {
+          handle = h;
+        },
+      });
+
+      cy.get('[data-cy="firstName_textinput"]').should('have.value', 'Ada');
+
+      cy.then(() => {
+        handle.setConfig({ formDef: lastNameFormDef(), data: { lastName: 'Lovelace' } });
+      });
+
+      cy.get('[data-cy="firstName_textinput"]').should('not.exist');
+      cy.get('[data-cy="lastName_textinput"]').should('have.value', 'Lovelace');
+
+      // The edit and the submit must reach the store the new form reads.
+      cy.get('[data-cy="lastName_textinput"]').clear();
+      cy.get('[data-cy="lastName_textinput"]').type('Byron');
+      cy.get('[data-cy="submitBtn_button"]').click();
+      cy.get('@formSubmit').should((spy: any) => {
+        expect(spy.lastCall.args[0].data).to.deep.equal({ lastName: 'Byron' });
+      });
+    });
+
+    it('shows the new data after a same-shape config replacement', () => {
+      let handle: FormHandle;
+      mountFn({
+        formDef: firstNameFormDef(),
+        data: { firstName: 'Ada' },
+        onFormReady: (h) => {
+          handle = h;
+        },
+      });
+
+      cy.get('[data-cy="firstName_textinput"]').should('have.value', 'Ada');
+
+      cy.then(() => {
+        handle.setConfig({ formDef: firstNameFormDef(), data: { firstName: 'Grace' } });
+      });
+
+      cy.get('[data-cy="firstName_textinput"]').should('have.value', 'Grace');
+
+      // The rendered form must read from the same store the handle writes to.
+      cy.then(() => {
+        handle.setData({ firstName: 'Hopper' });
+      });
+      cy.get('[data-cy="firstName_textinput"]').should('have.value', 'Hopper');
+    });
+  });
+};

--- a/libs/ui-testing/src/lib/utils.ts
+++ b/libs/ui-testing/src/lib/utils.ts
@@ -14,6 +14,15 @@ import { type CustomValidatorSchemas } from '@golemui/gui-validators';
 export interface FormHandle {
   setData: (data: Record<string, any>) => void;
   setMeta: (meta: Record<string, any>) => void;
+  /** Replaces the mounted form's whole config object, which reinitializes the form. */
+  setConfig: (next: SetConfigInput) => void;
+}
+
+/** The parts of the config `FormHandle.setConfig` replaces. */
+export interface SetConfigInput {
+  formDef: Form<any>;
+  data?: Record<string, any>;
+  meta?: Record<string, any>;
 }
 
 export interface MountOptions<StateKeys extends UiState = string> {

--- a/libs/vue/src/lib/FormComponent.vue
+++ b/libs/vue/src/lib/FormComponent.vue
@@ -29,6 +29,9 @@ const formLayoutField = ref<LayoutWidget<string> | null>(null);
 const health = ref<FormHealth>({ status: 'ok' });
 const direction = ref<'ltr' | 'rtl'>('ltr');
 const storeVersion = ref(0);
+// Keys the widget tree. Every INITIALIZE bumps it, so the whole tree is destroyed and
+// recreated and every widget subscribes to the store that INITIALIZE ran on.
+const treeGeneration = ref(0);
 
 provideFormContext(formContext);
 
@@ -48,17 +51,16 @@ const reinit = () => {
 
 reinit();
 
+// This watcher is created before the ones below, so on a config replacement it runs first
+// in the same flush: the store is already the new one when they dispatch into it.
 watch(
   () => [props.config, props.validators],
   () => reinit(),
-  { flush: 'post' },
 );
 
 // INITIALIZE resets the store and derives nothing. A new store gets its data and meta from the
 // watchers below, but a formDef replaced on the same config object does not bump storeVersion,
-// so this watcher dispatches them itself. A replaced config object is not that case: reinit()
-// runs after this watcher and builds a new store, so the follow-up would only feed a store that
-// is about to be dropped.
+// so this watcher dispatches them itself.
 let initializedStoreVersion = -1;
 let initializedConfig: FormComponentProps['config'] | null = null;
 watch(
@@ -68,6 +70,7 @@ watch(
     const configIsNew = props.config !== initializedConfig;
     initializedStoreVersion = storeVersion.value;
     initializedConfig = props.config;
+    treeGeneration.value += 1;
     formContext.store.dispatch({
       type: 'INITIALIZE',
       payload: {
@@ -189,7 +192,7 @@ const onFormSubmit = (event: SubmitEvent) => {
         :autocomplete="autocomplete"
         @submit.stop="onFormSubmit"
       >
-        <WidgetErrorBoundary v-if="formLayoutField" :widget="formLayoutField">
+        <WidgetErrorBoundary v-if="formLayoutField" :key="treeGeneration" :widget="formLayoutField">
           <WidgetRenderer :widget="formLayoutField" />
         </WidgetErrorBoundary>
       </form>


### PR DESCRIPTION
FormContext.initialize replaces the store, but the mounted widget components kept the subscriptions they opened at setup. After a config replacement the form kept rendering from the replaced store while edits went to the new one, so the visible form and the submitted data disagreed. React recovered by accident, Vue, Angular and Lit did not.

Every form component now keys its widget tree by a generation counter bumped on every INITIALIZE: the tree is destroyed and recreated, and every widget subscribes to the store INITIALIZE ran on. 

Also included:

- Vue dispatched the whole new config into the store it was about to replace (its reinit watcher ran post-flush, after the config watchers). It now runs pre-flush, so the dispatches reach the new store, and the generation key also covers the in-place formDef swap.
- Angular and Lit now reinitialize when the validators input changes, matching React and Vue.
- The Lit widget set wrapper built its config bundle inside render(), so changing any other property reset the form. It now builds the bundle only when the config property changes.
- The shared mount contract gained FormHandle.setConfig, and a new shared reinit spec runs on all four frameworks. It failed on Vue, Angular and Lit before the fixes and passes everywhere after. A Lit-local spec covers the wrapper property change.