### PR TITLE
fix: make tabs and accordion DOM ids unique and keep their aria pairs correct

### DIFF
--- a/libs/gui/angular/cypress/test/gui-features/accordion.cy.ts
+++ b/libs/gui/angular/cypress/test/gui-features/accordion.cy.ts
@@ -1,0 +1,4 @@
+import { runAccordionComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runAccordionComponentTests(mountFramework);

--- a/libs/gui/angular/cypress/test/gui-features/tabs.cy.ts
+++ b/libs/gui/angular/cypress/test/gui-features/tabs.cy.ts
@@ -1,0 +1,4 @@
+import { runTabsComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runTabsComponentTests(mountFramework);

--- a/libs/gui/angular/src/lib/components/accordion/accordion.component.html
+++ b/libs/gui/angular/src/lib/components/accordion/accordion.component.html
@@ -6,8 +6,8 @@
       <button
         type="button"
         tabindex="0"
-        [id]="'accordion_button_' + section.uid"
-        [attr.aria-controls]="'accordion_section_' + section.uid"
+        [id]="buttonId(section.uid)"
+        [attr.aria-controls]="sectionId(section.uid)"
         [attr.aria-expanded]="activeSections[section.uid] ? 'true' : 'false'"
         [class.active]="activeSections[section.uid]"
         (click)="onClickButton(section.uid)"
@@ -27,8 +27,8 @@
           class="gui-widget"
           role="region"
           [hidden]="!activeSections[section.uid] && templateData.renderMode !== 'activeOnly'"
-          [id]="'accordion_section_' + section.uid"
-          [attr.aria-labelledby]="'accordion_button_' + section.uid"
+          [id]="sectionId(section.uid)"
+          [attr.aria-labelledby]="buttonId(section.uid)"
         >
           <ng-container guiWidget [widget]="child" />
         </section>

--- a/libs/gui/angular/src/lib/components/accordion/accordion.component.ts
+++ b/libs/gui/angular/src/lib/components/accordion/accordion.component.ts
@@ -3,7 +3,12 @@ import { Component, inject, type OnDestroy, type OnInit } from '@angular/core';
 import { LayoutWidgetAdapter, WidgetDirective } from '@golemui/angular';
 import type { LayoutWidget, NonFunctionWidget, WithWidget } from '@golemui/core';
 import type { AccordionEventDetail } from '@golemui/gui-components/internals';
-import { type AccordionProps, repeaterIndexSuffix } from '@golemui/gui-shared/internals';
+import {
+  accordionButtonId,
+  accordionSectionId,
+  type AccordionProps,
+  repeaterIndexSuffix,
+} from '@golemui/gui-shared/internals';
 
 @Component({
   standalone: true,
@@ -54,6 +59,14 @@ export class AccordionComponent implements OnInit, OnDestroy, WithWidget {
   getChild(uid: string): NonFunctionWidget<string> | undefined {
     const childUid = `${uid}${this.rowIndexSuffix}`;
     return this.adapter.templateData().children.find((section) => section.uid === childUid);
+  }
+
+  buttonId(sectionUid: string) {
+    return accordionButtonId(this.widget.uid, sectionUid);
+  }
+
+  sectionId(sectionUid: string) {
+    return accordionSectionId(this.widget.uid, sectionUid);
   }
 
   ngOnDestroy(): void {

--- a/libs/gui/angular/src/lib/components/tabs/tabs.component.html
+++ b/libs/gui/angular/src/lib/components/tabs/tabs.component.html
@@ -8,18 +8,18 @@
 >
   <ul role="tablist">
     <li role="presentation" #startSentinel class="gui-sentinel gui-sentinel__start"></li>
-    @for (tab of templateData.tabs; track tab.uid; let i = $index) {
+    @for (tab of templateData.tabs; track tab.uid) {
       <li role="presentation">
         <button
           #tabButtonRef
           type="button"
           role="tab"
-          [attr.data-cy]="'tab_' + widget.uid + '_' + i"
-          [tabindex]="tab.uid === activeTab() ? 0 : -1"
-          [id]="'tab_' + widget.uid + '_' + i"
-          [attr.aria-controls]="'tabpanel_' + widget.uid + '_' + i"
-          [attr.aria-selected]="tab.uid === activeTab() ? 'true' : 'false'"
-          [class.active]="tab.uid === activeTab()"
+          [attr.data-cy]="tabId(tab.uid)"
+          [tabindex]="isActiveTab(tab.uid) ? 0 : -1"
+          [id]="tabId(tab.uid)"
+          [attr.aria-controls]="panelId(tab.uid)"
+          [attr.aria-selected]="isActiveTab(tab.uid) ? 'true' : 'false'"
+          [class.active]="isActiveTab(tab.uid)"
           (click)="onClickTab(tab.uid)"
           (keydown)="onKeyDown($event)"
           (focus)="onFocus($event)"
@@ -32,15 +32,18 @@
   </ul>
 </nav>
 
-@for (child of templateData.children; track child.uid; let i = $index) {
-  @if (isActiveTab(child) || templateData.renderMode !== 'activeOnly') {
+<!-- Panels come from the tab list, so a tab and its panel always carry the same uid. A tab whose
+     child is hidden by a `when` keeps its header and gets no panel. -->
+@for (tab of templateData.tabs; track tab.uid) {
+  @let child = getChild(tab.uid);
+  @if (child && (isActiveTab(tab.uid) || templateData.renderMode !== 'activeOnly')) {
     <section
       role="tabpanel"
       tabindex="0"
-      [hidden]="!isActiveTab(child) && templateData.renderMode !== 'activeOnly'"
-      [attr.data-cy]="'tabpanel_' + widget.uid + '_' + i"
-      [id]="'tabpanel_' + widget.uid + '_' + i"
-      [attr.aria-labelledby]="'tab_' + widget.uid + '_' + i"
+      [hidden]="!isActiveTab(tab.uid)"
+      [attr.data-cy]="panelId(tab.uid)"
+      [id]="panelId(tab.uid)"
+      [attr.aria-labelledby]="tabId(tab.uid)"
     >
       <ng-container guiWidget [widget]="child" />
     </section>

--- a/libs/gui/angular/src/lib/components/tabs/tabs.component.ts
+++ b/libs/gui/angular/src/lib/components/tabs/tabs.component.ts
@@ -11,12 +11,17 @@ import {
   viewChildren,
 } from '@angular/core';
 import { LayoutWidgetAdapter, WidgetDirective } from '@golemui/angular';
-import type { LayoutWidget, WithWidget } from '@golemui/core';
+import type { LayoutWidget, NonFunctionWidget, WithWidget } from '@golemui/core';
 import {
   createIntersectionObserver,
   type TabsEventDetail,
 } from '@golemui/gui-components/internals';
-import { repeaterIndexSuffix, type TabsProps } from '@golemui/gui-shared/internals';
+import {
+  repeaterIndexSuffix,
+  tabButtonId,
+  tabPanelId,
+  type TabsProps,
+} from '@golemui/gui-shared/internals';
 
 @Component({
   standalone: true,
@@ -73,10 +78,24 @@ export class TabsComponent implements OnInit, AfterViewInit, OnDestroy, WithWidg
 
   /**
    * The tab uids come from the props and carry no repeater row indexes, the panel children come
-   * from the store with the indexes already applied, so the comparison adds this tabs layout's own.
+   * from the store with the indexes already applied, so the lookup adds this tabs layout's own.
+   * Returns `undefined` when the tab's child is hidden, the children only hold visible ones.
    */
-  isActiveTab(child: { uid: string }) {
-    return child.uid === `${this.activeTab()}${this.rowIndexSuffix}`;
+  getChild(tabUid: string): NonFunctionWidget<string> | undefined {
+    const childUid = `${tabUid}${this.rowIndexSuffix}`;
+    return this.adapter.templateData().children.find((child) => child.uid === childUid);
+  }
+
+  isActiveTab(tabUid: string) {
+    return tabUid === this.activeTab();
+  }
+
+  tabId(tabUid: string) {
+    return tabButtonId(this.widget.uid, tabUid);
+  }
+
+  panelId(tabUid: string) {
+    return tabPanelId(this.widget.uid, tabUid);
   }
 
   onClickTab(uid: string) {

--- a/libs/gui/lit/cypress/test/gui-features/accordion.cy.ts
+++ b/libs/gui/lit/cypress/test/gui-features/accordion.cy.ts
@@ -1,0 +1,4 @@
+import { runAccordionComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runAccordionComponentTests(mountFramework);

--- a/libs/gui/lit/cypress/test/gui-features/tabs.cy.ts
+++ b/libs/gui/lit/cypress/test/gui-features/tabs.cy.ts
@@ -1,0 +1,4 @@
+import { runTabsComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runTabsComponentTests(mountFramework);

--- a/libs/gui/lit/src/lib/components/accordion.element.ts
+++ b/libs/gui/lit/src/lib/components/accordion.element.ts
@@ -1,6 +1,11 @@
 import type { LayoutWidget, WithWidget } from '@golemui/core';
 import { LayoutWidgetAdapter, type LitFormContext, formContext, layoutContext } from '@golemui/lit';
-import { type AccordionProps, repeaterIndexSuffix } from '@golemui/gui-shared/internals';
+import {
+  accordionButtonId,
+  accordionSectionId,
+  type AccordionProps,
+  repeaterIndexSuffix,
+} from '@golemui/gui-shared/internals';
 import { consume, provide } from '@lit/context';
 import { html, LitElement, nothing } from 'lit';
 import { property } from 'lit/decorators.js';
@@ -96,10 +101,10 @@ export class AccordionElement extends LitElement implements WithWidget {
                     ? html`<section
                         class="gui-widget"
                         role="region"
-                        id=${`accordion_section_${section.uid}`}
+                        id=${accordionSectionId(this.widget.uid, section.uid)}
                         ?hidden=${!this.activeSections[section.uid] &&
                         this.adapter.templateData.renderMode !== 'activeOnly'}
-                        aria-labelledby=${`accordion_button_${section.uid}`}
+                        aria-labelledby=${accordionButtonId(this.widget.uid, section.uid)}
                       >
                         <gui-widget .widget=${child}></gui-widget>
                       </section>`
@@ -112,8 +117,8 @@ export class AccordionElement extends LitElement implements WithWidget {
                     class=${classMap({
                       active: this.activeSections[section.uid],
                     })}
-                    id=${`accordion_button_${section.uid}`}
-                    aria-controls=${`accordion_section_${section.uid}`}
+                    id=${accordionButtonId(this.widget.uid, section.uid)}
+                    aria-controls=${accordionSectionId(this.widget.uid, section.uid)}
                     aria-expanded=${this.activeSections[section.uid] ? 'true' : 'false'}
                     @click=${() => this.onClickButton(section.uid)}
                   >

--- a/libs/gui/lit/src/lib/components/tabs.element.ts
+++ b/libs/gui/lit/src/lib/components/tabs.element.ts
@@ -5,7 +5,12 @@ import {
   type TabsEventDetail,
 } from '@golemui/gui-components/internals';
 import { safeDefine } from '@golemui/lit/internals';
-import { repeaterIndexSuffix, type TabsProps } from '@golemui/gui-shared/internals';
+import {
+  repeaterIndexSuffix,
+  tabButtonId,
+  tabPanelId,
+  type TabsProps,
+} from '@golemui/gui-shared/internals';
 import { consume, provide } from '@lit/context';
 import { html, LitElement, nothing, type PropertyValues } from 'lit';
 import { repeat } from 'lit-html/directives/repeat.js';
@@ -16,8 +21,10 @@ import { type Subscription } from 'rxjs';
 export class TabsElement extends LitElement implements WithWidget {
   widget!: LayoutWidget;
 
-  @query('#start-sentinel') startSentinel!: HTMLElement;
-  @query('#end-sentinel') endSentinel!: HTMLElement;
+  // Queried by class: this element renders into the light DOM, so a fixed id would be duplicated
+  // across every tabs instance on the page.
+  @query('.gui-sentinel__start') startSentinel!: HTMLElement;
+  @query('.gui-sentinel__end') endSentinel!: HTMLElement;
 
   @state() isStartVisible!: boolean;
   @state() isEndVisible!: boolean;
@@ -43,7 +50,11 @@ export class TabsElement extends LitElement implements WithWidget {
   private endObserver?: IntersectionObserver;
 
   private get activeChildUid() {
-    return `${this.activeTab}${this.rowIndexSuffix}`;
+    return this.childUid(this.activeTab);
+  }
+
+  private childUid(tabUid: string) {
+    return `${tabUid}${this.rowIndexSuffix}`;
   }
 
   override createRenderRoot() {
@@ -97,11 +108,19 @@ export class TabsElement extends LitElement implements WithWidget {
   override render() {
     if (!this.adapter.templateData) return html``;
 
-    const activeSections = (this.adapter.templateData.children ?? []).filter(
-      (section: any) =>
-        section.uid === this.activeChildUid ||
-        this.adapter.templateData.renderMode !== 'activeOnly',
-    );
+    // Panels come from the tab list, so a tab and its panel always carry the same uid. A tab whose
+    // child is hidden by a `when` keeps its header and gets no panel.
+    const children = this.adapter.templateData.children ?? [];
+    const panels = (this.adapter.templateData.tabs ?? [])
+      .map((tab) => {
+        const child = children.find((section: any) => section.uid === this.childUid(tab.uid));
+        return { tab, child, isActive: child?.uid === this.activeChildUid };
+      })
+      .filter(
+        ({ child, isActive }) =>
+          child !== undefined &&
+          (isActive || this.adapter.templateData.renderMode !== 'activeOnly'),
+      );
 
     const navClasses = {
       'gui-widget': true,
@@ -112,19 +131,19 @@ export class TabsElement extends LitElement implements WithWidget {
 
     return html`<nav class=${classMap(navClasses)} id=${this.widget.uid}>
         <ul role="tablist">
-          <li role="presentation" id="start-sentinel" class="gui-sentinel"></li>
+          <li role="presentation" class="gui-sentinel gui-sentinel__start"></li>
           ${this.adapter.templateData.tabs
             ? repeat(
                 this.adapter.templateData.tabs,
-                (tab, index) => html`
+                (tab) => html`
                   <li role="presentation">
                     <button
                       type="button"
                       role="tab"
                       tabindex=${tab.uid === this.activeTab ? '0' : '-1'}
-                      data-cy=${`tab_${this.widget.uid}_${index}`}
-                      id=${`tab_${this.widget.uid}_${index}`}
-                      aria-controls=${`tabpanel_${this.widget.uid}_${index}`}
+                      data-cy=${tabButtonId(this.widget.uid, tab.uid)}
+                      id=${tabButtonId(this.widget.uid, tab.uid)}
+                      aria-controls=${tabPanelId(this.widget.uid, tab.uid)}
                       aria-selected=${tab.uid === this.activeTab ? 'true' : 'false'}
                       class=${classMap({ active: tab.uid === this.activeTab })}
                       @click=${() => this.onClickTab(tab.uid)}
@@ -141,23 +160,22 @@ export class TabsElement extends LitElement implements WithWidget {
                 `,
               )
             : nothing}
-          <li role="presentation" id="end-sentinel" class="gui-sentinel gui-sentinel__end"></li>
+          <li role="presentation" class="gui-sentinel gui-sentinel__end"></li>
         </ul>
       </nav>
       ${repeat(
-        activeSections,
-        (section) => section?.uid,
-        (section, index) =>
+        panels,
+        ({ tab }) => tab.uid,
+        ({ tab, child, isActive }) =>
           html`<section
             role="tabpanel"
             tabindex="0"
-            data-cy=${`tabpanel_${this.widget.uid}_${index}`}
-            id=${`tabpanel_${this.widget.uid}_${index}`}
-            ?hidden=${section.uid !== this.activeChildUid &&
-            this.adapter.templateData.renderMode !== 'activeOnly'}
-            aria-labelledby=${`tab_${this.widget.uid}_${index}`}
+            data-cy=${tabPanelId(this.widget.uid, tab.uid)}
+            id=${tabPanelId(this.widget.uid, tab.uid)}
+            ?hidden=${!isActive}
+            aria-labelledby=${tabButtonId(this.widget.uid, tab.uid)}
           >
-            <gui-widget .widget=${section}></gui-widget>
+            <gui-widget .widget=${child}></gui-widget>
           </section>`,
       )}`;
   }

--- a/libs/gui/react/cypress/test/gui-features/accordion.cy.ts
+++ b/libs/gui/react/cypress/test/gui-features/accordion.cy.ts
@@ -1,0 +1,4 @@
+import { runAccordionComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runAccordionComponentTests(mountFramework);

--- a/libs/gui/react/cypress/test/gui-features/tabs.cy.ts
+++ b/libs/gui/react/cypress/test/gui-features/tabs.cy.ts
@@ -1,0 +1,4 @@
+import { runTabsComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runTabsComponentTests(mountFramework);

--- a/libs/gui/react/src/lib/components/Accordion.tsx
+++ b/libs/gui/react/src/lib/components/Accordion.tsx
@@ -1,6 +1,11 @@
 import type { LayoutWidget, NonFunctionWidget, WithWidget } from '@golemui/core';
 import { useLayoutWidget, WidgetRenderer } from '@golemui/react';
-import { type AccordionProps, repeaterIndexSuffix } from '@golemui/gui-shared/internals';
+import {
+  accordionButtonId,
+  accordionSectionId,
+  type AccordionProps,
+  repeaterIndexSuffix,
+} from '@golemui/gui-shared/internals';
 import { useCallback, useEffect, useState } from 'react';
 
 const empty = {};
@@ -42,35 +47,35 @@ export function Accordion(widgetInstance: WithWidget) {
   const rowIndexSuffix = repeaterIndexSuffix(widget.uid);
 
   const renderContent = useCallback(
-    (uid: string) => {
+    (sectionUid: string) => {
       const child = children.find(
-        (section) => section.uid === `${uid}${rowIndexSuffix}`,
+        (section) => section.uid === `${sectionUid}${rowIndexSuffix}`,
       ) as NonFunctionWidget<string>;
-      const isActiveSection = activeSections[uid];
+      const isActiveSection = activeSections[sectionUid];
       return (isActiveSection || templateData.renderMode !== 'activeOnly') && child ? (
         <section
           className="gui-widget"
           role="region"
-          id={`accordion_section_${uid}`}
+          id={accordionSectionId(widget.uid, sectionUid)}
           hidden={!isActiveSection && templateData.renderMode !== 'activeOnly'}
-          aria-labelledby={`accordion_button_${uid}`}
+          aria-labelledby={accordionButtonId(widget.uid, sectionUid)}
         >
           <WidgetRenderer widget={child} />
         </section>
       ) : null;
     },
-    [children, activeSections, templateData.renderMode],
+    [children, activeSections, templateData.renderMode, widget, rowIndexSuffix],
   );
 
   const renderAccordion = useCallback(() => {
     const sections = templateData.sections || [];
-    return sections.map((section, index) => (
-      <div className="gui-accordion__section" key={`${'accordion_section_' + section.uid}`}>
+    return sections.map((section) => (
+      <div className="gui-accordion__section" key={accordionSectionId(widget.uid, section.uid)}>
         <button
           type="button"
           tabIndex={0}
-          id={`accordion_button_${section.uid}`}
-          aria-controls={`accordion_section_${section.uid}`}
+          id={accordionButtonId(widget.uid, section.uid)}
+          aria-controls={accordionSectionId(widget.uid, section.uid)}
           aria-expanded={activeSections[section.uid] ? 'true' : 'false'}
           className={activeSections[section.uid] ? 'active' : ''}
           onClick={() => onClickButton(section.uid)}
@@ -86,7 +91,7 @@ export function Accordion(widgetInstance: WithWidget) {
         {renderContent(section.uid)}
       </div>
     ));
-  }, [templateData.sections, activeSections, renderContent, onClickButton]);
+  }, [templateData.sections, activeSections, renderContent, onClickButton, widget]);
 
   return (
     <div className="gui-accordion gui-field" style={{ flex: templateData.size }}>

--- a/libs/gui/react/src/lib/components/Tabs.tsx
+++ b/libs/gui/react/src/lib/components/Tabs.tsx
@@ -1,7 +1,12 @@
 import type { LayoutWidget, NonFunctionWidget, WithWidget } from '@golemui/core';
 import { cn, useLayoutWidget, WidgetRenderer } from '@golemui/react';
 import { createIntersectionObserver } from '@golemui/gui-components/internals';
-import { repeaterIndexSuffix, type TabsProps } from '@golemui/gui-shared/internals';
+import {
+  repeaterIndexSuffix,
+  tabButtonId,
+  tabPanelId,
+  type TabsProps,
+} from '@golemui/gui-shared/internals';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 export function Tabs(widgetInstance: WithWidget) {
@@ -110,7 +115,7 @@ export function Tabs(widgetInstance: WithWidget) {
     const tabs = templateData.tabs || [];
     return tabs.map((tab, index) => {
       return (
-        <li role="presentation" key={`tab_${widget.uid}_${tab.uid}`}>
+        <li role="presentation" key={tabButtonId(widget.uid, tab.uid)}>
           <button
             ref={(el) => {
               tabRefs.current[index] = el!;
@@ -118,9 +123,9 @@ export function Tabs(widgetInstance: WithWidget) {
             type="button"
             role="tab"
             tabIndex={tab.uid === activeTab ? 0 : -1}
-            data-cy={`tab_${widget.uid}_${index}`}
-            id={`tab_${widget.uid}_${index}`}
-            aria-controls={`tabpanel_${widget.uid}_${index}`}
+            data-cy={tabButtonId(widget.uid, tab.uid)}
+            id={tabButtonId(widget.uid, tab.uid)}
+            aria-controls={tabPanelId(widget.uid, tab.uid)}
             aria-selected={tab.uid === activeTab ? 'true' : 'false'}
             className={`${tab.uid === activeTab ? 'active' : ''}`}
             onClick={() => handleTabChange(tab.uid)}
@@ -136,25 +141,34 @@ export function Tabs(widgetInstance: WithWidget) {
     });
   }, [templateData, activeTab, widget, tabRefs, handleTabChange, onKeyDown]);
 
+  // Panels are built from the tab list, not from the children, so a tab and its panel always
+  // carry the same uid. A tab whose child is hidden by a `when` keeps its header and gets no panel.
   const renderWidgets = useCallback(() => {
-    const activeSectionIndex = children.findIndex((section: any) => section.uid === activeChildUid);
+    const tabs = templateData.tabs || [];
 
-    return children
-      .filter((widget) => widget.uid === activeChildUid || templateData.renderMode !== 'activeOnly')
-      .map((section) => (
+    return tabs.map((tab) => {
+      const child = children.find((section) => section.uid === `${tab.uid}${rowIndexSuffix}`);
+      const isActive = child?.uid === activeChildUid;
+
+      if (!child || (!isActive && templateData.renderMode === 'activeOnly')) {
+        return null;
+      }
+
+      return (
         <section
-          key={`tabpanel_${widget.uid}_${section.uid}`}
+          key={tabPanelId(widget.uid, tab.uid)}
           role="tabpanel"
           tabIndex={0}
-          data-cy={`tabpanel_${widget.uid}_${activeSectionIndex}`}
-          id={`tabpanel_${widget.uid}_${activeSectionIndex}`}
-          hidden={section.uid !== activeChildUid && templateData.renderMode !== 'activeOnly'}
-          aria-labelledby={`tab_${widget.uid}_${activeSectionIndex}`}
+          data-cy={tabPanelId(widget.uid, tab.uid)}
+          id={tabPanelId(widget.uid, tab.uid)}
+          hidden={!isActive}
+          aria-labelledby={tabButtonId(widget.uid, tab.uid)}
         >
-          <WidgetRenderer key={section.uid} widget={section as NonFunctionWidget<string>} />
+          <WidgetRenderer key={child.uid} widget={child as NonFunctionWidget<string>} />
         </section>
-      ));
-  }, [children, activeChildUid, widget]);
+      );
+    });
+  }, [children, activeChildUid, widget, templateData, rowIndexSuffix]);
 
   return (
     <div className="gui-tabs gui-field" style={{ flex: templateData.size }}>

--- a/libs/gui/shared/src/internals.ts
+++ b/libs/gui/shared/src/internals.ts
@@ -346,4 +346,10 @@ export { golemForm } from './lib/golem-form';
 // ─── Utils ───
 
 export { isOption } from './lib/utils/one-of';
+export {
+  accordionButtonId,
+  accordionSectionId,
+  tabButtonId,
+  tabPanelId,
+} from './lib/utils/layout-ids';
 export { getItemKey, repeaterIndexSuffix } from './lib/utils/repeater';

--- a/libs/gui/shared/src/lib/utils/layout-ids.spec.ts
+++ b/libs/gui/shared/src/lib/utils/layout-ids.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { accordionButtonId, accordionSectionId, tabButtonId, tabPanelId } from './layout-ids';
+
+describe('layout ids', () => {
+  it('builds a tab button id from the layout uid and the tab uid', () => {
+    expect(tabButtonId('settingsTabs', 'firstPanel')).toBe('tab_settingsTabs_firstPanel');
+  });
+
+  it('builds a tab panel id from the layout uid and the tab uid', () => {
+    expect(tabPanelId('settingsTabs', 'firstPanel')).toBe('tabpanel_settingsTabs_firstPanel');
+  });
+
+  it('builds an accordion button id from the layout uid and the section uid', () => {
+    expect(accordionButtonId('settings', 'firstSection')).toBe(
+      'accordion_button_settings_firstSection',
+    );
+  });
+
+  it('builds an accordion section id from the layout uid and the section uid', () => {
+    expect(accordionSectionId('settings', 'firstSection')).toBe(
+      'accordion_section_settings_firstSection',
+    );
+  });
+
+  it('keeps the row index of a layout inside a repeater, so two rows differ', () => {
+    expect(tabPanelId('rowTabs[0]', 'firstPanel')).not.toBe(tabPanelId('rowTabs[1]', 'firstPanel'));
+    expect(accordionButtonId('rowAccordion[1]', 'secondSection')).toBe(
+      'accordion_button_rowAccordion[1]_secondSection',
+    );
+  });
+});

--- a/libs/gui/shared/src/lib/utils/layout-ids.ts
+++ b/libs/gui/shared/src/lib/utils/layout-ids.ts
@@ -1,0 +1,56 @@
+/**
+ * @internal Used by framework layout components, not part of the end-user public API.
+ *
+ * DOM ids for the tabs and accordion layouts. They are built from the layout widget's own uid
+ * plus the tab or section uid, never from a position, so two repeater rows of the same layout
+ * produce different ids: the layout uid already carries the row index suffix.
+ */
+
+/**
+ * The id of a tab button, also its `data-cy`.
+ *
+ * @param layoutUid - The tabs layout widget's uid, row index suffix included.
+ * @param tabUid - The tab uid from the layout props.
+ * @example
+ * tabButtonId('rowTabs[1]', 'secondPanel'); // 'tab_rowTabs[1]_secondPanel'
+ */
+export function tabButtonId(layoutUid: string, tabUid: string): string {
+  return `tab_${layoutUid}_${tabUid}`;
+}
+
+/**
+ * The id of a tab panel, also its `data-cy`. The tab button's `aria-controls` and the panel's
+ * `aria-labelledby` are the other side of the same pair.
+ *
+ * @param layoutUid - The tabs layout widget's uid, row index suffix included.
+ * @param tabUid - The tab uid from the layout props.
+ * @example
+ * tabPanelId('rowTabs[1]', 'secondPanel'); // 'tabpanel_rowTabs[1]_secondPanel'
+ */
+export function tabPanelId(layoutUid: string, tabUid: string): string {
+  return `tabpanel_${layoutUid}_${tabUid}`;
+}
+
+/**
+ * The id of an accordion header button.
+ *
+ * @param layoutUid - The accordion layout widget's uid, row index suffix included.
+ * @param sectionUid - The section uid from the layout props.
+ * @example
+ * accordionButtonId('rowAccordion[1]', 'secondSection'); // 'accordion_button_rowAccordion[1]_secondSection'
+ */
+export function accordionButtonId(layoutUid: string, sectionUid: string): string {
+  return `accordion_button_${layoutUid}_${sectionUid}`;
+}
+
+/**
+ * The id of an accordion section region.
+ *
+ * @param layoutUid - The accordion layout widget's uid, row index suffix included.
+ * @param sectionUid - The section uid from the layout props.
+ * @example
+ * accordionSectionId('rowAccordion[1]', 'secondSection'); // 'accordion_section_rowAccordion[1]_secondSection'
+ */
+export function accordionSectionId(layoutUid: string, sectionUid: string): string {
+  return `accordion_section_${layoutUid}_${sectionUid}`;
+}

--- a/libs/gui/vue/cypress/test/gui-features/accordion.cy.ts
+++ b/libs/gui/vue/cypress/test/gui-features/accordion.cy.ts
@@ -1,0 +1,4 @@
+import { runAccordionComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runAccordionComponentTests(mountFramework);

--- a/libs/gui/vue/cypress/test/gui-features/tabs.cy.ts
+++ b/libs/gui/vue/cypress/test/gui-features/tabs.cy.ts
@@ -1,0 +1,4 @@
+import { runTabsComponentTests } from '@golemui/ui-testing';
+import { mountFramework } from '../../support/mount';
+
+runTabsComponentTests(mountFramework);

--- a/libs/gui/vue/src/lib/components/Accordion.vue
+++ b/libs/gui/vue/src/lib/components/Accordion.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import type { LayoutWidget, NonFunctionWidget, WithWidget } from '@golemui/core';
 import { useLayoutWidget, WidgetRenderer } from '@golemui/vue';
-import { type AccordionProps, repeaterIndexSuffix } from '@golemui/gui-shared/internals';
+import {
+  accordionButtonId,
+  accordionSectionId,
+  type AccordionProps,
+  repeaterIndexSuffix,
+} from '@golemui/gui-shared/internals';
 import { computed, ref, watch } from 'vue';
 
 const props = defineProps<WithWidget>();
@@ -61,14 +66,14 @@ const sections = computed(() => templateData.value.sections || []);
     <div class="gui-widget" :id="uid">
       <div
         v-for="section in sections"
-        :key="`accordion_section_${section.uid}`"
+        :key="accordionSectionId(widget.uid, section.uid)"
         class="gui-accordion__section"
       >
         <button
           type="button"
           tabindex="0"
-          :id="`accordion_button_${section.uid}`"
-          :aria-controls="`accordion_section_${section.uid}`"
+          :id="accordionButtonId(widget.uid, section.uid)"
+          :aria-controls="accordionSectionId(widget.uid, section.uid)"
           :aria-expanded="isActive(section.uid) ? 'true' : 'false'"
           :class="isActive(section.uid) ? 'active' : ''"
           @click="onClickButton(section.uid)"
@@ -86,9 +91,9 @@ const sections = computed(() => templateData.value.sections || []);
           v-if="shouldRenderContent(section.uid) && sectionForUid(section.uid)"
           class="gui-widget"
           role="region"
-          :id="`accordion_section_${section.uid}`"
+          :id="accordionSectionId(widget.uid, section.uid)"
           :hidden="!isActive(section.uid) && templateData.renderMode !== 'activeOnly'"
-          :aria-labelledby="`accordion_button_${section.uid}`"
+          :aria-labelledby="accordionButtonId(widget.uid, section.uid)"
         >
           <WidgetRenderer :widget="sectionForUid(section.uid)!" />
         </section>

--- a/libs/gui/vue/src/lib/components/Tabs.vue
+++ b/libs/gui/vue/src/lib/components/Tabs.vue
@@ -2,7 +2,12 @@
 import type { LayoutWidget, NonFunctionWidget, WithWidget } from '@golemui/core';
 import { useLayoutWidget, WidgetRenderer } from '@golemui/vue';
 import { createIntersectionObserver } from '@golemui/gui-components/internals';
-import { repeaterIndexSuffix, type TabsProps } from '@golemui/gui-shared/internals';
+import {
+  repeaterIndexSuffix,
+  tabButtonId,
+  tabPanelId,
+  type TabsProps,
+} from '@golemui/gui-shared/internals';
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 
 const props = defineProps<WithWidget>();
@@ -105,11 +110,20 @@ const setTabRef = (idx: number) => (el: any) => {
   if (el) tabRefs.value[idx] = el as HTMLButtonElement;
 };
 
-const visibleSections = computed(() => {
+// Panels are built from the tab list, not from the children, so a tab and its panel always carry
+// the same uid. A tab whose child is hidden by a `when` keeps its header and gets no panel.
+const visiblePanels = computed(() => {
   const renderMode = templateData.value.renderMode;
-  return (children.value as NonFunctionWidget<string>[]).filter(
-    (section) => section.uid === activeChildUid.value || renderMode !== 'activeOnly',
-  );
+  const sections = children.value as NonFunctionWidget<string>[];
+
+  return (templateData.value.tabs || [])
+    .map((tab) => {
+      const child = sections.find((section) => section.uid === `${tab.uid}${rowIndexSuffix}`);
+      return { tab, child, isActive: child?.uid === activeChildUid.value };
+    })
+    .filter(
+      ({ child, isActive }) => child !== undefined && (isActive || renderMode !== 'activeOnly'),
+    );
 });
 </script>
 
@@ -132,7 +146,7 @@ const visibleSections = computed(() => {
         ></li>
         <li
           v-for="(tab, index) in templateData.tabs"
-          :key="`tab_${widget.uid}_${tab.uid}`"
+          :key="tabButtonId(widget.uid, tab.uid)"
           role="presentation"
         >
           <button
@@ -140,9 +154,9 @@ const visibleSections = computed(() => {
             type="button"
             role="tab"
             :tabindex="tab.uid === activeTab ? 0 : -1"
-            :data-cy="`tab_${widget.uid}_${index}`"
-            :id="`tab_${widget.uid}_${index}`"
-            :aria-controls="`tabpanel_${widget.uid}_${index}`"
+            :data-cy="tabButtonId(widget.uid, tab.uid)"
+            :id="tabButtonId(widget.uid, tab.uid)"
+            :aria-controls="tabPanelId(widget.uid, tab.uid)"
             :aria-selected="tab.uid === activeTab ? 'true' : 'false'"
             :class="tab.uid === activeTab ? 'active' : ''"
             @click="handleTabChange(tab.uid)"
@@ -159,16 +173,16 @@ const visibleSections = computed(() => {
       </ul>
     </nav>
     <section
-      v-for="(section, idx) in visibleSections"
-      :key="`tabpanel_${widget.uid}_${section.uid}`"
+      v-for="panel in visiblePanels"
+      :key="tabPanelId(widget.uid, panel.tab.uid)"
       role="tabpanel"
       tabindex="0"
-      :data-cy="`tabpanel_${widget.uid}_${idx}`"
-      :id="`tabpanel_${widget.uid}_${idx}`"
-      :hidden="section.uid !== activeChildUid && templateData.renderMode !== 'activeOnly'"
-      :aria-labelledby="`tab_${widget.uid}_${idx}`"
+      :data-cy="tabPanelId(widget.uid, panel.tab.uid)"
+      :id="tabPanelId(widget.uid, panel.tab.uid)"
+      :hidden="!panel.isActive"
+      :aria-labelledby="tabButtonId(widget.uid, panel.tab.uid)"
     >
-      <WidgetRenderer :widget="section" />
+      <WidgetRenderer :widget="panel.child!" />
     </section>
   </div>
 </template>

--- a/libs/ui-testing/src/index.ts
+++ b/libs/ui-testing/src/index.ts
@@ -22,6 +22,7 @@ export * from './lib/core-features/validator-injection.cy';
 export * from './lib/core-features/widget-loaders.cy';
 
 // gui widget suites
+export * from './lib/gui-features/accordion.cy';
 export * from './lib/gui-features/alert.cy';
 export * from './lib/gui-features/currency.cy';
 export * from './lib/gui-features/dateinput.cy';
@@ -44,6 +45,7 @@ export * from './lib/gui-features/rangedatepicker.cy';
 export * from './lib/gui-features/rangetimepicker.cy';
 export * from './lib/gui-features/repeater.cy';
 export * from './lib/gui-features/select.cy';
+export * from './lib/gui-features/tabs.cy';
 export * from './lib/gui-features/tags.cy';
 export * from './lib/gui-features/timeinput.cy';
 export * from './lib/gui-features/datetimecalendar.cy';

--- a/libs/ui-testing/src/lib/core-features/events.cy.ts
+++ b/libs/ui-testing/src/lib/core-features/events.cy.ts
@@ -232,19 +232,19 @@ export const runEventsComponentTests = (mountFn: MountComponentFn) => {
         formEvent: formEventHandler,
       });
 
-      cy.get('[data-cy="tab_tabsComponent_1"]').click();
+      cy.get('[data-cy="tab_tabsComponent_tab2"]').click();
       cy.get('@formEventHandler').should('have.been.calledWithMatch', {
         name: 'onTabEvent',
         detail: 'tab2',
       });
-      cy.get('[data-cy="tabpanel_tabsComponent_1"]').should('have.attr', 'tabindex', '0');
+      cy.get('[data-cy="tabpanel_tabsComponent_tab2"]').should('have.attr', 'tabindex', '0');
 
-      cy.get('[data-cy="tab_tabsComponent_0"]').click();
+      cy.get('[data-cy="tab_tabsComponent_tab1"]').click();
       cy.get('@formEventHandler').should('have.been.calledWithMatch', {
         name: 'onTabEvent',
         detail: 'tab1',
       });
-      cy.get('[data-cy="tabpanel_tabsComponent_0"]').should('have.attr', 'tabindex', '0');
+      cy.get('[data-cy="tabpanel_tabsComponent_tab1"]').should('have.attr', 'tabindex', '0');
     });
 
     it('Should execute form events on click', () => {

--- a/libs/ui-testing/src/lib/gui-features/accordion.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/accordion.cy.ts
@@ -1,0 +1,77 @@
+import { defineForm } from '@golemui/core';
+import { expectNoDuplicateIds, type MountComponentFn } from '../utils';
+
+export const runAccordionComponentTests = (mountFn: MountComponentFn) => {
+  describe('Accordion Component', () => {
+    const ACCORDION_UID = 'settingsAccordion';
+
+    beforeEach(() => {
+      mountFn({
+        formDef: defineForm({
+          form: [
+            {
+              uid: ACCORDION_UID,
+              kind: 'layout',
+              type: 'accordion',
+              props: {
+                defaultOpen: { firstSection: true },
+                sections: [
+                  { uid: 'firstSection', label: 'First' },
+                  { uid: 'secondSection', label: 'Second' },
+                ],
+              },
+              children: [
+                {
+                  uid: 'firstSection',
+                  kind: 'input',
+                  type: 'textinput',
+                  path: 'accordion.first',
+                  label: 'First',
+                },
+                {
+                  uid: 'secondSection',
+                  kind: 'input',
+                  type: 'textinput',
+                  path: 'accordion.second',
+                  label: 'Second',
+                },
+              ],
+            },
+          ],
+        }),
+      });
+    });
+
+    it('gives every button and region an id built from the accordion uid', () => {
+      ['firstSection', 'secondSection'].forEach((sectionUid) => {
+        cy.get(`[id="accordion_button_${ACCORDION_UID}_${sectionUid}"]`).should(
+          'have.attr',
+          'aria-controls',
+          `accordion_section_${ACCORDION_UID}_${sectionUid}`,
+        );
+        cy.get(`[id="accordion_section_${ACCORDION_UID}_${sectionUid}"]`).should(
+          'have.attr',
+          'aria-labelledby',
+          `accordion_button_${ACCORDION_UID}_${sectionUid}`,
+        );
+      });
+
+      expectNoDuplicateIds();
+    });
+
+    it('toggles the section the clicked button controls', () => {
+      cy.get(`[id="accordion_section_${ACCORDION_UID}_secondSection"]`).should(
+        'have.attr',
+        'hidden',
+      );
+      cy.get(`[id="accordion_button_${ACCORDION_UID}_secondSection"]`)
+        .should('have.attr', 'aria-expanded', 'false')
+        .click();
+      cy.get(`[id="accordion_section_${ACCORDION_UID}_secondSection"]`).should(
+        'not.have.attr',
+        'hidden',
+      );
+      cy.get('[data-cy="secondSection_textinput"]').should('be.visible');
+    });
+  });
+};

--- a/libs/ui-testing/src/lib/gui-features/repeater.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/repeater.cy.ts
@@ -1,5 +1,5 @@
 import { defineForm, identityTranslator } from '@golemui/core';
-import { type MountComponentFn } from '../utils';
+import { expectNoDuplicateIds, type MountComponentFn } from '../utils';
 
 export const runRepeaterComponentTests = (mountFn: MountComponentFn) => {
   describe('Repeater Component', () => {
@@ -863,9 +863,22 @@ export const runRepeaterComponentTests = (mountFn: MountComponentFn) => {
         cy.get('[data-cy="secondPanel[0]_textinput"]').should('not.exist');
 
         // Switching a tab in the second row opens that row's panel only
-        cy.get('[data-cy="tab_rowTabs[1]_1"]').click();
+        cy.get('[data-cy="tab_rowTabs[1]_secondPanel"]').click();
         cy.get('[data-cy="secondPanel[1]_textinput"]').should('have.value', 'Bea');
         cy.get('[data-cy="secondPanel[0]_textinput"]').should('not.exist');
+
+        // Each row's tabs address their own panel, the layout uid carries the row index
+        cy.get('[data-cy="tab_rowTabs[0]_firstPanel"]').should(
+          'have.attr',
+          'aria-controls',
+          'tabpanel_rowTabs[0]_firstPanel',
+        );
+        cy.get('[data-cy="tab_rowTabs[1]_secondPanel"]').should(
+          'have.attr',
+          'aria-controls',
+          'tabpanel_rowTabs[1]_secondPanel',
+        );
+        expectNoDuplicateIds();
       });
 
       it('renders the open section of an accordion in every repeater row', () => {
@@ -922,10 +935,23 @@ export const runRepeaterComponentTests = (mountFn: MountComponentFn) => {
         cy.get('[data-cy="firstSection[1]_textinput"]').should('have.value', 'Bob');
         cy.get('[data-cy="secondSection[1]_textinput"]').should('not.exist');
 
-        // The section buttons carry the template uid, so pick the one of the second row
-        cy.get('[id="accordion_button_secondSection"]').eq(1).click();
+        // The section buttons carry the layout uid with its row index, so address the second row
+        cy.get('[id="accordion_button_rowAccordion[1]_secondSection"]').click();
         cy.get('[data-cy="secondSection[1]_textinput"]').should('have.value', 'Bea');
         cy.get('[data-cy="secondSection[0]_textinput"]').should('not.exist');
+
+        // Each row's button controls its own region
+        cy.get('[id="accordion_button_rowAccordion[0]_firstSection"]').should(
+          'have.attr',
+          'aria-controls',
+          'accordion_section_rowAccordion[0]_firstSection',
+        );
+        cy.get('[id="accordion_button_rowAccordion[1]_secondSection"]').should(
+          'have.attr',
+          'aria-controls',
+          'accordion_section_rowAccordion[1]_secondSection',
+        );
+        expectNoDuplicateIds();
       });
 
       it('a hidden section child renders no section', () => {
@@ -987,8 +1013,10 @@ export const runRepeaterComponentTests = (mountFn: MountComponentFn) => {
         cy.get('[data-cy="secondSection[1]_textinput"]').should('not.exist');
 
         // The header button still renders in both rows, the region only where the child exists
-        cy.get('[id="accordion_button_secondSection"]').should('have.length', 2);
-        cy.get('[id="accordion_section_secondSection"]').should('have.length', 1);
+        cy.get('[id="accordion_button_rowAccordion[0]_secondSection"]').should('exist');
+        cy.get('[id="accordion_button_rowAccordion[1]_secondSection"]').should('exist');
+        cy.get('[id="accordion_section_rowAccordion[0]_secondSection"]').should('exist');
+        cy.get('[id="accordion_section_rowAccordion[1]_secondSection"]').should('not.exist');
       });
     });
   });

--- a/libs/ui-testing/src/lib/gui-features/tabs.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/tabs.cy.ts
@@ -1,0 +1,109 @@
+import { defineForm } from '@golemui/core';
+import { expectNoDuplicateIds, type MountComponentFn } from '../utils';
+
+export const runTabsComponentTests = (mountFn: MountComponentFn) => {
+  describe('Tabs Component', () => {
+    const TABS_UID = 'settingsTabs';
+
+    const getFormDefinition = (
+      props: Record<string, unknown> = {},
+      thirdPanelInclude?: { when: string },
+    ) =>
+      defineForm({
+        form: [
+          {
+            uid: TABS_UID,
+            kind: 'layout',
+            type: 'tabs',
+            props: {
+              tabs: [
+                { uid: 'firstPanel', label: 'First' },
+                { uid: 'secondPanel', label: 'Second' },
+                { uid: 'thirdPanel', label: 'Third' },
+              ],
+              ...props,
+            },
+            children: [
+              {
+                uid: 'firstPanel',
+                kind: 'input',
+                type: 'textinput',
+                path: 'tabs.first',
+                label: 'First',
+              },
+              {
+                uid: 'secondPanel',
+                kind: 'input',
+                type: 'textinput',
+                path: 'tabs.second',
+                label: 'Second',
+              },
+              {
+                uid: 'thirdPanel',
+                kind: 'input',
+                type: 'textinput',
+                path: 'tabs.third',
+                label: 'Third',
+                ...(thirdPanelInclude ? { include: thirdPanelInclude } : {}),
+              },
+            ],
+          },
+        ],
+      });
+
+    it('gives every tab and panel an id built from the tab uid', () => {
+      mountFn({ formDef: getFormDefinition() });
+
+      ['firstPanel', 'secondPanel', 'thirdPanel'].forEach((tabUid) => {
+        cy.get(`[data-cy="tab_${TABS_UID}_${tabUid}"]`).should(
+          'have.attr',
+          'aria-controls',
+          `tabpanel_${TABS_UID}_${tabUid}`,
+        );
+        cy.get(`[data-cy="tabpanel_${TABS_UID}_${tabUid}"]`)
+          .should('have.attr', 'id', `tabpanel_${TABS_UID}_${tabUid}`)
+          .and('have.attr', 'aria-labelledby', `tab_${TABS_UID}_${tabUid}`);
+      });
+
+      expectNoDuplicateIds();
+    });
+
+    it('points the active tab at the only panel rendered in activeOnly mode', () => {
+      mountFn({
+        formDef: getFormDefinition({ renderMode: 'activeOnly', defaultOpen: 'secondPanel' }),
+      });
+
+      // The single rendered panel is the second one, so both sides of the pair carry its tab uid
+      cy.get('section[role="tabpanel"]').should('have.length', 1);
+      cy.get(`[data-cy="tab_${TABS_UID}_secondPanel"]`)
+        .should('have.attr', 'aria-selected', 'true')
+        .and('have.attr', 'aria-controls', `tabpanel_${TABS_UID}_secondPanel`);
+      cy.get('section[role="tabpanel"]')
+        .should('have.attr', 'id', `tabpanel_${TABS_UID}_secondPanel`)
+        .and('have.attr', 'aria-labelledby', `tab_${TABS_UID}_secondPanel`);
+    });
+
+    it('keeps the remaining panels wired to their own tab when a child is hidden', () => {
+      mountFn({
+        data: { tabs: { first: 'Alice' } },
+        formDef: getFormDefinition({}, { when: '$form.tabs.first === "Bob"' }),
+      });
+
+      // The third tab's child is hidden, so its header stays and its panel is gone
+      cy.get(`[data-cy="tab_${TABS_UID}_thirdPanel"]`).should('exist');
+      cy.get(`[data-cy="tabpanel_${TABS_UID}_thirdPanel"]`).should('not.exist');
+
+      // The tabs that are left still address their own panel and not a neighbour's
+      cy.get(`[data-cy="tabpanel_${TABS_UID}_secondPanel"]`).should(
+        'have.attr',
+        'aria-labelledby',
+        `tab_${TABS_UID}_secondPanel`,
+      );
+      cy.get(`[data-cy="tabpanel_${TABS_UID}_firstPanel"]`).should(
+        'have.attr',
+        'aria-labelledby',
+        `tab_${TABS_UID}_firstPanel`,
+      );
+    });
+  });
+};

--- a/libs/ui-testing/src/lib/utils.ts
+++ b/libs/ui-testing/src/lib/utils.ts
@@ -48,6 +48,30 @@ export type MountComponentFn<StateKeys extends UiState = string> = (
 
 const PILLS_WIDTH_STYLE_ID = 'ui-testing-pills-width-override';
 
+/**
+ * Fails when an id appears more than once in the document, which also breaks every `aria-controls`
+ * and `aria-labelledby` that names it. The style element this file injects is excluded.
+ */
+export const expectNoDuplicateIds = () => {
+  cy.document().then((doc) => {
+    const seen = new Set<string>();
+    const duplicates = new Set<string>();
+
+    doc.querySelectorAll('[id]').forEach((element) => {
+      const id = element.id;
+      if (!id || id === PILLS_WIDTH_STYLE_ID) {
+        return;
+      }
+      if (seen.has(id)) {
+        duplicates.add(id);
+      }
+      seen.add(id);
+    });
+
+    expect(Array.from(duplicates), 'duplicate DOM ids').to.deep.equal([]);
+  });
+};
+
 const setPillsWidth = (wrapperSelector: string, width: string) => {
   cy.document().then((doc) => {
     let style = doc.getElementById(PILLS_WIDTH_STYLE_ID);


### PR DESCRIPTION
## Description

The tabs and accordion layouts produced broken DOM ids in two situations.

- The accordion built its ids from the section uid alone. Two instances of the same layout, for example one per repeater row, rendered the same ids twice. `aria-controls` and `aria-labelledby` then resolved to whichever element came first in the document, usually one from another row.
- The tabs built its ids from the render position, and the panels were rendered from the visible children. When a `when` condition hides a child, the panel positions shift relative to the tab positions and the aria pairs point at the wrong elements. The React implementation also wrote the active panel's position into every panel's id, which duplicated ids inside a single instance.

Every id is now built from the layout widget uid plus the tab or section uid through four shared builders (`tabButtonId`, `tabPanelId`, `accordionButtonId`, `accordionSectionId`) used by all four frameworks. The layout uid already has the repeater row index, so repeated rows produce distinct ids. The `data-cy` attributes follow the same scheme, so test
selectors no longer move when a child is hidden.

Tab panels are now rendered from the tab list instead of the children list, so a tab and its panel always has the same uid. A tab whose child is hidden keeps its header and gets no panel.

The Lit tabs element also gave its two scroll sentinels fixed ids. It renders into the light DOM, so those ids repeated across instances. The sentinels are now queried by class.