### PR TITLE
fix(core): discard the whole derive when one of its passes fails

### DIFF
--- a/libs/core/src/lib/store/reducer.spec.ts
+++ b/libs/core/src/lib/store/reducer.spec.ts
@@ -531,6 +531,39 @@ const makeBrokenWhenFormDef = () => ({
   ],
 });
 
+/**
+ * A repeater whose row template interpolates a host function that does not exist. With no rows
+ * the props pass has nothing to resolve, so the first derive succeeds and adding a row throws a
+ * code 40 while the rows are being resolved.
+ */
+const makeBrokenRowPropFormDef = () => ({
+  form: [
+    { uid: 'title', kind: 'display', type: 'heading', props: { text: 'Users' } },
+    {
+      uid: 'users',
+      kind: 'input',
+      type: 'repeater',
+      path: 'users',
+      props: {
+        template: {
+          uid: 'usersRow',
+          kind: 'layout',
+          type: 'flex',
+          children: [
+            {
+              uid: 'greeting',
+              kind: 'display',
+              type: 'heading',
+              props: { text: 'Hi {{$fn.missing()}}' },
+            },
+            { uid: 'name', kind: 'input', type: 'textinput', path: 'users.items.name' },
+          ],
+        },
+      },
+    },
+  ],
+});
+
 /** A form driven entirely by `$meta`: one state, one flag and one interpolated prop. */
 const makeMetaFormDef = () => ({
   states: { debug: '$meta.debug === true' },
@@ -1389,7 +1422,7 @@ describe('reducer end-to-end', () => {
   // ---------------------------------------------------------------------------
 
   describe('form health', () => {
-    it('reports an errored form when a prop interpolation throws, and computes no props', () => {
+    it('reports an errored form when a prop interpolation throws, and publishes no widgets', () => {
       const state = drive([init(makeBrokenInterpolationFormDef()), setData({ age: 21 })]);
 
       expect(state.formHealth).toEqual({
@@ -1399,10 +1432,11 @@ describe('reducer end-to-end', () => {
         code: 40,
       });
 
-      // States and flags ran, the props pass threw before writing anything.
-      expect(state.currentStates).toEqual(['adult']);
-      expect(state.calculatedWidgets['oops'].current).toEqual({});
-      expect(state.calculatedWidgets['fine'].current).toEqual({});
+      // The failed derive publishes nothing, so this first one leaves the form with no widgets
+      // and no states rather than with the placeholder entries the props pass was filling.
+      expect(state.currentStates).toEqual([]);
+      expect(state.calculatedWidgets).toEqual({});
+      expect(state.data).toEqual({ age: 21 });
     });
 
     it('recovers from an interpolation error as soon as the data computes again', () => {
@@ -2338,6 +2372,53 @@ describe('reducer end-to-end', () => {
       expect(propsOf(state, 'firstName')['placeholder']).toBe('Your name');
       // The function still owns every other prop it returns.
       expect(propsOf(state, 'firstName')['seenTranslate']).toBe('function');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 24. A derive-owned error discards the whole pass
+  // ---------------------------------------------------------------------------
+
+  // A pass that catches its own error must not publish what the passes before it produced:
+  // `fillCalculatedWidgets` seeds new entries with an empty `current`, and a state carrying
+  // those placeholders renders widgets with no type and no props.
+  describe('a derive-owned error discards the whole pass', () => {
+    it('publishes no half-computed widgets when the props pass fails on a new row', () => {
+      const ok = drive([init(makeBrokenRowPropFormDef()), setData({ users: [] })]);
+      expect(ok.formHealth).toEqual({ status: 'ok' });
+
+      const reduce = makeReducer();
+      const errored = reduce(ok, setData({ users: [{ name: 'Ada' }] }));
+
+      expect(errored.formHealth.status).toBe('errored');
+      if (errored.formHealth.status === 'errored') {
+        expect(errored.formHealth.code).toBe(40);
+      }
+      // The data change is stored, nothing computed from it is.
+      expect(errored.data).toEqual({ users: [{ name: 'Ada' }] });
+      expect(errored.calculatedWidgets).toBe(ok.calculatedWidgets);
+      expect(errored.resolvedSources).toBe(ok.resolvedSources);
+      expect(errored.widgetFlags).toBe(ok.widgetFlags);
+      // No entry for the row the failed pass was resolving, and no empty placeholder anywhere.
+      expect(errored.calculatedWidgets['greeting[0]']).toBeUndefined();
+      const currents = Object.values(errored.calculatedWidgets).map((entry) => entry.current);
+      expect(currents.every((current) => Object.keys(current).length > 0)).toBe(true);
+    });
+
+    it('recovers the row on the next derive once the props resolve', () => {
+      const errored = drive([
+        init(makeBrokenRowPropFormDef()),
+        setData({ users: [] }),
+        setData({ users: [{ name: 'Ada' }] }),
+      ]);
+      expect(errored.formHealth.status).toBe('errored');
+
+      const reduce = makeReducer();
+      const healed = reduce(errored, setData({ users: [] }));
+
+      expect(healed.formHealth).toEqual({ status: 'ok' });
+      expect(healed.calculatedWidgets['greeting[0]']).toBeUndefined();
+      expect(propsOf(healed, 'title')['text']).toBe('Users');
     });
   });
 });

--- a/libs/core/src/lib/store/reducer.ts
+++ b/libs/core/src/lib/store/reducer.ts
@@ -130,6 +130,11 @@ function makeDerive(localization: I18nTranslator, functions: ExpressionFunctions
     if (erroredOutsideDerive(state)) {
       return state;
     }
+    // A failed pass publishes the input state with only the new health, so an entry whose
+    // `current` is still the empty placeholder never reaches a renderer. The next derive
+    // computes everything again.
+    const discardPass = (formHealth: State['formHealth']): State => ({ ...state, formHealth });
+
     try {
       let next: State =
         state.formHealth.status === 'ok' ? state : { ...state, formHealth: { status: 'ok' } };
@@ -138,18 +143,19 @@ function makeDerive(localization: I18nTranslator, functions: ExpressionFunctions
       const validationVariables = calculateValidationVariables(next);
       next = applyCurrentState(next, validationVariables);
       if (next.formHealth.status !== 'ok') {
-        return next;
+        return discardPass(next.formHealth);
       }
       next = applyWidgetFlags(next, validationVariables);
       next = fillCalculatedWidgets(next);
-      return applyWidgetProps(next, validationVariables);
+      next = applyWidgetProps(next, validationVariables);
+      return next.formHealth.status === 'ok' ? next : discardPass(next.formHealth);
     } catch (err) {
-      // Nothing from this pass is applied, so the last good widgets stay in place.
       const code = errorCodes.calculateWidgetFlagsError;
-      return {
-        ...state,
-        formHealth: { status: 'errored', code, message: `[${code}] ${(err as Error).message}` },
-      };
+      return discardPass({
+        status: 'errored',
+        code,
+        message: `[${code}] ${(err as Error).message}`,
+      });
     }
   };
 }


### PR DESCRIPTION
## Description

`makeDerive` ran its passes in sequence and returned whatever the last one gave back. Two of those passes catch their own errors and return `{ ...state, formHealth }` from the state they were handed, which inside the derive is a partially computed state. A props error (code 12 or 40) therefore published the new data, the new `resolvedSources`, the new flags, and `calculatedWidgets` entries whose `current` was still the empty placeholder `fillCalculatedWidgets` seeds. A row added with a broken template prop reached the renderer as an empty widget object.

The derive now has one `discardPass(formHealth)` helper that returns the derive input state with only the new health, and all three failure paths use it: the props pass result (codes 12 and 40), the states pass early return (code 10), and the outer catch (code 11, which already had that shape). The internal catch in `calculateWidgetProps` stays, because `SET_LANGUAGE` calls that pass on its own.

The code 10 path is not tested. `calculateCurrentState` catches every expression error per state name, so nothing expressible in a form definition reaches its outer catch. It goes through the same helper for uniformity.
