### PR TITLE
fix(core): copy a function widget result before writing uid and path

### DIFF
--- a/libs/core/src/lib/store/reducer.spec.ts
+++ b/libs/core/src/lib/store/reducer.spec.ts
@@ -337,6 +337,41 @@ const makeRowFunctionFormDef = () => ({
   ],
 });
 
+/**
+ * A repeater whose row function widget returns ONE cached object for every row, which is what a
+ * memoizing widget author writes.
+ */
+const makeCachedRowWidgetFormDef = () => {
+  const cached = {
+    uid: 'cachedRow',
+    kind: 'input',
+    type: 'textinput',
+    path: 'users.items.name',
+    props: { label: 'Name' },
+  } as unknown as InputWidget<any, string>;
+  const rowName: FunctionWidget<string> = () => cached;
+  rowName.uid = 'rowName';
+  const formDef = {
+    form: [
+      {
+        uid: 'users',
+        kind: 'input',
+        type: 'repeater',
+        path: 'users',
+        props: {
+          template: {
+            uid: 'usersRow',
+            kind: 'layout',
+            type: 'flex',
+            children: [rowName],
+          },
+        },
+      },
+    ],
+  };
+  return { cached, formDef };
+};
+
 /** A function widget at the top level and another inside a repeater row, both required. */
 const makeFunctionWidgetsFormDef = () => ({
   form: [
@@ -2419,6 +2454,29 @@ describe('reducer end-to-end', () => {
       expect(healed.formHealth).toEqual({ status: 'ok' });
       expect(healed.calculatedWidgets['greeting[0]']).toBeUndefined();
       expect(propsOf(healed, 'title')['text']).toBe('Users');
+    });
+  });
+  // ---------------------------------------------------------------------------
+  // 25. A function widget that returns a cached object
+  // ---------------------------------------------------------------------------
+
+  // The store writes `uid` and `path` into the widget a function returns. Writing them into the
+  // returned object itself corrupts a cached object: two rows overwrite each other, and the
+  // object the user owns is modified.
+  describe('a function widget that returns a cached object', () => {
+    it('gives each row its own uid and path and does not modify the cached object', () => {
+      const { cached, formDef } = makeCachedRowWidgetFormDef();
+
+      const state = drive([init(formDef), setData({ users: [{ name: 'Ada' }, { name: 'Bob' }] })]);
+
+      const first = state.calculatedWidgets['rowName[0]'].current as InputWidget<any, string>;
+      const second = state.calculatedWidgets['rowName[1]'].current as InputWidget<any, string>;
+      expect(first.uid).toBe('rowName[0]');
+      expect(first.path).toBe('users.0.name');
+      expect(second.uid).toBe('rowName[1]');
+      expect(second.path).toBe('users.1.name');
+      expect(cached.uid).toBe('cachedRow');
+      expect(cached.path).toBe('users.items.name');
     });
   });
 });

--- a/libs/core/src/lib/store/reducers/calculate-widget-flags.spec.ts
+++ b/libs/core/src/lib/store/reducers/calculate-widget-flags.spec.ts
@@ -173,6 +173,29 @@ describe('calculateWidgetFlags: $item / $index in item when conditions', () => {
   });
 });
 
+describe('calculateWidgetFlags: function widget results', () => {
+  let state: State;
+
+  beforeEach(() => {
+    state = createInitialState('en-US');
+  });
+
+  it('does not write uid into an object the function returns from a cache', () => {
+    // A memoized function returns the same object on every call. The uid write then modifies
+    // an object the user owns.
+    const cached = displayChild('cached-note', { include: { when: '$form.show === true' } });
+    const note: FunctionWidget<string> = () => cached as never;
+    note.uid = 'note' as never;
+    state.flatForm = { note: note as unknown as FormWidget<string> };
+    state.data = { show: true };
+
+    const next = runFlagsPipeline(state);
+
+    expect(cached.uid).toBe('cached-note');
+    expect(next.widgetFlags['note'].hidden).toBe(false);
+  });
+});
+
 describe('calculateWidgetFlags: $fn in when conditions', () => {
   let state: State;
 

--- a/libs/core/src/lib/store/reducers/calculate-widget-flags.ts
+++ b/libs/core/src/lib/store/reducers/calculate-widget-flags.ts
@@ -209,14 +209,18 @@ function resolveForFlags(
   const itemScope = state.repeaterItemScopes[uid];
   let widget: NonFunctionWidget<string>;
   if (isFunctionWidget(source)) {
-    widget = source({
-      $form: state.data,
-      $item: itemScope ? get(state.data, itemScope.itemPath) : undefined,
-      $index: itemScope?.index,
-      errors: undefined,
-      touched: undefined,
-      translate: undefined,
-    });
+    // The function may return a cached object. Copy it before writing the uid,
+    // so the write never reaches the object the function owns.
+    widget = {
+      ...source({
+        $form: state.data,
+        $item: itemScope ? get(state.data, itemScope.itemPath) : undefined,
+        $index: itemScope?.index,
+        errors: undefined,
+        touched: undefined,
+        translate: undefined,
+      }),
+    };
     widget.uid = uid;
   } else {
     widget = source;

--- a/libs/core/src/lib/store/reducers/calculate-widget-props.spec.ts
+++ b/libs/core/src/lib/store/reducers/calculate-widget-props.spec.ts
@@ -768,6 +768,55 @@ describe('calculateWidgetProps', () => {
       expect(second.calculatedWidgets['name[1]']).toBe(first.calculatedWidgets['name[1]']);
     });
 
+    it('does not write uid or path into an object the function returns from a cache', () => {
+      // A memoized function returns the same object for every row. The uid and path writes then
+      // modify an object the user owns, and two rows overwrite each other.
+      const cached = {
+        kind: 'input',
+        uid: 'cached',
+        type: 'textinput',
+        path: 'users.items.name',
+      } as InputWidget<unknown, string>;
+      const makeSource = (uid: string, path: string): FunctionWidget<string> =>
+        Object.assign(() => cached, { uid, type: 'textinput', path });
+      seed(state, 'name[0]', makeSource('name[0]', 'users.0.name'));
+      seed(state, 'name[1]', makeSource('name[1]', 'users.1.name'));
+
+      const next = run(state);
+
+      expect(cached.uid).toBe('cached');
+      expect(cached.path).toBe('users.items.name');
+      const first = next.calculatedWidgets['name[0]'].current as InputWidget<unknown, string>;
+      const second = next.calculatedWidgets['name[1]'].current as InputWidget<unknown, string>;
+      expect(first.uid).toBe('name[0]');
+      expect(first.path).toBe('users.0.name');
+      expect(second.uid).toBe('name[1]');
+      expect(second.path).toBe('users.1.name');
+    });
+
+    it('detects a prop change on an object the function returns from a cache', () => {
+      const cached = {
+        kind: 'display',
+        uid: 'cached',
+        type: 'heading',
+        props: { text: 'first' },
+      } as unknown as DisplayWidget<string>;
+      const source: FunctionWidget<string> = Object.assign(() => cached, {
+        uid: 'f',
+        type: 'heading',
+      });
+      seed(state, 'f', source);
+
+      const first = run(state);
+      cached.props = { text: 'second' };
+      const second = run(first);
+
+      // Without a copy the stored entry is the cached object itself. The comparison then compares
+      // that object with itself, so subscribers keep the old reference for a widget that changed.
+      expect(second.calculatedWidgets['f']).not.toBe(first.calculatedWidgets['f']);
+      expect(second.calculatedWidgets['f'].current.props?.['text']).toBe('second');
+    });
+
     it('leaves current.path alone when the source has no path', () => {
       const source: FunctionWidget<string> = Object.assign(
         () =>

--- a/libs/core/src/lib/store/reducers/calculate-widget-props.ts
+++ b/libs/core/src/lib/store/reducers/calculate-widget-props.ts
@@ -114,14 +114,18 @@ function computeFunctionWidget(
   localization: I18nTranslator,
   itemScope?: RepeaterItemScope,
 ): DerivedWidget<FormWidget<string>> {
-  const current = source({
-    $form: state.data,
-    errors: source.path ? state.validations[source.path] : undefined,
-    touched: source.path ? state.touchedControls[source.path] : undefined,
-    translate: localization.translate,
-    $item: itemScope ? get(state.data, itemScope.itemPath) : undefined,
-    $index: itemScope?.index,
-  });
+  // The function may return a cached object. Copy it before writing uid and path,
+  // so the write never reaches the object the function owns.
+  const current = {
+    ...source({
+      $form: state.data,
+      errors: source.path ? state.validations[source.path] : undefined,
+      touched: source.path ? state.touchedControls[source.path] : undefined,
+      translate: localization.translate,
+      $item: itemScope ? get(state.data, itemScope.itemPath) : undefined,
+      $index: itemScope?.index,
+    }),
+  };
   current.uid = uid;
   // A row function widget returns the template path, the source carries the row path.
   if (source.path !== undefined) {

--- a/libs/core/src/lib/utils/expand-sources.spec.ts
+++ b/libs/core/src/lib/utils/expand-sources.spec.ts
@@ -242,6 +242,24 @@ describe('expandSources: nested repeaters', () => {
     expect(pathOf(resolvedSources['dev-name[1][0]'])).toBe('teams.1.devs.0.name');
   });
 
+  it('does not write uid into a repeater object a row function widget returns from a cache', () => {
+    // A memoized function returns the same object for every row. The uid write then modifies
+    // an object the user owns.
+    const cached = repeater('cached-devs', 'teams.items.devs', [
+      inputChild('dev-name', 'teams.items.devs.items.name'),
+    ]);
+    const devsFn: FunctionWidget<string> = () => cached as never;
+    devsFn.uid = 'devs' as never;
+
+    const { resolvedSources } = expandSources(
+      flatFormOf(repeater('teams', 'teams', [devsFn])),
+      data,
+    );
+
+    expect(cached.uid).toBe('cached-devs');
+    expect(pathOf(resolvedSources['dev-name[2][1]'])).toBe('teams.2.devs.1.name');
+  });
+
   it('recurses into a nested repeater produced by a row function widget', () => {
     const devsFn: FunctionWidget<string> = () =>
       repeater('devs', 'teams.items.devs', [

--- a/libs/core/src/lib/utils/repeater.ts
+++ b/libs/core/src/lib/utils/repeater.ts
@@ -131,8 +131,10 @@ function asNestedRepeater(
   if (resolved.type !== 'repeater') {
     return undefined;
   }
-  resolved.uid = templateWidget.uid as string;
-  return makeRepeaterItemConfig(resolved, indexes) as RepeaterTemplateWidget;
+  // The function may return a cached object. Copy it before writing the uid,
+  // so the write never reaches the object the function owns.
+  const resolvedWithUid = { ...resolved, uid: templateWidget.uid as string };
+  return makeRepeaterItemConfig(resolvedWithUid, indexes) as RepeaterTemplateWidget;
 }
 
 /**


### PR DESCRIPTION
## Description

A function widget may return a cached object. Returning one object for every call is a normal way to write a memoized widget, and today it breaks two ways.

1. The store writes `uid` and `path` into the object the function returned, so it modifies data the user owns. Inside a repeater every row receives the same object, and each row overwrites the previous row's `uid` and `path`. The last row wins, so earlier rows carry the wrong identity and the wrong data path.
2. The entry stored in `calculatedWidgets` is then that same cached object. The change comparsion compares the object with itself and reports no change, so subscribers keep the old reference for a widget whose content changed.

Both effects come from the same cause: the store writes into an object it does not own