### PR TITLE
perf(core): remove redundant derive work and cache compiled expressions

### DIFF
--- a/libs/core/src/lib/store/reducer.perf.spec.ts
+++ b/libs/core/src/lib/store/reducer.perf.spec.ts
@@ -16,6 +16,7 @@ import { reducer } from './reducer';
 const ROWS = 200;
 const EDITS = 20;
 const BUDGET_MS = 2000;
+const ITERATIONS = 5;
 
 const validators: ValidatorFn<unknown> = (): StandardSchemaV1 => ({
   '~standard': { version: 1, vendor: 'reducer-perf-spec', validate: (value) => ({ value }) },
@@ -53,41 +54,51 @@ const makeFormDef = () => ({
 const makeRows = () =>
   Array.from({ length: ROWS }, (_, index) => ({ a: `a${index}`, b: `b${index}`, c: `c${index}` }));
 
+// INITIALIZE writes into the form array, so every run builds its own formDef and state.
+const runScenario = (): { state: State; elapsedMs: number } => {
+  const reduce = reducer({
+    validators,
+    validateOn: 'eager',
+    localization: identityTranslator('en-US'),
+    functions: {},
+  });
+  const actions: Action[] = [
+    { type: 'INITIALIZE', payload: { formName: 'perf', formDef: makeFormDef() } },
+    { type: 'SET_DATA', payload: { data: { rows: makeRows() } } },
+    ...Array.from(
+      { length: EDITS },
+      (_, index): Action => ({
+        type: 'SET_WIDGET_DATA',
+        payload: { path: `rows.${index * 7}.a`, data: `edited ${index}` },
+      }),
+    ),
+  ];
+
+  const start = performance.now();
+  const state = actions.reduce(
+    (current: State, action) => reduce(current, action),
+    createInitialState('en-US'),
+  );
+  return { state, elapsedMs: performance.now() - start };
+};
+
 describe('reducer performance', () => {
-  it(`derives a ${ROWS}-row repeater on SET_DATA plus ${EDITS} edits under ${BUDGET_MS} ms`, () => {
-    const reduce = reducer({
-      validators,
-      validateOn: 'eager',
-      localization: identityTranslator('en-US'),
-      functions: {},
-    });
-    const actions: Action[] = [
-      { type: 'INITIALIZE', payload: { formName: 'perf', formDef: makeFormDef() } },
-      { type: 'SET_DATA', payload: { data: { rows: makeRows() } } },
-      ...Array.from(
-        { length: EDITS },
-        (_, index): Action => ({
-          type: 'SET_WIDGET_DATA',
-          payload: { path: `rows.${index * 7}.a`, data: `edited ${index}` },
-        }),
-      ),
-    ];
-
-    const start = performance.now();
-    const state = actions.reduce(
-      (current: State, action) => reduce(current, action),
-      createInitialState('en-US'),
-    );
-    const elapsed = performance.now() - start;
-
-    expect(state.formHealth.status).toBe('ok');
-    expect(Object.keys(state.calculatedWidgets).length).toBe(ROWS * 5 + 2);
-    expect(state.calculatedWidgets['summary[7]'].current.props?.['text']).toBe(
+  it(`derives a ${ROWS}-row repeater on SET_DATA plus ${EDITS} edits with a median under ${BUDGET_MS} ms`, () => {
+    // The warmup run also fills the module-level expression compile cache, so the timed
+    // iterations measure the steady-state path.
+    const warmup = runScenario();
+    expect(warmup.state.formHealth.status).toBe('ok');
+    expect(Object.keys(warmup.state.calculatedWidgets).length).toBe(ROWS * 5 + 2);
+    expect(warmup.state.calculatedWidgets['summary[7]'].current.props?.['text']).toBe(
       'Row 7: edited 1 / b7',
     );
+
+    const timings = Array.from({ length: ITERATIONS }, () => runScenario().elapsedMs);
+    const median = [...timings].sort((left, right) => left - right)[Math.floor(ITERATIONS / 2)];
+
     console.info(
-      `[reducer.perf] ${ROWS} rows, SET_DATA + ${EDITS} edits: ${elapsed.toFixed(0)} ms`,
+      `[reducer.perf] ${ROWS} rows, SET_DATA + ${EDITS} edits: median ${median.toFixed(0)} ms over ${ITERATIONS} runs (warmup ${warmup.elapsedMs.toFixed(0)} ms)`,
     );
-    expect(elapsed).toBeLessThan(BUDGET_MS);
+    expect(median).toBeLessThan(BUDGET_MS);
   });
 });

--- a/libs/core/src/lib/store/reducer.ts
+++ b/libs/core/src/lib/store/reducer.ts
@@ -41,7 +41,10 @@ export const reducer = ({
   const applyWidgetProps = calculateWidgetProps(localization, functions);
   // Every action that changes a derive input goes through this wrapper.
   const deriveAndValidateAppearingInputs = (state: State): State =>
-    validateInputsAppearingAfterSubmit(state, derive, validate);
+    validateInputsAppearingAfterSubmit(state, derive, validate, false);
+  // Validation actions recompute isFormValid exactly once, on whichever path the helper exits through.
+  const deriveAfterValidationAction = (state: State): State =>
+    validateInputsAppearingAfterSubmit(state, derive, validate, true);
 
   return (state: State, action: Action): State => {
     switch (action.type) {
@@ -77,9 +80,7 @@ export const reducer = ({
         return setFormHealth(state, action);
 
       case 'VALIDATE_ALL':
-        return calculateIsFormValid(
-          deriveAndValidateAppearingInputs(validate(touchAllInputs(state))),
-        );
+        return deriveAfterValidationAction(validate(touchAllInputs(state)));
 
       case 'ATTEMPT_VALIDATION': {
         if (!shouldValidate(validateOn, action.payload.reason)) {
@@ -90,7 +91,7 @@ export const reducer = ({
           touched: true,
           touchedControls: { ...state.touchedControls, [action.payload.path]: true },
         };
-        return calculateIsFormValid(deriveAndValidateAppearingInputs(validate(touched)));
+        return deriveAfterValidationAction(validate(touched));
       }
 
       case 'INJECT_VALIDATION_ISSUES':
@@ -169,22 +170,29 @@ function makeDerive(localization: I18nTranslator, functions: ExpressionFunctions
  * an input that this derive makes appear (a new repeater row, a revealed field) is touched and
  * validated right away so its errors show without interaction, then the derive runs once more so
  * `$errors`, `$formIsInvalid` and function widgets see the new validation result.
+ *
+ * When `recalculateIsFormValidOnEveryPath` is true, the exit paths that skip the appearing-input
+ * validation also recompute `isFormValid`, so a validation action computes it exactly once here
+ * instead of repeating it on the returned state.
  */
 function validateInputsAppearingAfterSubmit(
   state: State,
   derive: (state: State) => State,
   validate: (state: State) => State,
+  recalculateIsFormValidOnEveryPath: boolean,
 ): State {
+  const finishPass = (result: State): State =>
+    recalculateIsFormValidOnEveryPath ? calculateIsFormValid(result) : result;
   const previousSources = state.resolvedSources;
   const previousFlags = state.widgetFlags;
   let next = derive(state);
   if (!next.allControlsValidated || next.formHealth.status !== 'ok') {
-    return next;
+    return finishPass(next);
   }
 
   const appearing = pathsOfInputsAppearingIn(next, previousSources, previousFlags);
   if (appearing.length === 0) {
-    return next;
+    return finishPass(next);
   }
 
   const touchedControls = { ...next.touchedControls };

--- a/libs/core/src/lib/store/reducers/calculate-widget-flags.ts
+++ b/libs/core/src/lib/store/reducers/calculate-widget-flags.ts
@@ -41,104 +41,115 @@ function calculateFlags(
   $formIsInvalid: boolean,
   functions: ExpressionFunctions,
 ): State['widgetFlags'] {
-  const widgets = Object.entries(state.resolvedSources).map(([uid, source]) =>
-    resolveForFlags(uid as Uid, source, state),
-  );
+  // A function widget resolves first because its flag fields are impossible to know before the call.
+  // Other widgets are checked on the source directly: the when-transform never adds or removes fields.
+  const widgets: NonFunctionWidget<string>[] = [];
+  for (const [uid, source] of Object.entries(state.resolvedSources)) {
+    if (isFunctionWidget(source)) {
+      const resolved = resolveForFlags(uid as Uid, source, state);
+      if (hasReactiveFlagFields(resolved)) {
+        widgets.push(resolved);
+      }
+    } else if (hasReactiveFlagFields(source)) {
+      widgets.push(resolveForFlags(uid as Uid, source, state));
+    }
+  }
 
-  const flags = widgets
-    .filter((widget) => {
-      if (widget.include && ('in' in widget.include || 'when' in widget.include)) {
-        return true;
+  const flags = widgets.reduce(
+    (flags, widget) => {
+      flags[widget.uid] = flags[widget.uid] || {};
+
+      // Widgets inside a repeater item see that item through $item / $index
+      const itemScope = state.repeaterItemScopes[widget.uid];
+      const extraScope = itemScope
+        ? { $item: get(state.data, itemScope.itemPath), $index: itemScope.index, $fn: functions }
+        : { $fn: functions };
+
+      // show
+      if (widget.include && 'in' in widget.include) {
+        flags[widget.uid].hidden = !widget.include.in.some((widgetState) =>
+          state.currentStates.includes(widgetState),
+        );
+      } else if (widget.include && 'when' in widget.include) {
+        flags[widget.uid].hidden = !expressionIsTrue(
+          widget.include.when,
+          state.data,
+          state.meta,
+          $errors,
+          $formIsInvalid,
+          extraScope,
+        );
       }
-      if (widget.exclude && ('from' in widget.exclude || 'when' in widget.exclude)) {
-        return true;
+
+      // hide
+      if (widget.exclude && 'from' in widget.exclude) {
+        flags[widget.uid].hidden = widget.exclude.from.some((widgetState) =>
+          state.currentStates.includes(widgetState),
+        );
+      } else if (widget.exclude && 'when' in widget.exclude) {
+        flags[widget.uid].hidden = expressionIsTrue(
+          widget.exclude.when,
+          state.data,
+          state.meta,
+          $errors,
+          $formIsInvalid,
+          extraScope,
+        );
       }
-      if ((isInputWidget(widget) || isActionWidget(widget)) && hasWhen(widget.disabled)) {
-        return true;
+
+      // TODO: We have to document that (disabled|readonly).when is NOT compatible with states e.g. `{'disabled.register': {when: '...'}}`
+      //       It's either boolean, states + boolean or when.
+
+      // disabled
+      if (isInputWidget(widget) || isActionWidget(widget)) {
+        if (hasWhen(widget.disabled)) {
+          flags[widget.uid].disabled = expressionIsTrue(
+            (widget.disabled as { when: string }).when,
+            state.data,
+            state.meta,
+            $errors,
+            $formIsInvalid,
+            extraScope,
+          );
+        }
       }
+
+      // readonly
       if (isInputWidget(widget) && hasWhen(widget.readonly)) {
-        return true;
+        flags[widget.uid].readonly = expressionIsTrue(
+          (widget.readonly as { when: string }).when,
+          state.data,
+          state.meta,
+          $errors,
+          $formIsInvalid,
+          extraScope,
+        );
       }
-      return false;
-    })
-    .reduce(
-      (flags, widget) => {
-        flags[widget.uid] = flags[widget.uid] || {};
 
-        // Widgets inside a repeater item see that item through $item / $index
-        const itemScope = state.repeaterItemScopes[widget.uid];
-        const extraScope = itemScope
-          ? { $item: get(state.data, itemScope.itemPath), $index: itemScope.index, $fn: functions }
-          : { $fn: functions };
-
-        // show
-        if (widget.include && 'in' in widget.include) {
-          flags[widget.uid].hidden = !widget.include.in.some((widgetState) =>
-            state.currentStates.includes(widgetState),
-          );
-        } else if (widget.include && 'when' in widget.include) {
-          flags[widget.uid].hidden = !expressionIsTrue(
-            widget.include.when,
-            state.data,
-            state.meta,
-            $errors,
-            $formIsInvalid,
-            extraScope,
-          );
-        }
-
-        // hide
-        if (widget.exclude && 'from' in widget.exclude) {
-          flags[widget.uid].hidden = widget.exclude.from.some((widgetState) =>
-            state.currentStates.includes(widgetState),
-          );
-        } else if (widget.exclude && 'when' in widget.exclude) {
-          flags[widget.uid].hidden = expressionIsTrue(
-            widget.exclude.when,
-            state.data,
-            state.meta,
-            $errors,
-            $formIsInvalid,
-            extraScope,
-          );
-        }
-
-        // TODO: We have to document that (disabled|readonly).when is NOT compatible with states e.g. `{'disabled.register': {when: '...'}}`
-        //       It's either boolean, states + boolean or when.
-
-        // disabled
-        if (isInputWidget(widget) || isActionWidget(widget)) {
-          if (hasWhen(widget.disabled)) {
-            flags[widget.uid].disabled = expressionIsTrue(
-              (widget.disabled as { when: string }).when,
-              state.data,
-              state.meta,
-              $errors,
-              $formIsInvalid,
-              extraScope,
-            );
-          }
-        }
-
-        // readonly
-        if (isInputWidget(widget) && hasWhen(widget.readonly)) {
-          flags[widget.uid].readonly = expressionIsTrue(
-            (widget.readonly as { when: string }).when,
-            state.data,
-            state.meta,
-            $errors,
-            $formIsInvalid,
-            extraScope,
-          );
-        }
-
-        return flags;
-      },
-      {} as State['widgetFlags'],
-    );
+      return flags;
+    },
+    {} as State['widgetFlags'],
+  );
 
   propagateHiddenToDescendants(state, flags);
   return flags;
+}
+
+/** True when the widget has at least one include / exclude / disabled / readonly condition to evaluate. */
+function hasReactiveFlagFields(widget: NonFunctionWidget<string>): boolean {
+  if (widget.include && ('in' in widget.include || 'when' in widget.include)) {
+    return true;
+  }
+  if (widget.exclude && ('from' in widget.exclude || 'when' in widget.exclude)) {
+    return true;
+  }
+  if ((isInputWidget(widget) || isActionWidget(widget)) && hasWhen(widget.disabled)) {
+    return true;
+  }
+  if (isInputWidget(widget) && hasWhen(widget.readonly)) {
+    return true;
+  }
+  return false;
 }
 
 /**

--- a/libs/core/src/lib/store/reducers/calculate-widget-props.ts
+++ b/libs/core/src/lib/store/reducers/calculate-widget-props.ts
@@ -17,10 +17,9 @@ import {
   isTranslationConfig,
   type TranslationConfig,
 } from '../../i18n';
-import { compile, parse } from 'subscript/justin';
 import { type $Errors, type ExpressionFunctions } from '../../shared';
 import { calculateValidationVariables, type ValidationVariables } from '../../utils/form';
-import { normalizeArrayIndexes } from '../../utils/justin';
+import { compileExpression } from '../../utils/justin';
 import { get, set } from '../../utils/object';
 import { extractRepeaterIndexes } from '../../utils/repeater';
 import { type DerivedWidget, type RepeaterItemScope, type State } from '../model';
@@ -365,9 +364,8 @@ function resolveString(input: string, ctx: ResolverCtx): string {
   }
 
   return input.replace(STRING_INTERPOLATION_REGEX, (_match, rawExpr: string) => {
-    const expr = normalizeArrayIndexes(rawExpr.trim());
     try {
-      const result = compile(parse(expr))({
+      const result = compileExpression(rawExpr.trim())({
         $form: ctx.$form,
         $meta: ctx.$meta,
         $errors: ctx.$errors,
@@ -485,7 +483,7 @@ function resolveI18nParams(
     const param = String(params[key]);
     if (isPotentialExpression(param)) {
       try {
-        const result = compile(parse(normalizeArrayIndexes(param)))({
+        const result = compileExpression(param)({
           $form: ctx.$form,
           $meta: ctx.$meta,
           $errors: ctx.$errors,

--- a/libs/core/src/lib/utils/justin.spec.ts
+++ b/libs/core/src/lib/utils/justin.spec.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { expressionIsTrue, normalizeArrayIndexes } from './justin';
+import {
+  COMPILED_EXPRESSION_CACHE_LIMIT,
+  compileExpression,
+  expressionIsTrue,
+  normalizeArrayIndexes,
+} from './justin';
 
 describe('justin', () => {
   const $form = {
@@ -245,6 +250,30 @@ describe('justin', () => {
 
     it('returns false when $formIsInvalid does not match expected value', () => {
       expect(expressionIsTrue('$formIsInvalid === true', {}, {}, {}, false)).toBe(false);
+    });
+  });
+
+  describe('compileExpression cache', () => {
+    it('returns the same evaluator for the same expression string', () => {
+      const first = compileExpression('$form.total * 2');
+      const second = compileExpression('$form.total * 2');
+      expect(second).toBe(first);
+    });
+
+    it('re-evaluates a cached expression against new scope values', () => {
+      expect(expressionIsTrue('$form.age >= 18', { age: 21 }, {}, {}, false)).toBe(true);
+      expect(expressionIsTrue('$form.age >= 18', { age: 12 }, {}, {}, false)).toBe(false);
+    });
+
+    it('clears the cache at the limit and recompiles a working evaluator', () => {
+      const before = compileExpression('$form.a');
+      // Enough distinct expressions to reach the limit at least once from any starting size
+      for (let index = 0; index <= COMPILED_EXPRESSION_CACHE_LIMIT; index++) {
+        compileExpression(`$form.a + ${index}`);
+      }
+      const after = compileExpression('$form.a');
+      expect(after).not.toBe(before);
+      expect(after({ $form: { a: 7 } })).toBe(7);
     });
   });
 });

--- a/libs/core/src/lib/utils/justin.ts
+++ b/libs/core/src/lib/utils/justin.ts
@@ -1,4 +1,4 @@
-import { compile, parse } from 'subscript/justin';
+import { compile, type Evaluator, parse } from 'subscript/justin';
 import { type $Errors, type ExpressionFunctions, type ReactiveExpression } from '../shared';
 import { type State } from '../store/model';
 import { Debug } from './debug';
@@ -18,7 +18,29 @@ export type ExpressionExtraScope = RepeaterItemExpressionScope & {
   $fn?: ExpressionFunctions;
 };
 
-// TODO: caching or memoization
+export const COMPILED_EXPRESSION_CACHE_LIMIT = 2000;
+const compiledExpressionCache = new Map<string, Evaluator>();
+
+/**
+ * Returns the compiled evaluator for an expression, compiling on the first call.
+ *
+ * Row-rewritten `when` expressions are distinct per row, so the cache grows with the row
+ * count and is cleared when it reaches the limit. The next call recompiles. A failed parse
+ * is never cached, so an invalid expression throws the same error on every call.
+ */
+export function compileExpression(expression: string): Evaluator {
+  const cached = compiledExpressionCache.get(expression);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const evaluate = compile(parse(normalizeArrayIndexes(expression)));
+  if (compiledExpressionCache.size >= COMPILED_EXPRESSION_CACHE_LIMIT) {
+    compiledExpressionCache.clear();
+  }
+  compiledExpressionCache.set(expression, evaluate);
+  return evaluate;
+}
+
 export function expressionIsTrue(
   expression: ReactiveExpression,
   $form: State['data'],
@@ -27,8 +49,7 @@ export function expressionIsTrue(
   $formIsInvalid: boolean,
   extraScope?: ExpressionExtraScope,
 ): boolean {
-  const ast = parse(normalizeArrayIndexes(expression));
-  const evaluate = compile(ast);
+  const evaluate = compileExpression(expression);
   const result = evaluate({
     $form,
     $meta,

--- a/libs/core/src/lib/utils/repeater.spec.ts
+++ b/libs/core/src/lib/utils/repeater.spec.ts
@@ -236,9 +236,11 @@ describe('transformWidgetWhenExpressions', () => {
       exclude: { from: ['summary'] },
       disabled: true,
     });
+    // No when expression anywhere, so the input is returned by reference
+    expect(result).toBe(widget);
   });
 
-  it('should return an equivalent widget when no flag field is present', () => {
+  it('should return the same widget reference when no flag field is present', () => {
     const widget = {
       uid: 'row-note[0]',
       props: { md: 'hello' },
@@ -246,8 +248,7 @@ describe('transformWidgetWhenExpressions', () => {
 
     const result = transformWidgetWhenExpressions(widget, [0]);
 
-    expect(result).toEqual(widget);
-    expect(result).not.toBe(widget);
+    expect(result).toBe(widget);
   });
 });
 

--- a/libs/core/src/lib/utils/repeater.ts
+++ b/libs/core/src/lib/utils/repeater.ts
@@ -264,7 +264,8 @@ const WHEN_FIELDS = ['include', 'exclude', 'disabled', 'readonly'] as const;
  *
  * @param widget - A widget already materialized for a repeater item (see {@link makeRepeaterItemConfig}).
  * @param repeaterIndexes - Ordered list of indexes for each nesting level.
- * @returns A new widget config with item-concrete `when` expressions. The original is not mutated.
+ * @returns A new widget config with item-concrete `when` expressions, or the input widget by
+ * reference when no flag field has a `when` expression. The original is never mutated.
  *
  * @example
  * // repeaterIndexes = [1]
@@ -275,6 +276,13 @@ export function transformWidgetWhenExpressions(
   widget: NonFunctionWidget<string>,
   repeaterIndexes: number[],
 ): NonFunctionWidget<string> {
+  const hasAnyWhenExpression = WHEN_FIELDS.some((field) =>
+    hasWhenExpression((widget as Record<string, unknown>)[field]),
+  );
+  if (!hasAnyWhenExpression) {
+    return widget;
+  }
+
   const transformed = { ...widget } as Record<string, unknown>;
 
   for (const field of WHEN_FIELDS) {


### PR DESCRIPTION
## Description

Every data change runs a full derive, so redundant work in it runs on every keystroke.
This branch removes four cases:

- The flags pass resolved and copied every widget, then discarded the ones with no flag conditions. The check now runs before the resolve.
- The `when` expression rewrite copied every row widget even with nothing to rewrite. It now returns the input unchanged in that case.
- `VALIDATE_ALL` and `ATTEMPT_VALIDATION` computed `isFormValid` twice when a submit attempt made new inputs appear. Now once per dispatch.
- Every expression was parsed and compiled on every evaluation. Compiled evaluators are now cached by their source string