### PR TITLE
fix: read calculated props in the Angular and Lit tabs and accordion

### DIFF
--- a/libs/gui/angular/src/lib/components/accordion/accordion.component.ts
+++ b/libs/gui/angular/src/lib/components/accordion/accordion.component.ts
@@ -29,16 +29,14 @@ export class AccordionComponent implements OnInit, OnDestroy, WithWidget {
   private rowIndexSuffix = '';
 
   ngOnInit(): void {
-    const props: AccordionProps = this.widget.props as AccordionProps;
     this.adapter.init(this.widget);
-    // Repeater rows share one props object, so never write into `defaultOpen` itself.
-    this.activeSections = { ...(props.defaultOpen ?? {}) };
+    // Repeater rows share one `defaultOpen` object, so never write into it, copy it
+    this.activeSections = { ...(this.adapter.templateData().defaultOpen ?? {}) };
     this.rowIndexSuffix = repeaterIndexSuffix(this.widget.uid);
   }
 
   onClickButton(uid: string) {
-    const props: AccordionProps = this.widget.props as AccordionProps;
-    if (props.singleOpen) {
+    if (this.adapter.templateData().singleOpen) {
       Object.keys(this.activeSections)
         .filter((sectionUid) => sectionUid !== uid)
         .forEach((key) => {

--- a/libs/gui/angular/src/lib/components/tabs/tabs.component.ts
+++ b/libs/gui/angular/src/lib/components/tabs/tabs.component.ts
@@ -51,9 +51,9 @@ export class TabsComponent implements OnInit, AfterViewInit, OnDestroy, WithWidg
   private rowIndexSuffix = '';
 
   ngOnInit(): void {
-    const props: TabsProps = this.widget.props as TabsProps;
     this.adapter.init(this.widget);
-    this.activeTab.set(props.defaultOpen ?? props.tabs[0].uid);
+    const templateData = this.adapter.templateData();
+    this.activeTab.set(templateData.defaultOpen ?? templateData.tabs?.[0]?.uid ?? '');
     this.rowIndexSuffix = repeaterIndexSuffix(this.widget.uid);
 
     this.startObserver = createIntersectionObserver(
@@ -68,12 +68,14 @@ export class TabsComponent implements OnInit, AfterViewInit, OnDestroy, WithWidg
 
   ngAfterViewInit() {
     // Scroll into view the active tab, just in case it's out of view
-    const tabs = (this.widget.props as TabsProps).tabs;
+    const tabs = this.adapter.templateData().tabs ?? [];
     const currentIndex = tabs.findIndex((tab) => tab.uid === this.activeTab());
-    this.tabButtons()[currentIndex].nativeElement.scrollIntoView({
-      block: 'nearest',
-      inline: 'nearest',
-    });
+    if (currentIndex > -1) {
+      this.tabButtons()[currentIndex].nativeElement.scrollIntoView({
+        block: 'nearest',
+        inline: 'nearest',
+      });
+    }
   }
 
   /**
@@ -108,7 +110,7 @@ export class TabsComponent implements OnInit, AfterViewInit, OnDestroy, WithWidg
   }
 
   onKeyDown($event: KeyboardEvent) {
-    const tabs = (this.widget.props as TabsProps).tabs;
+    const tabs = this.adapter.templateData().tabs ?? [];
     const currentIndex = tabs.findIndex((tab) => tab.uid === this.activeTab());
     const isRTL = window.getComputedStyle(this.elementRef.nativeElement).direction === 'rtl';
 

--- a/libs/gui/lit/src/lib/components/accordion.element.ts
+++ b/libs/gui/lit/src/lib/components/accordion.element.ts
@@ -50,11 +50,10 @@ export class AccordionElement extends LitElement implements WithWidget {
   override connectedCallback() {
     super.connectedCallback();
     this.classList.add('gui-accordion', 'gui-field');
-    const props: AccordionProps = this.widget.props as AccordionProps;
     this.adapter.context = this.formContext;
     this.adapter.init(this.widget);
-    // Copy: repeater rows share one props object, a direct write would open the section in every row.
-    this.activeSections = { ...(props.defaultOpen ?? {}) };
+    // Copy: repeater rows share one `defaultOpen` object, a direct write would open the section in every row
+    this.activeSections = { ...(this.adapter.templateData.defaultOpen ?? {}) };
     this.rowIndexSuffix = repeaterIndexSuffix(this.widget.uid);
 
     this.subscriptions.push(
@@ -63,8 +62,7 @@ export class AccordionElement extends LitElement implements WithWidget {
   }
 
   onClickButton(uid: string) {
-    const props: AccordionProps = this.widget.props as AccordionProps;
-    if (props.singleOpen) {
+    if (this.adapter.templateData.singleOpen) {
       Object.keys(this.activeSections)
         .filter((sectionUid) => sectionUid !== uid)
         .forEach((key) => {

--- a/libs/gui/lit/src/lib/components/tabs.element.ts
+++ b/libs/gui/lit/src/lib/components/tabs.element.ts
@@ -76,10 +76,10 @@ export class TabsElement extends LitElement implements WithWidget {
   override connectedCallback() {
     super.connectedCallback();
     this.classList.add('gui-tabs', 'gui-field');
-    const props: TabsProps = this.widget.props as TabsProps;
     this.adapter.context = this.formContext;
     this.adapter.init(this.widget);
-    this.activeTab = props.defaultOpen ?? props.tabs[0].uid;
+    const templateData = this.adapter.templateData;
+    this.activeTab = templateData.defaultOpen ?? templateData.tabs?.[0]?.uid ?? '';
     this.rowIndexSuffix = repeaterIndexSuffix(this.widget.uid);
 
     this.subscriptions.push(
@@ -100,9 +100,11 @@ export class TabsElement extends LitElement implements WithWidget {
     );
 
     // Scroll into view the active tab, just in case it's out of view
-    const tabs = (this.widget.props as TabsProps).tabs;
+    const tabs = this.adapter.templateData.tabs ?? [];
     const currentIndex = tabs.findIndex((tab) => tab.uid === this.activeTab);
-    this.tabButtons[currentIndex].scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    if (currentIndex > -1) {
+      this.tabButtons[currentIndex].scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    }
   }
 
   override render() {
@@ -195,7 +197,7 @@ export class TabsElement extends LitElement implements WithWidget {
   }
 
   private onKeyDown(event: KeyboardEvent) {
-    const tabs = (this.widget.props as TabsProps).tabs;
+    const tabs = this.adapter.templateData.tabs ?? [];
     const currentIndex = tabs.findIndex((tab) => tab.uid === this.activeTab);
     const tabButtons = Array.from(this.tabButtons);
     const isRTL = window.getComputedStyle(this).direction === 'rtl';

--- a/libs/ui-testing/src/lib/gui-features/accordion.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/accordion.cy.ts
@@ -74,4 +74,59 @@ export const runAccordionComponentTests = (mountFn: MountComponentFn) => {
       cy.get('[data-cy="secondSection_textinput"]').should('be.visible');
     });
   });
+
+  describe('Accordion Component with calculated props', () => {
+    const ACCORDION_UID = 'calculatedAccordion';
+
+    it('reads singleOpen from the calculated props when a property function produces it', () => {
+      // The raw prop value is the function itself (truthy), only the calculated props hold `false`
+      mountFn({
+        formDef: defineForm({
+          form: [
+            {
+              uid: ACCORDION_UID,
+              kind: 'layout',
+              type: 'accordion',
+              props: {
+                singleOpen: () => false,
+                defaultOpen: { firstSection: true },
+                sections: [
+                  { uid: 'firstSection', label: 'First' },
+                  { uid: 'secondSection', label: 'Second' },
+                ],
+              },
+              children: [
+                {
+                  uid: 'firstSection',
+                  kind: 'input',
+                  type: 'textinput',
+                  path: 'accordion.first',
+                  label: 'First',
+                },
+                {
+                  uid: 'secondSection',
+                  kind: 'input',
+                  type: 'textinput',
+                  path: 'accordion.second',
+                  label: 'Second',
+                },
+              ],
+            },
+          ],
+        }),
+      });
+
+      cy.get(`[id="accordion_button_${ACCORDION_UID}_secondSection"]`).click();
+
+      // singleOpen is false, so opening the second section keeps the first one open
+      cy.get(`[id="accordion_section_${ACCORDION_UID}_secondSection"]`).should(
+        'not.have.attr',
+        'hidden',
+      );
+      cy.get(`[id="accordion_section_${ACCORDION_UID}_firstSection"]`).should(
+        'not.have.attr',
+        'hidden',
+      );
+    });
+  });
 };

--- a/libs/ui-testing/src/lib/gui-features/tabs.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/tabs.cy.ts
@@ -83,6 +83,50 @@ export const runTabsComponentTests = (mountFn: MountComponentFn) => {
         .and('have.attr', 'aria-labelledby', `tab_${TABS_UID}_secondPanel`);
     });
 
+    it('reads the tabs from the calculated props when a property function produces them', () => {
+      // The raw prop value is the function itself, only the calculated props hold the array
+      mountFn({
+        formDef: getFormDefinition({
+          tabs: () => [
+            { uid: 'firstPanel', label: 'First' },
+            { uid: 'secondPanel', label: 'Second' },
+            { uid: 'thirdPanel', label: 'Third' },
+          ],
+        }),
+      });
+
+      cy.get('button[role="tab"]').should('have.length', 3);
+      cy.get(`[data-cy="tab_${TABS_UID}_firstPanel"]`).should('have.attr', 'aria-selected', 'true');
+      cy.get(`[data-cy="tabpanel_${TABS_UID}_firstPanel"]`).should('not.have.attr', 'hidden');
+    });
+
+    it('renders no tab headers and does not throw when the tabs array is empty', () => {
+      mountFn({
+        formDef: defineForm({
+          form: [
+            {
+              uid: TABS_UID,
+              kind: 'layout',
+              type: 'tabs',
+              props: { tabs: [] },
+              children: [],
+            },
+            {
+              uid: 'outsideTabs',
+              kind: 'input',
+              type: 'textinput',
+              path: 'outside',
+              label: 'Outside',
+            },
+          ],
+        }),
+      });
+
+      cy.get('[data-cy="outsideTabs_textinput"]').should('be.visible');
+      cy.get('button[role="tab"]').should('have.length', 0);
+      cy.get('section[role="tabpanel"]').should('not.exist');
+    });
+
     it('keeps the remaining panels wired to their own tab when a child is hidden', () => {
       mountFn({
         data: { tabs: { first: 'Alice' } },


### PR DESCRIPTION
## Description

A tabs or accordion prop can be produced by a property function. The raw prop value is then the function itself, and only the calculated props hold the real value. React and Vue read the calculated props (`templateData`), but Angular and Lit read raw `widget.props` for `defaultOpen`, `tabs` and `singleOpen`. 

The same form definition behaved differently per framework: a function-produced `tabs` array crashed Angular and Lit on init, and a function-produced `singleOpen` was treated as always on because a function is truthy.
Angular and Lit also threw on an empty `tabs` array (`props.tabs[0].uid`), where React and Vue render an empty tab list.

Now Angular and Lit read these three props from the adapter's `templateData`, which is filled with the calculated values during `init`, and guards the active-tab scroll-into-view call so an empty `tabs` array is safe. 

No changes for forms with plain literal props.