### PR TITLE
fix(core): allow OVERRIDE_WIDGET_PROP to target a hidden widget

### DIFF
--- a/libs/core/src/lib/store/reducer.spec.ts
+++ b/libs/core/src/lib/store/reducer.spec.ts
@@ -1,5 +1,5 @@
 import { type StandardSchemaV1 } from '@standard-schema/spec';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { type ValidatorFn } from '../form-validator';
 import {
   type ActionWidget,
@@ -1856,27 +1856,21 @@ describe('reducer end-to-end', () => {
   // ---------------------------------------------------------------------------
 
   describe('actions that address a widget calculatedWidgets does not hold', () => {
-    // Both actions carry a uid. A hidden widget or one that is not in the form has no entry, and
-    // neither action may throw for it: OVERRIDE_WIDGET_PROP is a public API called from event
-    // handlers, and ATTEMPT_VALIDATION rides on DOM events that can outlive a mount.
-    it('OVERRIDE_WIDGET_PROP warns and returns the same state for an unknown uid', () => {
+    // Both actions carry a uid. A widget that is not in the form has no entry, and neither action
+    // may throw for it: OVERRIDE_WIDGET_PROP is a public API called from event handlers, and
+    // ATTEMPT_VALIDATION rides on DOM events that can outlive a mount. A HIDDEN widget is a
+    // different case, it is still in `resolvedSources` and both actions reach it (section 26).
+    it('OVERRIDE_WIDGET_PROP warns and returns the same state for a uid no form produces', () => {
       const initial = drive([init(makeBaseFormDef()), setData({})]);
-      expect(initial.calculatedWidgets).not.toHaveProperty('bio');
 
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
       const reduce = makeReducer();
-
-      const hidden = reduce(initial, {
-        type: 'OVERRIDE_WIDGET_PROP',
-        payload: { uid: 'bio', prop: 'text', value: 'hello' },
-      });
-      expect(hidden).toBe(initial);
-      expect(warn).toHaveBeenCalledWith('Widget with uid "bio" not found');
 
       const unknown = reduce(initial, {
         type: 'OVERRIDE_WIDGET_PROP',
         payload: { uid: 'ghost', prop: 'text', value: 'hello' },
       });
+
       expect(unknown).toBe(initial);
       expect(warn).toHaveBeenCalledWith('Widget with uid "ghost" not found');
       warn.mockRestore();
@@ -2419,6 +2413,79 @@ describe('reducer end-to-end', () => {
       expect(healed.formHealth).toEqual({ status: 'ok' });
       expect(healed.calculatedWidgets['greeting[0]']).toBeUndefined();
       expect(propsOf(healed, 'title')['text']).toBe('Users');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 26. Overrides on a hidden widget
+  // ---------------------------------------------------------------------------
+
+  // A hidden widget has no `calculatedWidgets` entry, but it is still in `resolvedSources` and an
+  // override stored while it was visible is deliberately kept. Accepting a new one is the same
+  // contract. An override only reaches `props`, so it can never reveal the widget by itself.
+  describe('overrides on a hidden widget', () => {
+    // A test that fails before its own `mockRestore` would otherwise leak the spy into the next one.
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('stores an override by uid and applies it when the widget is revealed', () => {
+      const hidden = drive([init(makeBaseFormDef()), setData({ age: 10 })]);
+      expect(hidden.widgetFlags['bio']).toEqual({ hidden: true });
+      expect(hidden.calculatedWidgets).not.toHaveProperty('bio');
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const reduce = makeReducer();
+
+      const overridden = reduce(hidden, {
+        type: 'OVERRIDE_WIDGET_PROP',
+        payload: { uid: 'bio', prop: 'text', value: 'About you' },
+      });
+
+      expect(warn).not.toHaveBeenCalled();
+      expect(overridden.widgetPropOverrides['bio']).toEqual({ text: 'About you' });
+      expect(overridden.widgetFlags['bio']).toEqual({ hidden: true });
+      expect(overridden.calculatedWidgets).not.toHaveProperty('bio');
+
+      const revealed = reduce(overridden, setData({ age: 21 }));
+
+      expect(propsOf(revealed, 'bio')['text']).toBe('About you');
+    });
+
+    it('stores an override by path and applies it when the input is revealed', () => {
+      const hidden = drive([init(makeGatedInputFormDef()), setData({ age: 10 })]);
+      expect(hidden.widgetFlags['secret']).toEqual({ hidden: true });
+      expect(hidden.calculatedWidgets).not.toHaveProperty('secret');
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const reduce = makeReducer();
+
+      const overridden = reduce(hidden, {
+        type: 'OVERRIDE_WIDGET_PROP',
+        payload: { path: 'secret', prop: 'placeholder', value: 'Say it' },
+      });
+
+      expect(warn).not.toHaveBeenCalled();
+      expect(overridden.widgetPropOverrides['secret']).toEqual({ placeholder: 'Say it' });
+
+      const revealed = reduce(overridden, setData({ age: 21 }));
+
+      expect(propsOf(revealed, 'secret')['placeholder']).toBe('Say it');
+    });
+
+    it('still warns for a path no widget in the form owns', () => {
+      const hidden = drive([init(makeGatedInputFormDef()), setData({ age: 10 })]);
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const reduce = makeReducer();
+
+      const same = reduce(hidden, {
+        type: 'OVERRIDE_WIDGET_PROP',
+        payload: { path: 'ghost', prop: 'placeholder', value: 'Say it' },
+      });
+
+      expect(same).toBe(hidden);
+      expect(warn).toHaveBeenCalledWith('Input with path "ghost" not found');
     });
   });
 });

--- a/libs/core/src/lib/store/reducers/override-widget-prop.ts
+++ b/libs/core/src/lib/store/reducers/override-widget-prop.ts
@@ -1,28 +1,20 @@
-import { type FormWidget } from '../../form-widget';
 import { inputPath } from '../../utils/form';
 import type { OVERRIDE_WIDGET_PROP } from '../actions';
-import { type DerivedWidget, type State } from '../model';
+import { type State } from '../model';
 
+/**
+ * Stores a prop override for one widget, addressed by uid or by the path its input owns.
+ *
+ * The target is looked up in `resolvedSources`, not in `calculatedWidgets`, so a hidden widget can
+ * be addressed too. The props pass applies the stored value on the derive that reveals it.
+ */
 export const overrideWidgetProp = (state: State, { payload }: OVERRIDE_WIDGET_PROP): State => {
-  let widget: DerivedWidget<FormWidget<string, any, any>> | undefined;
-
-  if ('path' in payload) {
-    widget = Object.values(state.calculatedWidgets).find(
-      ({ source, current }) => (inputPath(current) ?? inputPath(source)) === payload.path,
-    );
-    if (!widget) {
-      console.warn(`Input with path "${payload.path}" not found`);
-      return state;
-    }
-  } else {
-    widget = state.calculatedWidgets[payload.uid];
-    if (!widget) {
-      console.warn(`Widget with uid "${payload.uid}" not found`);
-      return state;
-    }
+  const uid =
+    'path' in payload ? findUidByPath(state, payload.path) : findUidByUid(state, payload.uid);
+  if (uid === undefined) {
+    return state;
   }
 
-  const uid = widget.source.uid as string;
   const propOverrides = state.widgetPropOverrides[uid] || {};
   return {
     ...state,
@@ -32,3 +24,32 @@ export const overrideWidgetProp = (state: State, { payload }: OVERRIDE_WIDGET_PR
     },
   };
 };
+
+function findUidByUid(state: State, uid: string): string | undefined {
+  if (uid in state.resolvedSources) {
+    return uid;
+  }
+  console.warn(`Widget with uid "${uid}" not found`);
+  return undefined;
+}
+
+function findUidByPath(state: State, path: string): string | undefined {
+  // Visible widgets first, so a visible owner of the path wins, and so a function widget whose
+  // source declares no path is still found through the input shape it returns in `current`.
+  const calculated = Object.values(state.calculatedWidgets).find(
+    ({ source, current }) => (inputPath(current) ?? inputPath(source)) === path,
+  );
+  if (calculated) {
+    return calculated.source.uid as string;
+  }
+
+  const hidden = Object.keys(state.resolvedSources).find(
+    (uid) => inputPath(state.resolvedSources[uid]) === path,
+  );
+  if (hidden !== undefined) {
+    return hidden;
+  }
+
+  console.warn(`Input with path "${path}" not found`);
+  return undefined;
+}


### PR DESCRIPTION
The store already holds prop overrides on hidden widgets. `dropRemovedWidgetEntries` keeps an override as long as its uid is in `resolvedSources`, and a hidden widget stays in `resolvedSources`. But `overrideWidgetProp` looked the target up in `calculatedWidgets`, which the props pass never fills for a hidden widget. So the store could keep an override on a hidden widget but could not accept a new one.

An event handler that overrides a prop on a widget the user has not revealed yet got a misleading "not found" warning and no effect. There was no way to prepare an override before the widget appears