### PR TITLE
fix(core): deterministic function widget uids and default language

### DIFF
--- a/libs/core/src/lib/form-widget.ts
+++ b/libs/core/src/lib/form-widget.ts
@@ -25,7 +25,6 @@ import {
   type WidgetPropertyFunction,
 } from './shared';
 import { objectWithSuffix } from './utils/decoder';
-import { shortUUID } from './utils/random';
 import { type AllSuffixable, type SomeSuffixable } from './utils/suffixable';
 
 // --------------------------------
@@ -345,8 +344,9 @@ const functionWidgetDecoder: Decoder<FunctionWidget<string>> = new Decoder((json
       touched: undefined,
       translate: undefined,
     });
-    // The uid is stored on the function object itself so re-decoding the same function keeps the same uid
-    fnWidget.uid = fnWidget.uid || widget.uid || shortUUID();
+    // The uid is stored on the function object itself so re-decoding the same function keeps the same uid.
+    // An empty uid gets a position uid later (see assignDeterministicUids), so a server and a client process decoding the same definition agree on it.
+    fnWidget.uid = fnWidget.uid || widget.uid;
     fnWidget.type = widget.type;
     fnWidget.path = (widget as InputWidget<unknown>).path; // this could be undefined, and it's ok.
     return ok(fnWidget);

--- a/libs/core/src/lib/form.spec.ts
+++ b/libs/core/src/lib/form.spec.ts
@@ -92,3 +92,58 @@ describe('formDefDecoder - deterministic uids', () => {
     expect(raw).toEqual(makeRawFormDef());
   });
 });
+
+// A function widget's uid is stored on the function object. It must be position-based, never random,
+// so that two processes decoding the same definition (a server render and the client hydrating it)
+// agree on it without sharing the function object
+describe('formDefDecoder - deterministic function widget uids', () => {
+  // Fresh function objects on every call, like a second process decoding the same source
+  const makeRawFormDefWithFunction = (): Record<string, any> => ({
+    form: {
+      kind: 'layout',
+      type: 'flex',
+      children: [
+        { kind: 'input', type: 'text', path: 'name' },
+        () => ({ kind: 'display', type: 'text', props: { text: 'from a function' } }),
+      ],
+    },
+  });
+
+  it('assigns the same position uid across decodes of fresh function objects', () => {
+    const firstDecode = formDefDecoder.parse(makeRawFormDefWithFunction());
+    const secondDecode = formDefDecoder.parse(makeRawFormDefWithFunction());
+
+    expect(firstDecode.form.children[1].uid).toBe(secondDecode.form.children[1].uid);
+  });
+
+  it("marks the function widget uid with a final 'f' segment", () => {
+    const decoded = formDefDecoder.parse(makeRawFormDefWithFunction());
+    expect(decoded.form.children[1].uid).toBe('#0.1.f');
+  });
+
+  it('keeps the first uid when the same function object is decoded again at another position', () => {
+    const raw = makeRawFormDefWithFunction();
+    const sharedFunction = raw['form'].children[1];
+    formDefDecoder.parse(raw);
+
+    const rawWithFunctionFirst: Record<string, any> = {
+      form: { kind: 'layout', type: 'flex', children: [sharedFunction] },
+    };
+    const decoded = formDefDecoder.parse(rawWithFunctionFirst);
+
+    expect(decoded.form.children[0].uid).toBe('#0.1.f');
+  });
+
+  it('keeps a uid supplied by the widget the function returns', () => {
+    const raw: Record<string, any> = {
+      form: {
+        kind: 'layout',
+        type: 'flex',
+        children: [() => ({ kind: 'display', type: 'text', uid: 'explicitUid', props: {} })],
+      },
+    };
+    const decoded = formDefDecoder.parse(raw);
+
+    expect(decoded.form.children[0].uid).toBe('explicitUid');
+  });
+});

--- a/libs/core/src/lib/i18n.spec.ts
+++ b/libs/core/src/lib/i18n.spec.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { identityTranslator } from './i18n';
+
+describe('identityTranslator - default language', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('falls back to en-US when no navigator global exists (server runtimes)', () => {
+    vi.stubGlobal('navigator', undefined);
+    expect(identityTranslator().lang).toBe('en-US');
+  });
+
+  it('uses navigator.language when a navigator exists', () => {
+    vi.stubGlobal('navigator', { language: 'ca-ES' });
+    expect(identityTranslator().lang).toBe('ca-ES');
+  });
+
+  it('falls back to en-US when navigator.language is empty', () => {
+    vi.stubGlobal('navigator', { language: '' });
+    expect(identityTranslator().lang).toBe('en-US');
+  });
+
+  it('keeps an explicitly passed language', () => {
+    expect(identityTranslator('de-DE').lang).toBe('de-DE');
+  });
+});

--- a/libs/core/src/lib/i18n.ts
+++ b/libs/core/src/lib/i18n.ts
@@ -115,18 +115,16 @@ export function getDirectionFromLanguage(lang: string): 'ltr' | 'rtl' {
 }
 
 /**
- * Default no-op translator.
+ * Default translator used when no i18n system is configured. Returns every
+ * translation key unchanged, but still supports `setLang` and subscriber
+ * notifications.
  *
- * This implementation performs no localization and simply returns the
- * translation key unchanged. It is intended for use as a safe default
- * when no i18n system is configured while still supporting runtime language
- * changes and subscriber notifications.
- *
- * Call `setLang` to change the active language and notify any subscribed listeners.
- *
- * @param lang The initial BCP 47 language tag; defaults to `navigator.language || 'en-US'`.
+ * @param lang The initial BCP 47 language tag. Defaults to `navigator.language`
+ * when a navigator global exists, otherwise to 'en-US' (e.g. server runtimes)
  */
-export const identityTranslator = (lang = navigator.language || 'en-US'): MutableI18nTranslator => {
+export const identityTranslator = (
+  lang = typeof navigator !== 'undefined' ? navigator.language || 'en-US' : 'en-US',
+): MutableI18nTranslator => {
   const listeners = new Set<(lang: string) => void>();
 
   const translator: MutableI18nTranslator = {

--- a/libs/core/src/lib/utils/deterministic-uids.ts
+++ b/libs/core/src/lib/utils/deterministic-uids.ts
@@ -7,17 +7,12 @@ import {
 } from '../form-widget';
 
 /**
- * Assigns a position-based uid to every widget in the tree that has none.
- *
- * The generated format is a dot-separated index path prefixed with '#', with a
- * 't' segment for a repeater template, e.g. '#0.2.t.1' is the second template
- * child of the repeater found at position 2 of the root layout. The format must
- * never contain '[<digits>]' because repeater item uids append '[index]' and
- * are parsed back with a regex.
- *
- * @param root - The decoded root widget of a form. Widgets with an explicit uid
- * are left untouched, function widgets are skipped because the decoder assigns
- * their uid directly on the function object.
+ * Assigns a position-based uid to every widget in the tree that has none, e.g. '#0.2.t.1'
+ * (dot-separated indexes, 't' for a repeater template, a final 'f' for a function widget).
+ * The format must never contain '[<digits>]' because repeater item uids append '[index]'
+ * and are parsed back with a regex.
+ * A function widget's uid is written onto the function object itself, so a function reused
+ * across decodes keeps the uid of its first decode.
  *
  * @example
  * const decodedForm = formDefDecoder.parse(rawFormDef);
@@ -29,6 +24,11 @@ export function assignDeterministicUids(root: FormWidget<string>): void {
 
 function assignUidByPosition(widget: FormWidget<string>, positionUid: string): void {
   if (isFunctionWidget(widget)) {
+    // The 'f' segment keeps these uids separate from plain position uids: a function reused in a
+    // second form keeps its first-decode uid, which must not equal a position uid of that form.
+    if (!widget.uid) {
+      widget.uid = `${positionUid}.f`;
+    }
     return;
   }
   if (!widget.uid) {

--- a/libs/lit/src/lib/utils/define.ts
+++ b/libs/lit/src/lib/utils/define.ts
@@ -1,11 +1,10 @@
 /**
- * Defines a custom element only if the tag is not already registered.
- * First definition wins; never throws on re-registration (duplicate package
- * copies, HMR, or host apps that pre-register gui-* tags).
- * No-ops where customElements is unavailable (SSR / node).
+ * Single registration point for every GolemUI element, exposed to the gui-* packages
+ * via @golemui/lit/internals. First definition wins and re-registration never throws
+ * (duplicate package copies, HMR, pre-registered gui-* tags).
  *
- * Single source of truth for every GolemUI element registration; exposed to
- * the gui-* packages via @golemui/lit/internals.
+ * In Node with lit loaded, `customElements` is the @lit-labs/ssr-dom-shim registry,
+ * so registration is real there too.
  */
 export function safeDefine(tag: string, ctor: CustomElementConstructor): void {
   if (typeof customElements === 'undefined' || customElements.get(tag)) {


### PR DESCRIPTION
## Description

Two parts of core behaved differently on each process run:

1. Function widgets received a random uid during decode, so a server and a browser decoding the same form gave the same widget two different identities. They now get a position uid written once on the function object. Explicit uids are kept.
2. The default translator read `navigator.language` and crashed when no `navigator` global was present. It now uses `'en-US'` when `navigator` doesnt exist.
