### PR TITLE
fix(core): find function widget controls by the path they own

### DIFF
--- a/libs/core/src/lib/store/reducer.spec.ts
+++ b/libs/core/src/lib/store/reducer.spec.ts
@@ -445,6 +445,21 @@ const makeGatedInputWithSiblingFormDef = () => ({
   ],
 });
 
+/** The same gated required input, produced by a function widget instead of a JSON object. */
+const makeGatedFunctionWidgetFormDef = () => {
+  const secret: FunctionWidget<string> = () =>
+    ({
+      uid: 'secret',
+      kind: 'input',
+      type: 'textinput',
+      path: 'secret',
+      validator: { required: true },
+      include: { in: ['adult'] },
+    }) as InputWidget<any, string>;
+  secret.uid = 'secret';
+  return { states: { adult: '$form.age >= 18' }, form: [secret] };
+};
+
 /**
  * A form whose state, flags and props all read the validation variables: `$errors` for one
  * widget's `when`, `$formIsInvalid` for a state and for a button's `disabled`.
@@ -1222,6 +1237,16 @@ describe('reducer end-to-end', () => {
       const pruned = pruneHiddenData(rows);
       expect(pruned['lineItems'][1]).not.toHaveProperty('quantity');
       expect(pruned['lineItems'][0]).toEqual(rowScopeData.lineItems[0]);
+    });
+
+    it('prunes a hidden function widget control', () => {
+      const state = drive([
+        init(makeGatedFunctionWidgetFormDef()),
+        setData({ age: 10, secret: 'shh' }),
+      ]);
+
+      expect(state.widgetFlags['secret']).toEqual({ hidden: true });
+      expect(pruneHiddenData(state)).toEqual({ age: 10 });
     });
   });
 
@@ -2223,6 +2248,96 @@ describe('reducer end-to-end', () => {
       expect(state.data['address']).toBe(payload.address);
       expect(state.data['users']).toBe(payload.users);
       expect(payload).not.toHaveProperty('settings');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 23. Function widget controls
+  // ---------------------------------------------------------------------------
+
+  // A function widget is stored as the callable itself, so its input shape only exists in
+  // `current`. Every pass keyed by the input path has to find it there or on the stamped
+  // `source.path`, exactly like a plain input.
+  describe('function widget controls', () => {
+    const overrideByPath = (path: string, value: string): Action => ({
+      type: 'OVERRIDE_WIDGET_PROP',
+      payload: { path, prop: 'placeholder', value },
+    });
+
+    const overrideByUid = (uid: string, value: string): Action => ({
+      type: 'OVERRIDE_WIDGET_PROP',
+      payload: { uid, prop: 'placeholder', value },
+    });
+
+    it('VALIDATE_ALL touches the path of a top-level and of a row function widget', () => {
+      const state = drive([
+        init(makeFunctionWidgetsFormDef()),
+        setData({ users: [{ name: '' }] }),
+        validateAllAction,
+      ]);
+
+      expect(state.touchedControls).toEqual({
+        firstName: true,
+        users: true,
+        'users.0.name': true,
+      });
+      expect(state.validations).toEqual({
+        firstName: ['required'],
+        users: null,
+        'users.0.name': ['required'],
+      });
+      expect(state.isFormValid).toBe(false);
+    });
+
+    it('touches AND validates a function widget row added after VALIDATE_ALL', () => {
+      const validated = drive([
+        init(makeFunctionWidgetsFormDef()),
+        setData({ firstName: 'Ada', users: [{ name: 'Ada' }] }),
+        validateAllAction,
+      ]);
+      expect(validated.isFormValid).toBe(true);
+
+      const reduce = makeReducer();
+      const state = reduce(validated, setWidgetData('users', [{ name: 'Ada' }, {}]));
+
+      expect(state.touchedControls['users.1.name']).toBe(true);
+      expect(state.validations['users.1.name']).toEqual(['required']);
+      expect(state.isFormValid).toBe(false);
+    });
+
+    it('OVERRIDE_WIDGET_PROP by path finds a function widget control and applies the value', () => {
+      const initial = drive([
+        init(makeFunctionWidgetsFormDef()),
+        setData({ firstName: 'Ada', users: [{ name: 'Ada' }] }),
+      ]);
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const reduce = makeReducer();
+
+      const state = reduce(initial, overrideByPath('firstName', 'Your name'));
+      const rowState = reduce(state, overrideByPath('users.0.name', 'Row name'));
+
+      expect(warn).not.toHaveBeenCalled();
+      warn.mockRestore();
+
+      expect(rowState.widgetPropOverrides['firstName']).toEqual({ placeholder: 'Your name' });
+      expect(rowState.widgetPropOverrides['rowName[0]']).toEqual({ placeholder: 'Row name' });
+      expect(propsOf(rowState, 'firstName')['placeholder']).toBe('Your name');
+      expect(propsOf(rowState, 'rowName[0]')['placeholder']).toBe('Row name');
+    });
+
+    it('OVERRIDE_WIDGET_PROP by uid reaches the props of a function widget', () => {
+      const initial = drive([
+        init(makeFunctionWidgetsFormDef()),
+        setData({ firstName: 'Ada', users: [] }),
+      ]);
+
+      const reduce = makeReducer();
+      const state = reduce(initial, overrideByUid('firstName', 'Your name'));
+
+      expect(propsOf(state, 'firstName')['placeholder']).toBe('Your name');
+      // The function still owns every other prop it returns.
+      expect(propsOf(state, 'firstName')['seenTranslate']).toBe('function');
     });
   });
 });

--- a/libs/core/src/lib/store/reducer.ts
+++ b/libs/core/src/lib/store/reducer.ts
@@ -1,10 +1,10 @@
 import { errorCodes } from '../errors';
 import { type ValidatorFn } from '../form-validator';
-import { type InputWidget, isInputWidget } from '../form-widget';
+import { isInputWidget } from '../form-widget';
 import { type I18nTranslator } from '../i18n';
-import { type ExpressionFunctions, type Uid, type ValidateOn } from '../shared';
+import { type DotPath, type ExpressionFunctions, type ValidateOn } from '../shared';
 import { assertNever } from '../utils/assert-never';
-import { calculateValidationVariables } from '../utils/form';
+import { calculateValidationVariables, inputPath } from '../utils/form';
 import { type Action, type ATTEMPT_VALIDATION, type OVERRIDE_WIDGET_PROP } from './actions';
 import { type State } from './model';
 import {
@@ -176,40 +176,41 @@ function validateInputsAppearingAfterSubmit(
     return next;
   }
 
-  const appearing = inputsAppearingIn(next, previousSources, previousFlags);
+  const appearing = pathsOfInputsAppearingIn(next, previousSources, previousFlags);
   if (appearing.length === 0) {
     return next;
   }
 
   const touchedControls = { ...next.touchedControls };
-  for (const uid of appearing) {
-    touchedControls[(next.resolvedSources[uid] as InputWidget<unknown, string>).path] = true;
+  for (const path of appearing) {
+    touchedControls[path] = true;
   }
   next = { ...next, touchedControls };
   return calculateIsFormValid(derive(validate(next)));
 }
 
-/** The uids of the visible, untouched inputs that are new or were hidden before this derive. */
-function inputsAppearingIn(
+/** The paths of the visible, untouched inputs that are new or were hidden before this derive. */
+function pathsOfInputsAppearingIn(
   next: State,
   previousSources: State['resolvedSources'],
   previousFlags: State['widgetFlags'],
-): Uid[] {
-  const appearing: Uid[] = [];
+): DotPath[] {
+  const appearing: DotPath[] = [];
   for (const [uid, widget] of Object.entries(next.resolvedSources)) {
-    if (!isInputWidget(widget)) {
+    const path = inputPath(widget);
+    if (path === undefined) {
       continue;
     }
     if (next.widgetFlags[uid]?.hidden === true) {
       continue;
     }
-    if (next.touchedControls[widget.path] === true) {
+    if (next.touchedControls[path] === true) {
       continue;
     }
     const isNew = previousSources[uid] === undefined;
     const becameVisible = previousFlags[uid]?.hidden === true;
     if (isNew || becameVisible) {
-      appearing.push(uid);
+      appearing.push(path);
     }
   }
   return appearing;
@@ -219,12 +220,19 @@ function inputsAppearingIn(
 // Validation helpers
 // -----------------------------------------------------------------------------
 
-/** Marks the form submitted and replaces the touched set with every visible input path. */
+/**
+ * Marks the form submitted and replaces the touched set with every visible input path.
+ *
+ * `current` is what `validateAll` keys the validations by, so it is read first and the touched
+ * key always matches the validation key. `source` covers an entry the props pass has not filled
+ * in yet.
+ */
 function touchAllInputs(state: State): State {
   const touchedControls: State['touchedControls'] = {};
-  for (const { source } of Object.values(state.calculatedWidgets)) {
-    if (isInputWidget(source)) {
-      touchedControls[source.path] = true;
+  for (const { source, current } of Object.values(state.calculatedWidgets)) {
+    const path = inputPath(current) ?? inputPath(source);
+    if (path !== undefined) {
+      touchedControls[path] = true;
     }
   }
   return { ...state, touched: true, allControlsValidated: true, touchedControls };

--- a/libs/core/src/lib/store/reducers/calculate-widget-props.ts
+++ b/libs/core/src/lib/store/reducers/calculate-widget-props.ts
@@ -128,6 +128,13 @@ function computeFunctionWidget(
     (current as InputWidget<unknown, string>).path = source.path;
   }
 
+  // An override wins over the value the function returned, the same precedence `applyPropsField`
+  // gives it for every other widget.
+  const overrides = state.widgetPropOverrides[uid];
+  if (overrides !== undefined) {
+    current.props = { ...current.props, ...overrides };
+  }
+
   // A function widget builds a new config object on every call, so compare the content
   // to avoid handing subscribers a new reference for an unchanged widget.
   if (prev.current && deepEqual(prev.current, current)) {

--- a/libs/core/src/lib/store/reducers/drop-removed-widget-entries.ts
+++ b/libs/core/src/lib/store/reducers/drop-removed-widget-entries.ts
@@ -1,5 +1,5 @@
-import { isFunctionWidget, isInputWidget } from '../../form-widget';
 import { type DotPath } from '../../shared';
+import { inputPath } from '../../utils/form';
 import { type State } from '../model';
 
 /**
@@ -42,10 +42,9 @@ export const dropRemovedWidgetEntries = (state: State): State => {
 function collectLivePaths(resolvedSources: State['resolvedSources']): Set<DotPath> {
   const paths = new Set<DotPath>();
   for (const widget of Object.values(resolvedSources)) {
-    if (isInputWidget(widget)) {
-      paths.add(widget.path);
-    } else if (isFunctionWidget(widget) && widget.path !== undefined) {
-      paths.add(widget.path);
+    const path = inputPath(widget);
+    if (path !== undefined) {
+      paths.add(path);
     }
   }
   return paths;

--- a/libs/core/src/lib/store/reducers/override-widget-prop.ts
+++ b/libs/core/src/lib/store/reducers/override-widget-prop.ts
@@ -1,4 +1,5 @@
-import { type FormWidget, isInputWidget } from '../../form-widget';
+import { type FormWidget } from '../../form-widget';
+import { inputPath } from '../../utils/form';
 import type { OVERRIDE_WIDGET_PROP } from '../actions';
 import { type DerivedWidget, type State } from '../model';
 
@@ -7,7 +8,7 @@ export const overrideWidgetProp = (state: State, { payload }: OVERRIDE_WIDGET_PR
 
   if ('path' in payload) {
     widget = Object.values(state.calculatedWidgets).find(
-      ({ source }) => isInputWidget(source) && source.path === payload.path,
+      ({ source, current }) => (inputPath(current) ?? inputPath(source)) === payload.path,
     );
     if (!widget) {
       console.warn(`Input with path "${payload.path}" not found`);

--- a/libs/core/src/lib/utils/form.ts
+++ b/libs/core/src/lib/utils/form.ts
@@ -1,5 +1,5 @@
-import { type FormWidget, isInputWidget, isLayoutWidget } from '../form-widget';
-import { type $Errors } from '../shared';
+import { type FormWidget, isFunctionWidget, isInputWidget, isLayoutWidget } from '../form-widget';
+import { type $Errors, type DotPath } from '../shared';
 import { type State } from '../store/model';
 import { cloneObject, set, unset } from './object';
 
@@ -57,6 +57,21 @@ export function calculateValidationVariables(state: State): ValidationVariables 
 }
 
 /**
+ * The data path a widget owns: an input widget's `path`, or a function widget's `path` when it
+ * returns a control. A function widget is stored as the callable itself, so `isInputWidget` is
+ * false for it and its path is the one the decoder stamped on the function object.
+ *
+ * @param widget - A `resolvedSources` entry, or a `calculatedWidgets` `current` / `source`.
+ * @returns The path, or `undefined` for a widget that owns none.
+ */
+export function inputPath(widget: FormWidget<string> | undefined): DotPath | undefined {
+  if (widget === undefined) {
+    return undefined;
+  }
+  return isInputWidget(widget) || isFunctionWidget(widget) ? widget.path : undefined;
+}
+
+/**
  * Returns a copy of the form data with values for currently-hidden input widgets removed.
  * Paths come from `resolvedSources`, so hidden repeater row inputs are pruned too and hidden
  * widgets absent from calculatedWidgets are still covered.
@@ -66,9 +81,9 @@ export function pruneHiddenData(state: State): Record<string, any> {
 
   for (const [uid, flags] of Object.entries(state.widgetFlags)) {
     if (flags.hidden === true) {
-      const widget = state.resolvedSources[uid];
-      if (widget && isInputWidget(widget)) {
-        unset(pruned, widget.path);
+      const path = inputPath(state.resolvedSources[uid]);
+      if (path !== undefined) {
+        unset(pruned, path);
       }
     }
   }

--- a/libs/ui-testing/src/lib/core-features/reactive-functions.cy.ts
+++ b/libs/ui-testing/src/lib/core-features/reactive-functions.cy.ts
@@ -131,5 +131,36 @@ export const runReactiveFunctionsComponentTests = (mountFn: MountComponentFn) =>
       // No more errors because validation passes
       cy.get('[data-cy="inputUid_label"]').contains('Ohmmm');
     });
+
+    it('Should show the errors of a required field function after a submit attempt', () => {
+      mountFn({
+        data: {},
+        formDef: defineForm<TestData>({
+          form: [
+            () => ({
+              uid: 'inputUid',
+              kind: 'input',
+              type: 'textinput',
+              path: 'myInput',
+              label: 'My input',
+              validator: { type: 'string', required: true },
+            }),
+            {
+              uid: 'submitBtn',
+              kind: 'action',
+              type: 'button',
+              label: 'Submit',
+              actionType: 'submit',
+            },
+          ],
+        }),
+      });
+
+      cy.get('[data-cy="inputUid_validator-errors"]').should('not.exist');
+
+      // The submit touches every input, so the error shows without interacting with the field.
+      cy.get('[data-cy="submitBtn_button"]').click();
+      cy.get('[data-cy="inputUid_validator-errors"]').should('exist');
+    });
   });
 };


### PR DESCRIPTION
A function widget is stored as the callable itself, so `isInputWidget` is false for it and its input shape only exists in `calculatedWidgets[uid].current`. The core passes that work from an input's path did not find these controls:

- Submit did not touch their path, so the form blocked on their validation while their error stayed hidden, and no interaction with other fields fixed it.
- One revealed or added as a repeater row after a submit attempt was not touched and validated.
- `OVERRIDE_WIDGET_PROP` by path warned "Input with path ... not found" and dropped the override.
- A hidden one kept its value in the data of every emitted event.