### PR TITLE
fix(core): return only the repeater rows the store has resolved

### DIFF
--- a/libs/core/src/lib/store/view-model.spec.ts
+++ b/libs/core/src/lib/store/view-model.spec.ts
@@ -177,6 +177,36 @@ const makeRowScopeFormDef = () => ({
   ],
 });
 
+/**
+ * A repeater whose row prop throws when the row has no `name`. Adding such a row fails the props
+ * pass, and the errored state then carries a `users` array longer than `resolvedSources` knows.
+ */
+const makeThrowingRowPropFormDef = () => ({
+  form: [
+    {
+      uid: 'users',
+      kind: 'input',
+      type: 'repeater',
+      path: 'users',
+      props: {
+        template: {
+          uid: 'usersRow',
+          kind: 'layout',
+          type: 'flex',
+          children: [
+            {
+              uid: 'greeting',
+              kind: 'display',
+              type: 'heading',
+              props: { text: 'Hi {{$item.name.toUpperCase()}}' },
+            },
+          ],
+        },
+      },
+    },
+  ],
+});
+
 /** A repeater inside a repeater template, so row index chains can be asserted. */
 const makeNestedRepeaterFormDef = () => ({
   form: [
@@ -363,6 +393,26 @@ describe('widgetViewModel', () => {
       const innerRow = widgetViewModel(state, 'devRow[2][0]');
       expect(uidsOf(innerRow.children as { uid?: string }[])).toEqual(['devName[2][0]']);
       expect((innerRow.children[0] as { path?: string }).path).toBe('teams.2.devs.0.devName');
+    });
+
+    // A derive-owned error publishes the new `data` with the previous derive's `resolvedSources`,
+    // so the value array can be longer than the rows the store knows. A row renderer reads `.uid`
+    // off every entry, so an `undefined` entry crashes the binding.
+    it('skips the rows an errored derive never resolved', () => {
+      const reduce = makeReducer();
+      const ok = drive([init(makeThrowingRowPropFormDef()), setData({ users: [{ name: 'Ada' }] })]);
+      expect(ok.formHealth).toEqual({ status: 'ok' });
+      expect(uidsOf(widgetViewModel(ok, 'users').rows)).toEqual(['usersRow[0]']);
+
+      const errored = reduce(ok, setData({ users: [{ name: 'Ada' }, {}] }));
+
+      expect(errored.formHealth.status).toBe('errored');
+      expect(errored.data['users']).toHaveLength(2);
+      expect(errored.resolvedSources).toBe(ok.resolvedSources);
+
+      const vm = widgetViewModel(errored, 'users');
+      expect(vm.rows).not.toContain(undefined);
+      expect(uidsOf(vm.rows)).toEqual(['usersRow[0]']);
     });
   });
 });

--- a/libs/core/src/lib/store/view-model.ts
+++ b/libs/core/src/lib/store/view-model.ts
@@ -33,7 +33,8 @@ export type WidgetViewModel<T = unknown> = {
   /**
    * For a repeater input, one fully indexed row layout node per row of its array value, ready to
    * render. Empty for non-repeater widgets and while hidden. Row order matches the data array, so
-   * a row's position in this list is also its index in the value.
+   * a row's position in this list is also its index in the value. The one exception is an errored
+   * derive, where a row the failed derive never resolved is left out until the form recovers.
    */
   rows: NonFunctionWidget<string>[];
 
@@ -257,6 +258,10 @@ function stampedChildren(
  * looked up in `resolvedSources` by the template uid plus the full row index chain. A nested
  * repeater's own row indexes are read back from its uid, which is what makes the chain line up
  * with the keys `expandSources` writes.
+ *
+ * A row with no node is dropped. That happens on an errored derive, which publishes the new `data`
+ * with the previous derive's `resolvedSources`, so the value array can be longer than the rows the
+ * store knows. The next successful derive lists them all again.
  */
 function repeaterRows(
   state: State,
@@ -273,10 +278,12 @@ function repeaterRows(
   }
   const templateUid = source.props.template.uid as Uid;
   const ownIndexes = extractRepeaterIndexes(uid);
-  return value.map((_, rowIndex) => {
-    const rowUid = toRepeaterItemUid(templateUid, [...ownIndexes, rowIndex]);
-    return state.resolvedSources[rowUid] as NonFunctionWidget<string>;
-  });
+  return value
+    .map((_, rowIndex) => {
+      const rowUid = toRepeaterItemUid(templateUid, [...ownIndexes, rowIndex]);
+      return state.resolvedSources[rowUid];
+    })
+    .filter((row): row is NonFunctionWidget<string> => row !== undefined);
 }
 
 function mergedErrors(


### PR DESCRIPTION
## Description

A failed derive publishes the state it received as input. That state contains the new `data`, written by the action, and the previous derive's `resolvedSources`, because the failed derive discards its own work. The repeater value array is then longer than the list of rows the store knows about.

`repeaterRows` cast every lookup to a row node without checking for absence, so each unknown row became an `undefined` entry in `WidgetViewModel.rows`. A row renderer reads `.uid` off every entry, so the binding throws and the form stops rendering. The user cannot recover, because clearing the error needs a data change and the render is already broken