### PR TITLE
feat(core): add widget preloading for synchronous component access

### DIFF
--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -4,7 +4,7 @@ import type * as justin from './types/subscript__justin';
 type _ = justin;
 
 export { FormContext } from './lib/context/form.context';
-export type { WidgetLoaders } from './lib/context/widget-registry';
+export { preloadFormWidgets, type WidgetLoaders } from './lib/context/widget-registry';
 export type { WithWidget } from './lib/context/with-widget.type';
 
 export { errorCodes } from './lib/errors';

--- a/libs/core/src/lib/context/widget-registry.spec.ts
+++ b/libs/core/src/lib/context/widget-registry.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { WidgetRegistry } from './widget-registry';
+import { preloadFormWidgets, WidgetRegistry } from './widget-registry';
 
 type FakeComponent = { name: string };
 
@@ -7,6 +7,7 @@ const makeLoader = (component: FakeComponent) => vi.fn(() => Promise.resolve(com
 
 function clearWidgetRegistryCache() {
   WidgetRegistry['sharedCache'].clear();
+  WidgetRegistry['resolvedCache'].clear();
 }
 
 describe('WidgetRegistry', () => {
@@ -121,5 +122,82 @@ describe('WidgetRegistry', () => {
     expect(registry.ready).toBe(false);
     registry.setWidgetLoaders({ text: makeLoader({ name: 'T' }) } as any);
     expect(registry.ready).toBe(true);
+  });
+
+  describe('preloading', () => {
+    it('getIfLoaded returns undefined before preloadWidgets, and the component after', async () => {
+      const component = { name: 'TextWidget' };
+      const registry = new WidgetRegistry<FakeComponent>();
+      registry.setWidgetLoaders({ text: makeLoader(component) } as any);
+
+      expect(registry.getIfLoaded('text')).toBeUndefined();
+      await registry.preloadWidgets();
+      expect(registry.getIfLoaded('text')).toBe(component);
+    });
+
+    it('getIfLoaded returns undefined for a widget type with no configured loader', () => {
+      const registry = new WidgetRegistry<FakeComponent>();
+      registry.setWidgetLoaders({ text: makeLoader({ name: 'T' }) } as any);
+
+      expect(registry.getIfLoaded('unknown')).toBeUndefined();
+    });
+
+    it('preloadWidgets with a subset loads only the given types', async () => {
+      const textLoader = makeLoader({ name: 'Text' });
+      const numberLoader = makeLoader({ name: 'Number' });
+      const registry = new WidgetRegistry<FakeComponent>();
+      registry.setWidgetLoaders({ text: textLoader, number: numberLoader } as any);
+
+      await registry.preloadWidgets(['text']);
+
+      expect(registry.getIfLoaded('text')).toEqual({ name: 'Text' });
+      expect(registry.getIfLoaded('number')).toBeUndefined();
+      expect(numberLoader).not.toHaveBeenCalled();
+    });
+
+    it('a failed loader rejects preloadWidgets, stores nothing, and stays retryable', async () => {
+      const component = { name: 'TextWidget' };
+      const loader = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('network error'))
+        .mockResolvedValueOnce(component);
+      const registry = new WidgetRegistry<FakeComponent>();
+      registry.setWidgetLoaders({ text: loader } as any);
+
+      await expect(registry.preloadWidgets()).rejects.toThrow('network error');
+      expect(registry.getIfLoaded('text')).toBeUndefined();
+
+      await registry.preloadWidgets();
+      expect(registry.getIfLoaded('text')).toBe(component);
+    });
+
+    it('preloading through one instance makes the component available to another instance with the same loader functions', async () => {
+      const component = { name: 'TextWidget' };
+      const loader = makeLoader(component);
+
+      const first = new WidgetRegistry<FakeComponent>();
+      first.setWidgetLoaders({ text: loader } as any);
+      await first.preloadWidgets();
+
+      const second = new WidgetRegistry<FakeComponent>();
+      second.setWidgetLoaders({ text: loader } as any);
+
+      expect(second.getIfLoaded('text')).toBe(component);
+      expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it('preloadFormWidgets loads every configured widget for registries created later', async () => {
+      const textLoader = makeLoader({ name: 'Text' });
+      const numberLoader = makeLoader({ name: 'Number' });
+      const widgetLoaders = { text: textLoader, number: numberLoader } as any;
+
+      await preloadFormWidgets({ widgetLoaders });
+
+      const registry = new WidgetRegistry<FakeComponent>();
+      registry.setWidgetLoaders(widgetLoaders);
+
+      expect(registry.getIfLoaded('text')).toEqual({ name: 'Text' });
+      expect(registry.getIfLoaded('number')).toEqual({ name: 'Number' });
+    });
   });
 });

--- a/libs/core/src/lib/context/widget-registry.ts
+++ b/libs/core/src/lib/context/widget-registry.ts
@@ -18,6 +18,11 @@ export class WidgetRegistry<ComponentType> {
    */
   private static sharedCache = new Map<() => Promise<any>, Promise<any>>();
 
+  // Resolved components, filled by preloadWidgets. Keyed by loader reference like sharedCache,
+  // so a preload through any instance (e.g. preloadFormWidgets) makes the components available
+  // to every instance configured with the same loader functions.
+  private static resolvedCache = new Map<() => Promise<any>, any>();
+
   private widgetLoaders: WidgetLoaders<ComponentType> = {} as WidgetLoaders<ComponentType>;
   private _ready = false;
 
@@ -44,4 +49,50 @@ export class WidgetRegistry<ComponentType> {
     }
     return WidgetRegistry.sharedCache.get(loader);
   }
+
+  /**
+   * Loads the given widget types (default: every configured type) and stores each
+   * resolved component for synchronous access through `getIfLoaded`.
+   * A failed loader rejects the returned promise, stores nothing, and stays retryable.
+   */
+  async preloadWidgets(types?: NonFunctionWidget['type'][]): Promise<void> {
+    const widgetTypes = types ?? Object.keys(this.widgetLoaders);
+    await Promise.all(
+      widgetTypes.map(async (type) => {
+        const component = await this.loadWidget(type);
+        WidgetRegistry.resolvedCache.set(this.widgetLoaders[type], component);
+      }),
+    );
+  }
+
+  /**
+   * Returns the resolved component for the given widget type, or `undefined` when it
+   * was never preloaded. Never starts a load.
+   */
+  getIfLoaded(widget: NonFunctionWidget['type']): ComponentType | undefined {
+    const loader = this.widgetLoaders[widget];
+    if (!loader) {
+      return undefined;
+    }
+    return WidgetRegistry.resolvedCache.get(loader);
+  }
+}
+
+/**
+ * Loads every widget component of a form config so that a later render can read
+ * them synchronously. Rendering a form in an environment that cannot wait for
+ * dynamic imports (a server render is one) requires this call to finish first.
+ *
+ * @param config - Any object that contains the `widgetLoaders` a form is
+ * configured with, e.g. a `FormInitConfig`.
+ * @example
+ * await preloadFormWidgets(config);
+ * // every widget component of `config.widgetLoaders` is now available synchronously
+ */
+export async function preloadFormWidgets<ComponentType>(config: {
+  widgetLoaders: WidgetLoaders<ComponentType>;
+}): Promise<void> {
+  const registry = new WidgetRegistry<ComponentType>();
+  registry.setWidgetLoaders(config.widgetLoaders);
+  await registry.preloadWidgets();
 }


### PR DESCRIPTION
## Description

Widget components load through dynamic imports. A render that cannot wait for an import like a server render had no way to get the component. `preloadFormWidgets(config)` loads every configured widget component in advance. A registry configured with the same loader functions then reads them synchronously through `getIfLoaded`. 

The async loading path is unchanged.
