### PR TITLE
feat(react): support server-side rendering of forms

### DIFF
--- a/apps/react-ssr-harness/eslint.config.mjs
+++ b/apps/react-ssr-harness/eslint.config.mjs
@@ -1,0 +1,3 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default [...baseConfig];

--- a/apps/react-ssr-harness/index.html
+++ b/apps/react-ssr-harness/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en" data-theme="auto">
+  <head>
+    <meta charset="utf-8" />
+    <title>GolemUI React server rendering harness</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/src/styles.scss" />
+  </head>
+  <body>
+    <div id="root"><!--app-html--></div>
+    <script type="module" src="/src/entry-client.tsx"></script>
+  </body>
+</html>

--- a/apps/react-ssr-harness/package.json
+++ b/apps/react-ssr-harness/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@golemui/react-ssr-harness",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module"
+}

--- a/apps/react-ssr-harness/project.json
+++ b/apps/react-ssr-harness/project.json
@@ -1,0 +1,39 @@
+{
+  "name": "react-ssr-harness",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "apps/react-ssr-harness/src",
+  "tags": ["scope:app", "type:app"],
+  "// targets": "to see all targets run: nx show project react-ssr-harness --web",
+  "targets": {
+    "build": {
+      "dependsOn": ["build-server"]
+    },
+    "build-server": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "outputs": ["{workspaceRoot}/dist/apps/react-ssr-harness/server"],
+      "dependsOn": ["^build"],
+      "options": {
+        "cwd": "apps/react-ssr-harness",
+        "command": "npx vite build --ssr src/entry-server.tsx"
+      }
+    },
+    "serve-ssr": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "node apps/react-ssr-harness/server.mjs"
+      }
+    },
+    "serve-ssr-prod": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["build"],
+      "options": {
+        "command": "node apps/react-ssr-harness/server.mjs --production"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
+}

--- a/apps/react-ssr-harness/server.mjs
+++ b/apps/react-ssr-harness/server.mjs
@@ -1,0 +1,87 @@
+import { createServer as createHttpServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { dirname, extname, join, normalize } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Minimal server for the harness. Development uses vite in middleware mode.
+// Production reads the two build outputs.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const clientDir = join(here, '../../dist/apps/react-ssr-harness/client');
+const serverEntry = join(here, '../../dist/apps/react-ssr-harness/server/entry-server.js');
+const isProduction = process.argv.includes('--production');
+const port = Number(process.env.PORT ?? 3601);
+
+const contentTypes = {
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.css': 'text/css',
+  '.svg': 'image/svg+xml',
+  '.woff2': 'font/woff2',
+  '.json': 'application/json',
+};
+
+const send = (res, status, body, contentType = 'text/html') => {
+  res.writeHead(status, { 'Content-Type': contentType });
+  res.end(body);
+};
+
+const sendError = (res, error) => {
+  console.error(error);
+  send(res, 500, String(error?.stack ?? error), 'text/plain');
+};
+
+async function startDevelopment() {
+  const { createServer } = await import('vite');
+  const vite = await createServer({
+    configFile: join(here, 'vite.config.mts'),
+    server: { middlewareMode: true },
+    appType: 'custom',
+  });
+
+  return createHttpServer((req, res) => {
+    vite.middlewares(req, res, async () => {
+      try {
+        const template = await vite.transformIndexHtml(
+          req.url,
+          await readFile(join(here, 'index.html'), 'utf-8'),
+        );
+        const { render } = await vite.ssrLoadModule('/src/entry-server.tsx');
+        send(res, 200, template.replace('<!--app-html-->', await render()));
+      } catch (error) {
+        vite.ssrFixStacktrace(error);
+        sendError(res, error);
+      }
+    });
+  });
+}
+
+async function startProduction() {
+  const template = await readFile(join(clientDir, 'index.html'), 'utf-8');
+  const { render } = await import(serverEntry);
+
+  return createHttpServer(async (req, res) => {
+    try {
+      const path = normalize(decodeURIComponent(new URL(req.url, 'http://localhost').pathname));
+      const asset = join(clientDir, path);
+
+      if (path !== '/' && asset.startsWith(clientDir)) {
+        const file = await readFile(asset).catch(() => null);
+        if (file) {
+          send(res, 200, file, contentTypes[extname(asset)] ?? 'application/octet-stream');
+          return;
+        }
+      }
+
+      send(res, 200, template.replace('<!--app-html-->', await render()));
+    } catch (error) {
+      sendError(res, error);
+    }
+  });
+}
+
+const server = isProduction ? await startProduction() : await startDevelopment();
+server.listen(port, () => {
+  const mode = isProduction ? 'production' : 'development';
+  console.log(`react-ssr-harness (${mode}) on http://localhost:${port}`);
+});

--- a/apps/react-ssr-harness/src/App.tsx
+++ b/apps/react-ssr-harness/src/App.tsx
@@ -1,0 +1,87 @@
+import type { FormSubmitEvent } from '@golemui/core';
+import { gui, type DxDefinitionItem, type GuiFormInitConfig } from '@golemui/gui-shared';
+import { GuiForm } from '@golemui/gui-react';
+import { useEffect, useState } from 'react';
+
+// The same form as the Vue harness, so the two SSR harnesses stay directly comparable.
+// No tabs, no markdown, and no calendar, so the render does not depend on the server
+// clock. The widget internals are not server rendered, so each field only becomes usable
+// once Lit upgrades its custom element.
+const formDef: DxDefinitionItem[] = [
+  gui.layouts.flex(
+    [
+      gui.inputs.textInput('firstName', {
+        label: 'First name',
+        placeholder: 'Ada',
+        validator: { required: true, minLength: 2 },
+      }),
+      gui.inputs.textInput('lastName', {
+        label: 'Last name',
+        placeholder: 'Lovelace',
+        validator: { required: true, minLength: 2 },
+      }),
+    ],
+    { direction: 'row', gap: 16 },
+  ),
+  gui.inputs.numberInput('seats', {
+    label: 'Seats',
+    validator: { required: true, minimum: 1 },
+  }),
+  gui.inputs.select('plan', {
+    label: 'Plan',
+    options: [
+      { value: 'free', label: 'Free' },
+      { value: 'pro', label: 'Pro' },
+      { value: 'enterprise', label: 'Enterprise' },
+    ],
+    validator: { type: 'string', required: true },
+  }),
+  gui.inputs.checkbox('acceptTerms', {
+    label: 'I accept the terms',
+    validator: { required: true },
+  }),
+  gui.actions.button({
+    label: 'Create account',
+    actionType: 'submit',
+  }),
+];
+
+// An explicit formName keeps the form id identical on the server and the client.
+const config: GuiFormInitConfig = {
+  formName: 'harness-form',
+  formDef,
+  data: {
+    firstName: 'Ada',
+    lastName: 'Lovelace',
+    seats: 3,
+    plan: 'pro',
+    acceptTerms: false,
+  },
+};
+
+const onFormSubmit = (event: FormSubmitEvent) => {
+  console.log('form submitted', event.data);
+};
+
+export function App() {
+  // Starts false so the first client render matches the server markup. The effect runs
+  // after hydration, so the status text changes only after hydration has finished.
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  return (
+    <div className="harness">
+      <h1 className="harness__title">React server rendering harness</h1>
+      <p className="harness__status" data-hydrated={hydrated}>
+        {hydrated ? 'Hydrated on the client' : 'Server HTML, not yet hydrated'}
+      </p>
+      <p className="harness__note">
+        The React layer is server rendered. The widget internals are not, so every gui-* element
+        arrives empty and Lit fills it in when the browser upgrades it. View source to see it.
+      </p>
+      <GuiForm config={config} formSubmit={onFormSubmit} />
+    </div>
+  );
+}

--- a/apps/react-ssr-harness/src/entry-client.tsx
+++ b/apps/react-ssr-harness/src/entry-client.tsx
@@ -1,0 +1,18 @@
+import { preloadFormWidgets } from '@golemui/core';
+import { widgetLoaders } from '@golemui/gui-react';
+import { hydrateRoot } from 'react-dom/client';
+import { App } from './App';
+
+// The preload has to finish before hydration, or the client's first render would place
+// an empty tree over server markup that is not empty.
+// styles.scss is linked from index.html, so the page is styled with JavaScript disabled.
+preloadFormWidgets({ widgetLoaders }).then(() => {
+  const container = document.getElementById('root');
+  if (!container) {
+    throw new Error('The root element is missing from index.html');
+  }
+  hydrateRoot(container, <App />, {
+    // Logs hydration mismatches to the console, where the harness check looks.
+    onRecoverableError: (error) => console.error(error),
+  });
+});

--- a/apps/react-ssr-harness/src/entry-server.tsx
+++ b/apps/react-ssr-harness/src/entry-server.tsx
@@ -1,0 +1,15 @@
+import { preloadFormWidgets } from '@golemui/core';
+import { widgetLoaders } from '@golemui/gui-react';
+import { renderToString } from 'react-dom/server';
+import { App } from './App';
+
+/**
+ * Renders the harness form to a string. Called once per request by server.mjs.
+ *
+ * The preload has to finish before the render: the server cannot await a dynamic
+ * import while producing a string.
+ */
+export async function render(): Promise<string> {
+  await preloadFormWidgets({ widgetLoaders });
+  return renderToString(<App />);
+}

--- a/apps/react-ssr-harness/src/styles.scss
+++ b/apps/react-ssr-harness/src/styles.scss
@@ -1,0 +1,41 @@
+@use '../../../libs/gui/components/src/styles/index';
+
+html,
+body {
+  background-color: var(--gui-bg-default);
+  font-family: system-ui, sans-serif;
+  margin: 0;
+}
+
+.harness {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.harness__title {
+  font-size: 1.25rem;
+  margin: 0 0 1rem 0;
+}
+
+.harness__status {
+  font-family: ui-monospace, monospace;
+  font-size: var(--gui-font-sm);
+  margin: 0 0 0.5rem 0;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--gui-border-default);
+  border-radius: var(--gui-radius-md);
+  background-color: var(--gui-bg-surface);
+  color: var(--gui-text-default);
+}
+
+.harness__status[data-hydrated='true'] {
+  border-color: var(--gui-intent-primary);
+  color: var(--gui-intent-primary);
+}
+
+.harness__note {
+  font-size: var(--gui-font-sm);
+  color: var(--gui-text-muted);
+  margin: 0 0 1.5rem 0;
+}

--- a/apps/react-ssr-harness/tsconfig.app.json
+++ b/apps/react-ssr-harness/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["node", "vite/client"]
+  },
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/apps/react-ssr-harness/tsconfig.json
+++ b/apps/react-ssr-harness/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ESNext", "DOM"],
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "skipLibCheck": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
+}

--- a/apps/react-ssr-harness/vite.config.mts
+++ b/apps/react-ssr-harness/vite.config.mts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+
+// One config for both builds of the harness.
+// `vite build` emits the client bundle plus an index.html that already links the hashed
+// script and style, which is what the production server uses as its template.
+// `vite build --ssr src/entry-server.tsx` emits the server bundle. Vite sets isSsrBuild for it.
+export default defineConfig(({ isSsrBuild }) => ({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/apps/react-ssr-harness',
+  plugins: [react(), nxViteTsPaths()],
+  build: {
+    outDir: isSsrBuild
+      ? '../../dist/apps/react-ssr-harness/server'
+      : '../../dist/apps/react-ssr-harness/client',
+    emptyOutDir: true,
+    reportCompressedSize: !isSsrBuild,
+    commonjsOptions: { transformMixedEsModules: true },
+  },
+}));

--- a/libs/gui/react/src/lib/web-components.ts
+++ b/libs/gui/react/src/lib/web-components.ts
@@ -42,7 +42,29 @@ const wrap = <
   tagName: string,
   elementClass: { new (): I },
   events?: E,
-) => createComponent({ react: React, tagName, elementClass, events });
+) => {
+  const LitComponent = createComponent({ react: React, tagName, elementClass, events });
+  type LitComponentProps = React.ComponentProps<typeof LitComponent>;
+
+  // The `defer-hydration` attribute keeps a server-rendered element empty until React has
+  // hydrated it (the element renders into light DOM, so an early Lit render would add
+  // children the server markup does not have and hydration would fail on them). It is an
+  // unknown non-event prop, so it reaches the markup as an attribute on the server and
+  // the client alike, and the @lit/react wrapper removes it right after mount. In a
+  // client-only app the removal happens in the same commit the element connects in, so
+  // the first Lit render stays on its usual schedule.
+  const WithDeferredHydration = React.forwardRef<I, LitComponentProps>(
+    function WithDeferredHydration(props, ref) {
+      return React.createElement(LitComponent, {
+        ...props,
+        ref,
+        'defer-hydration': '',
+      } as LitComponentProps);
+    },
+  );
+  WithDeferredHydration.displayName = `WithDeferredHydration(${tagName})`;
+  return WithDeferredHydration;
+};
 
 export const GuiTextinputReact = wrap('gui-textinput', GuiTextinput, {
   onInput: 'input',

--- a/libs/gui/react/src/lib/widget.loaders.spec.ts
+++ b/libs/gui/react/src/lib/widget.loaders.spec.ts
@@ -1,0 +1,17 @@
+import { preloadFormWidgets } from '@golemui/core';
+import { describe, expect, it } from 'vitest';
+import { widgetLoaders } from './widget.loaders';
+
+describe('preloading the gui widget set outside a browser', () => {
+  it('resolves every widget module in a plain node environment', async () => {
+    await expect(preloadFormWidgets({ widgetLoaders })).resolves.toBeUndefined();
+  });
+
+  it('defines a loader function for every widget type', () => {
+    const missing = Object.entries(widgetLoaders)
+      .filter(([, loader]) => typeof loader !== 'function')
+      .map(([type]) => type);
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/libs/gui/react/vite.config.ts
+++ b/libs/gui/react/vite.config.ts
@@ -48,6 +48,12 @@ export default defineConfig(() => ({
       fileName: 'index',
     },
     rollupOptions: {
+      output: {
+        // Marks the published ES entry as a client module for React Server Component
+        // bundlers (Next.js App Router). Has no effect anywhere else. Minification
+        // removes it from the UMD file, which no RSC bundler reads.
+        banner: '"use client";',
+      },
       external: [
         'react',
         'react-dom',

--- a/libs/lit/src/lib/utils/define.spec.ts
+++ b/libs/lit/src/lib/utils/define.spec.ts
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { html, LitElement } from 'lit';
 import { describe, expect, it } from 'vitest';
 import { safeDefine } from './define';
 
@@ -15,5 +16,67 @@ describe('safeDefine', () => {
     safeDefine('x-safe-define-collision', A);
     expect(() => safeDefine('x-safe-define-collision', B)).not.toThrow();
     expect(customElements.get('x-safe-define-collision')).toBe(A);
+  });
+});
+
+describe('safeDefine defer-hydration support', () => {
+  // A light-DOM element like every GolemUI component, with one reactive property.
+  class DeferSpecBase extends LitElement {
+    static override properties = { label: {} };
+    declare label: string;
+
+    constructor() {
+      super();
+      this.label = 'initial';
+    }
+
+    override createRenderRoot() {
+      return this;
+    }
+
+    override render() {
+      return html`<span>${this.label}</span>`;
+    }
+  }
+
+  // Lit renders on a microtask, a macrotask always runs after it.
+  const afterLitRenderSchedule = () => new Promise((resolve) => setTimeout(resolve));
+
+  it('renders on the usual schedule when the attribute is absent', async () => {
+    safeDefine('x-defer-absent', class extends DeferSpecBase {});
+    const element = document.createElement('x-defer-absent');
+    document.body.appendChild(element);
+
+    await afterLitRenderSchedule();
+
+    expect(element.querySelector('span')?.textContent).toBe('initial');
+  });
+
+  it('holds rendering while the attribute is present and renders on removal', async () => {
+    safeDefine('x-defer-held', class extends DeferSpecBase {});
+    const element = document.createElement('x-defer-held') as DeferSpecBase;
+    element.setAttribute('defer-hydration', '');
+    document.body.appendChild(element);
+    // Set while held, so the first render must already contain it.
+    element.label = 'set before the removal';
+
+    await afterLitRenderSchedule();
+    expect(element.childElementCount).toBe(0);
+
+    element.removeAttribute('defer-hydration');
+    await afterLitRenderSchedule();
+
+    expect(element.querySelector('span')?.textContent).toBe('set before the removal');
+  });
+
+  it('keeps a parsed element empty when the definition arrives after the markup', async () => {
+    // The hydration flow: server markup first, the element module loads later.
+    document.body.innerHTML = '<x-defer-parsed defer-hydration></x-defer-parsed>';
+    safeDefine('x-defer-parsed', class extends DeferSpecBase {});
+    const element = document.body.querySelector('x-defer-parsed');
+
+    await afterLitRenderSchedule();
+
+    expect(element?.childElementCount).toBe(0);
   });
 });

--- a/libs/lit/src/lib/utils/define.ts
+++ b/libs/lit/src/lib/utils/define.ts
@@ -10,5 +10,68 @@ export function safeDefine(tag: string, ctor: CustomElementConstructor): void {
   if (typeof customElements === 'undefined' || customElements.get(tag)) {
     return; // TODO: dev-mode collision warn once isDevMode() is exported from @golemui/core
   }
+  supportDeferHydrationAttribute(ctor);
   customElements.define(tag, ctor);
+}
+
+const deferHydrationPatched = new WeakSet<CustomElementConstructor>();
+
+type PatchablePrototype = HTMLElement & {
+  connectedCallback?(): void;
+  attributeChangedCallback?(name: string, oldValue: string | null, value: string | null): void;
+};
+
+/**
+ * Implements the `defer-hydration` community protocol: an element that connects with a
+ * `defer-hydration` attribute does not render until the attribute is removed.
+ *
+ * The elements render into light DOM, so without this an element that upgrades between
+ * a server render and the framework's hydration pass fills itself with children the
+ * server markup did not have, and hydration fails on the extra nodes. A hydration
+ * entry point renders the attribute into the markup and removes it after hydration
+ * (the @lit/react wrappers already remove it on mount). Nothing sets the attribute in
+ * a client-only app, where this changes nothing.
+ *
+ * Installed here because upgrades of already-parsed elements run inside
+ * `customElements.define`, so a later patch would miss the first connection.
+ */
+function supportDeferHydrationAttribute(ctor: CustomElementConstructor): void {
+  if (deferHydrationPatched.has(ctor)) {
+    return;
+  }
+  deferHydrationPatched.add(ctor);
+
+  // `observedAttributes` is read once by `customElements.define`, right after this runs.
+  const staticSide = ctor as CustomElementConstructor & { observedAttributes?: string[] };
+  const observedAttributes = [...(staticSide.observedAttributes ?? [])];
+  Object.defineProperty(ctor, 'observedAttributes', {
+    configurable: true,
+    get: () => [...observedAttributes, 'defer-hydration'],
+  });
+
+  const prototype = ctor.prototype as PatchablePrototype;
+  const originalConnectedCallback = prototype.connectedCallback;
+  const originalAttributeChangedCallback = prototype.attributeChangedCallback;
+
+  prototype.connectedCallback = function (this: PatchablePrototype) {
+    if (this.hasAttribute('defer-hydration')) {
+      return;
+    }
+    originalConnectedCallback?.call(this);
+  };
+
+  prototype.attributeChangedCallback = function (
+    this: PatchablePrototype,
+    name: string,
+    oldValue: string | null,
+    value: string | null,
+  ) {
+    if (name === 'defer-hydration') {
+      if (value === null && this.isConnected) {
+        originalConnectedCallback?.call(this);
+      }
+      return;
+    }
+    originalAttributeChangedCallback?.call(this, name, oldValue, value);
+  };
 }

--- a/libs/react/react18-test-setup.ts
+++ b/libs/react/react18-test-setup.ts
@@ -1,0 +1,25 @@
+import Module from 'node:module';
+
+/**
+ * Runtime part of the REACT18=1 version lock.
+ *
+ * The vite alias rewrites the `react` and `react-dom` imports in transformed source, but
+ * vitest loads node_modules natively, so the `require('react')` calls inside the
+ * `react18` and `react18-dom` packages still resolve to the hoisted React 19 and the two
+ * versions crash on each other's internals. This hook redirects exactly those calls to
+ * the `react18` package, which keeps a single React 18 instance across the whole run.
+ */
+const moduleInternals = Module as unknown as {
+  _resolveFilename: (request: string, parent: { filename?: string }, ...rest: unknown[]) => string;
+};
+
+const originalResolveFilename = moduleInternals._resolveFilename;
+const isInsideReact18Package = (filename: string | undefined) =>
+  filename !== undefined && /node_modules\/react18(-dom)?\//.test(filename);
+
+moduleInternals._resolveFilename = function (request, parent, ...rest) {
+  if (request === 'react' && isInsideReact18Package(parent?.filename)) {
+    return originalResolveFilename.call(this, 'react18', parent, ...rest);
+  }
+  return originalResolveFilename.call(this, request, parent, ...rest);
+};

--- a/libs/react/src/lib/FormComponent.tsx
+++ b/libs/react/src/lib/FormComponent.tsx
@@ -7,11 +7,19 @@ import {
   type ValidatorFn,
   type WithWidget,
   getDirectionFromLanguage,
-  shortUUID,
   type FormSubmitEvent,
 } from '@golemui/core';
 import { type FormInitConfig } from '@golemui/core';
-import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import {
+  forwardRef,
+  useEffect,
+  useId,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 import { DefaultFormHealthBoundary, type FormHealthBoundary } from './FormHealthBoundary';
 import { ReactFormContextProvider } from './ReactFormContextProvider';
 import WidgetErrorBoundary from './WidgetErrorBoundary';
@@ -33,115 +41,195 @@ export interface FormComponentProps {
   autocomplete?: string;
 }
 
+type WidgetComponent = React.ComponentType<WithWidget>;
+
+/**
+ * Everything one store initialization produces, kept in one state value so the tree key,
+ * the provider value, and the subscriptions can never mix two initializations.
+ */
+type FormInstance = {
+  context: FormContext<WidgetComponent>;
+  store: FormContext<WidgetComponent>['store'];
+  /** The React key of the widget tree. Every initialization increments it, so the whole
+   * tree is destroyed and recreated and every widget subscribes to the store INITIALIZE
+   * ran on. */
+  generation: number;
+  /** The exact prop identities this instance was initialized with, compared by the reinit effect. */
+  config: FormInitConfig<WidgetComponent>;
+  validators: ValidatorFn<any>;
+  subscribe: (onStoreChange: () => void) => () => void;
+  getFormLayout: () => LayoutWidget<string>;
+  getLang: () => string;
+  getHealthError: () => FormHealth | null;
+};
+
+function createFormInstance(
+  config: FormInitConfig<WidgetComponent>,
+  validators: ValidatorFn<any>,
+  formName: string,
+  generation: number,
+): FormInstance {
+  const context = new FormContext<WidgetComponent>();
+  context.initialize(
+    config.widgetLoaders,
+    config.middlewares ?? [],
+    validators,
+    config.validateOn ?? 'eager',
+    config.itemRenderers ?? {},
+    config.localization,
+    config.dependencies ?? {},
+    config.functions ?? {},
+  );
+  // Dispatching during render is safe here: the store was created one line above and has
+  // no subscribers yet, so these stay private to this instance. Running init in render
+  // (not in an effect) is what gives a server render a populated store.
+  const store = context.store;
+  store.dispatch({ type: 'INITIALIZE', payload: { formName, formDef: config.formDef } });
+  store.dispatch({ type: 'SET_DATA', payload: { data: config.data ?? {} } });
+  store.dispatch({ type: 'SET_META', payload: { meta: config.meta ?? {} } });
+
+  // While a derive error is active the reducer allocates a new errored object on every
+  // dispatch, so the snapshot returns the cached one while message and code are unchanged.
+  let lastHealthError: FormHealth | null = null;
+
+  return {
+    context,
+    store,
+    generation,
+    config,
+    validators,
+    subscribe: (onStoreChange) => {
+      const subscription = store.state$.subscribe(onStoreChange);
+      return () => subscription.unsubscribe();
+    },
+    getFormLayout: () => store.getState().formDef.form,
+    getLang: () => store.getState().lang,
+    getHealthError: () => {
+      const health = store.getState().formHealth;
+      if (health.status !== 'errored') {
+        lastHealthError = null;
+        return null;
+      }
+      const isSameError =
+        lastHealthError?.status === 'errored' &&
+        lastHealthError.message === health.message &&
+        lastHealthError.code === health.code;
+      if (!isSameError) {
+        lastHealthError = health;
+      }
+      return lastHealthError;
+    },
+  };
+}
+
+// Effects never run during a server render, and renderToString warns on useLayoutEffect.
+const useBrowserLayoutEffect = typeof document === 'undefined' ? useEffect : useLayoutEffect;
+
 export const FormComponent = forwardRef<FormComponentHandle, FormComponentProps>(
   function FormComponent(
     { config, validators, formHealth, formEvent, formSubmit, formHealthBoundary, autocomplete },
     ref,
   ) {
-    const formContextRef = useRef<FormContext<React.ComponentType<WithWidget>>>(new FormContext());
-    const formNameRef = useRef<string>(config.formName ?? shortUUID());
-    const [formLayoutField, setFormLayoutField] = useState<LayoutWidget<string> | null>(null);
-    const [healthError, setHealthError] = useState<FormHealth | null>(null);
-    const [direction, setDirection] = useState<'ltr' | 'rtl'>('ltr');
-    // Keys the widget tree. Every initialization bumps it, so the whole tree is destroyed
-    // and recreated and every widget subscribes to the store INITIALIZE ran on.
-    const [treeGeneration, setTreeGeneration] = useState(0);
+    // useId gives the same id on the server and the hydrating client, so an omitted
+    // formName still produces matching markup. Computed once at mount and never updated,
+    // like every formName.
+    const generatedFormName = useId();
+    const [formName] = useState(() => config.formName ?? generatedFormName);
+    const [instance, setInstance] = useState(() =>
+      createFormInstance(config, validators, formName, 0),
+    );
 
     const callbacksRef = useRef({ formHealth, formEvent, formSubmit });
     callbacksRef.current = { formHealth, formEvent, formSubmit };
 
-    useEffect(() => {
-      const context = formContextRef.current;
-      context.initialize(
-        config.widgetLoaders,
-        config.middlewares ?? [],
-        validators,
-        config.validateOn ?? 'eager',
-        config.itemRenderers ?? {},
-        config.localization,
-        config.dependencies ?? {},
-        config.functions ?? {},
-      );
-      context.store.dispatch({
-        type: 'INITIALIZE',
-        payload: { formName: formNameRef.current, formDef: config.formDef },
-      });
-      context.store.dispatch({ type: 'SET_DATA', payload: { data: config.data ?? {} } });
-      context.store.dispatch({ type: 'SET_META', payload: { meta: config.meta ?? {} } });
-      setTreeGeneration((generation) => generation + 1);
-      setDirection(getDirectionFromLanguage(context.localization.lang));
+    const formLayoutField = useSyncExternalStore(
+      instance.subscribe,
+      instance.getFormLayout,
+      instance.getFormLayout,
+    );
+    const lang = useSyncExternalStore(instance.subscribe, instance.getLang, instance.getLang);
+    const healthError = useSyncExternalStore(
+      instance.subscribe,
+      instance.getHealthError,
+      instance.getHealthError,
+    );
+    const direction = getDirectionFromLanguage(lang);
 
-      const stateSub = context.store.state$.subscribe((state) => {
-        setFormLayoutField(state.formDef.form);
-        setDirection(getDirectionFromLanguage(context.localization.lang));
-      });
-      const healthSub = watchFormHealth(context.store.state$).subscribe((health) => {
-        setHealthError(health.status === 'errored' ? health : null);
+    // Reinit only when the config or validators object identity changes. The run after the
+    // first mount compares the identities the lazy initializer recorded and does nothing.
+    // Creation stays outside the setState updater, which has to be pure.
+    useEffect(() => {
+      if (instance.config === config && instance.validators === validators) {
+        return;
+      }
+      setInstance(createFormInstance(config, validators, formName, instance.generation + 1));
+    }, [config, validators, formName, instance]);
+
+    // Layout effect on purpose: the widget tree mounts in the same commit and emits its
+    // `load` events from passive effects, which run after every layout effect. A passive
+    // subscription here would subscribe too late and lose those events.
+    useBrowserLayoutEffect(() => {
+      const eventSub = instance.context.events$.subscribe((event) =>
+        callbacksRef.current.formEvent?.(event),
+      );
+      const submitSub = instance.context.submit$.subscribe((event) =>
+        callbacksRef.current.formSubmit?.(event),
+      );
+      const healthSub = watchFormHealth(instance.store.state$).subscribe((health) => {
         if (health.status === 'errored') {
           console.error('GolemUI form failed to initialize:', health.message);
         }
         callbacksRef.current.formHealth?.(health);
       });
-      const unsubscribeI18n = context.localization.subscribe((lang) => {
-        setDirection(getDirectionFromLanguage(lang));
-        context.store.dispatch({ type: 'SET_LANGUAGE', payload: { lang } });
-      });
-
-      return () => {
-        stateSub.unsubscribe();
-        healthSub.unsubscribe();
-        unsubscribeI18n();
-      };
-    }, [config, validators]);
-
-    useEffect(() => {
-      const context = formContextRef.current;
-      const eventSub = context.events$.subscribe((event) =>
-        callbacksRef.current.formEvent?.(event),
-      );
-      const submitSub = context.submit$.subscribe((event) =>
-        callbacksRef.current.formSubmit?.(event),
-      );
       return () => {
         eventSub.unsubscribe();
         submitSub.unsubscribe();
+        healthSub.unsubscribe();
       };
-    }, []);
+    }, [instance]);
+
+    // Browser-only subscription: a language change reaches the render through the store.
+    useEffect(() => {
+      const unsubscribeI18n = instance.context.localization.subscribe((newLang) => {
+        instance.store.dispatch({ type: 'SET_LANGUAGE', payload: { lang: newLang } });
+      });
+      return () => unsubscribeI18n();
+    }, [instance]);
 
     useImperativeHandle(
       ref,
       () => ({
         setData: (data) => {
-          formContextRef.current.store.dispatch({ type: 'SET_DATA', payload: { data } });
+          instance.store.dispatch({ type: 'SET_DATA', payload: { data } });
         },
         setMeta: (meta) => {
-          formContextRef.current.store.dispatch({ type: 'SET_META', payload: { meta } });
+          instance.store.dispatch({ type: 'SET_META', payload: { meta } });
         },
       }),
-      [],
+      [instance],
     );
 
     const onFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
       e.preventDefault();
-      formContextRef.current.emitSubmitEvent();
+      instance.context.emitSubmitEvent();
     };
 
     // Always render the form inside the boundary so a recovered health clears the error in place.
     const Boundary = formHealthBoundary ?? DefaultFormHealthBoundary;
 
     return (
-      <ReactFormContextProvider formContext={formContextRef.current}>
+      <ReactFormContextProvider formContext={instance.context}>
         <Boundary health={healthError ?? { status: 'ok' }}>
           <div className="gui-form">
             <form
-              id={formNameRef.current}
+              id={formName}
               noValidate
               dir={direction}
               autoComplete={autocomplete}
               onSubmit={onFormSubmit}
             >
               {formLayoutField && (
-                <WidgetErrorBoundary key={treeGeneration} widget={formLayoutField}>
+                <WidgetErrorBoundary key={instance.generation} widget={formLayoutField}>
                   <WidgetRenderer widget={formLayoutField} />
                 </WidgetErrorBoundary>
               )}

--- a/libs/react/src/lib/WidgetRenderer.tsx
+++ b/libs/react/src/lib/WidgetRenderer.tsx
@@ -12,16 +12,23 @@ type WidgetComponent = React.ComponentType<WithWidget>;
 // Repeater rows and layout children arrive from the store with their row indexes already applied to `uid` and `path`, so the renderer takes the widget as it is
 function WidgetRenderer(props: Props) {
   const { formContext } = useReactFormContext();
-  const [Component, setComponent] = useState<WidgetComponent | null>(null);
+  const [asyncLoadedComponent, setAsyncLoadedComponent] = useState<WidgetComponent | null>(null);
   const isMounted = useRef(true);
 
+  // Read synchronously so the very first render already shows the widget. A server render
+  // never runs effects and cannot await the dynamic import.
+  const preloadedComponent = formContext.widgetRegistry.getIfLoaded(props.widget.type) ?? null;
+
   useEffect(() => {
+    if (formContext.widgetRegistry.getIfLoaded(props.widget.type)) {
+      return;
+    }
     isMounted.current = true;
     const loadComponent = async () => {
       try {
         const loadedComponent = await formContext.widgetRegistry.loadWidget(props.widget.type);
         if (isMounted.current) {
-          setComponent(() => loadedComponent);
+          setAsyncLoadedComponent(() => loadedComponent);
         }
       } catch {
         const code = errorCodes.widgetCouldNotBeLoaded;
@@ -44,6 +51,7 @@ function WidgetRenderer(props: Props) {
     };
   }, [props.widget, formContext.widgetRegistry, formContext.store]);
 
+  const Component = preloadedComponent ?? asyncLoadedComponent;
   if (!Component) {
     return null;
   }

--- a/libs/react/src/lib/hooks/internal/use-widget-view-model.ts
+++ b/libs/react/src/lib/hooks/internal/use-widget-view-model.ts
@@ -1,0 +1,65 @@
+import {
+  createWidgetViewModelReader,
+  type FormContext,
+  type WidgetViewModel,
+  type WithWidget,
+} from '@golemui/core';
+import { useMemo, useState, useSyncExternalStore } from 'react';
+
+type FormStore = FormContext<React.ComponentType<WithWidget>>['store'];
+type Uid = WidgetViewModel['uid'];
+
+/**
+ * Reads one widget's view model from the store with `useSyncExternalStore`, so the value
+ * is available during the first render (a server render has no other chance to read it).
+ * The memoizing reader returns the identical object until one of the widget's state
+ * slices changes, which is what makes the snapshot `Object.is`-comparable.
+ */
+export function useWidgetViewModel<T = unknown>(store: FormStore, uid: Uid): WidgetViewModel<T> {
+  // Created once and kept for the hook instance's whole lifetime. Its cache is keyed by
+  // uid, so a repeater-row uid change just adds an entry, and a store replacement
+  // remounts the tree anyway.
+  const [readViewModel] = useState(() => createWidgetViewModelReader());
+
+  const subscribe = useMemo(
+    () => (onStoreChange: () => void) => {
+      const subscription = store.state$.subscribe(onStoreChange);
+      return () => subscription.unsubscribe();
+    },
+    [store],
+  );
+
+  const getSnapshot = () => readViewModel<T>(store.getState(), uid);
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/**
+ * Accumulates a per-widget render value across view-model changes. The widget hooks need
+ * this because a hidden widget has no calculated widget, and the last visible values must
+ * stay on screen.
+ *
+ * This is React's "adjusting state when props change" pattern: the state update happens
+ * during render, never in an effect, so the first render (the only render on a server)
+ * already returns the fully accumulated result.
+ *
+ * @param viewModel - The current view model, reference-stable between changes.
+ * @param accumulate - Combines the previous result (or `undefined` on the first render)
+ * with the current view model. Runs exactly once per distinct view model.
+ * @returns The accumulated result for the current view model.
+ */
+export function useViewModelAccumulator<Result>(
+  viewModel: WidgetViewModel,
+  accumulate: (previous: Result | undefined, viewModel: WidgetViewModel) => Result,
+): Result {
+  const [accumulated, setAccumulated] = useState(() => ({
+    viewModel,
+    result: accumulate(undefined, viewModel),
+  }));
+
+  let result = accumulated.result;
+  if (accumulated.viewModel !== viewModel) {
+    result = accumulate(accumulated.result, viewModel);
+    setAccumulated({ viewModel, result });
+  }
+  return result;
+}

--- a/libs/react/src/lib/hooks/useActionWidget.ts
+++ b/libs/react/src/lib/hooks/useActionWidget.ts
@@ -1,28 +1,30 @@
-import { type ActionWidget, widgetViewModel$ } from '@golemui/core';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { type ActionWidget } from '@golemui/core';
+import { useCallback, useEffect, useRef } from 'react';
 import { useReactFormContext } from '../ReactFormContext';
 import { mergeViewModelIntoTemplateData, type WithFlattenedProps } from './internal/template-data';
+import { useViewModelAccumulator, useWidgetViewModel } from './internal/use-widget-view-model';
+
+type ActionTemplateData<ExtraProps extends Record<string, any>> = WithFlattenedProps<
+  ActionWidget<string>,
+  ExtraProps
+> & { invalid?: boolean };
 
 export function useActionWidget<ExtraProps extends Record<string, any>>(
   widget: ActionWidget<string>,
 ) {
   const { formContext } = useReactFormContext();
-  const [templateData, setTemplateData] = useState(
-    {} as WithFlattenedProps<ActionWidget<string>, ExtraProps> & { invalid?: boolean },
-  );
 
-  useEffect(() => {
-    const sub = formContext.store.state$
-      .pipe(widgetViewModel$(widget.uid))
-      .subscribe((viewModel) => {
-        setTemplateData((current) =>
-          mergeViewModelIntoTemplateData(current, viewModel, formContext.dependencies, (vm) => ({
-            invalid: vm.formInvalid,
-          })),
-        );
-      });
-    return () => sub.unsubscribe();
-  }, [widget, formContext]);
+  const viewModel = useWidgetViewModel(formContext.store, widget.uid);
+  const templateData = useViewModelAccumulator<ActionTemplateData<ExtraProps>>(
+    viewModel,
+    (previous, currentViewModel) =>
+      mergeViewModelIntoTemplateData(
+        previous ?? ({} as ActionTemplateData<ExtraProps>),
+        currentViewModel,
+        formContext.dependencies,
+        (vm) => ({ invalid: vm.formInvalid }),
+      ),
+  );
 
   // A repeater row widget arrives as a new object whenever the row set changes, so emit
   // `load` once per uid and store, not once per widget object identity.

--- a/libs/react/src/lib/hooks/useDisplayWidget.ts
+++ b/libs/react/src/lib/hooks/useDisplayWidget.ts
@@ -1,26 +1,23 @@
-import { type DisplayWidget, widgetViewModel$ } from '@golemui/core';
-import { useEffect, useState } from 'react';
+import { type DisplayWidget } from '@golemui/core';
 import { useReactFormContext } from '../ReactFormContext';
 import { mergeViewModelIntoTemplateData, type WithFlattenedProps } from './internal/template-data';
+import { useViewModelAccumulator, useWidgetViewModel } from './internal/use-widget-view-model';
 
 export function useDisplayWidget<ExtraProps extends Record<string, any>>(
   widget: DisplayWidget<string>,
 ) {
   const { formContext } = useReactFormContext();
-  const [templateData, setTemplateData] = useState(
-    {} as WithFlattenedProps<DisplayWidget<string>, ExtraProps>,
-  );
 
-  useEffect(() => {
-    const sub = formContext.store.state$
-      .pipe(widgetViewModel$(widget.uid))
-      .subscribe((viewModel) => {
-        setTemplateData((current) =>
-          mergeViewModelIntoTemplateData(current, viewModel, formContext.dependencies),
-        );
-      });
-    return () => sub.unsubscribe();
-  }, [widget, formContext]);
+  const viewModel = useWidgetViewModel(formContext.store, widget.uid);
+  const templateData = useViewModelAccumulator<
+    WithFlattenedProps<DisplayWidget<string>, ExtraProps>
+  >(viewModel, (previous, currentViewModel) =>
+    mergeViewModelIntoTemplateData(
+      previous ?? ({} as WithFlattenedProps<DisplayWidget<string>, ExtraProps>),
+      currentViewModel,
+      formContext.dependencies,
+    ),
+  );
 
   return {
     uid: widget.uid,

--- a/libs/react/src/lib/hooks/useInputWidget.ts
+++ b/libs/react/src/lib/hooks/useInputWidget.ts
@@ -1,41 +1,40 @@
-import { type InputWidget, type NonFunctionWidget, widgetViewModel$ } from '@golemui/core';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { type InputWidget, type NonFunctionWidget } from '@golemui/core';
+import { useCallback, useEffect, useRef } from 'react';
 import { useReactFormContext } from '../ReactFormContext';
 import { mergeViewModelIntoTemplateData, type WithFlattenedProps } from './internal/template-data';
+import { useViewModelAccumulator, useWidgetViewModel } from './internal/use-widget-view-model';
+
+type InputTemplateData<T, ExtraProps extends Record<string, any>> = WithFlattenedProps<
+  InputWidget<T, string>,
+  ExtraProps
+> & {
+  /**
+   * Repeater inputs only: one row layout node per row of the array value, uid and path already indexed
+   */
+  rows?: NonFunctionWidget<string>[];
+};
 
 export function useInputWidget<T, ExtraProps extends Record<string, any>>(
   widget: InputWidget<T, string>,
 ) {
   const { formContext } = useReactFormContext();
-  const [value, setValue] = useState<T | undefined>(undefined);
-  const [errors, setErrors] = useState<string[]>([]);
-  const [isTouched, setIsTouched] = useState<boolean | undefined>(undefined);
-  const [templateData, setTemplateData] = useState(
-    {} as WithFlattenedProps<InputWidget<T, string>, ExtraProps> & {
-      /**
-       * Repeater inputs only: one row layout node per row of the array value, uid and path already indexed
-       */
-      rows?: NonFunctionWidget<string>[];
-    },
+
+  const viewModel = useWidgetViewModel<T>(formContext.store, widget.uid);
+  const templateData = useViewModelAccumulator<InputTemplateData<T, ExtraProps>>(
+    viewModel,
+    (previous, currentViewModel) =>
+      mergeViewModelIntoTemplateData(
+        previous ?? ({} as InputTemplateData<T, ExtraProps>),
+        currentViewModel,
+        formContext.dependencies,
+        (vm) =>
+          // Keep the last rows while hidden, the view model empties them.
+          vm.widget !== undefined ? { rows: vm.rows } : {},
+      ),
   );
 
-  useEffect(() => {
-    const sub = formContext.store.state$
-      .pipe(widgetViewModel$<T>(widget.uid))
-      .subscribe((viewModel) => {
-        setValue(viewModel.value);
-        // `errors` is shared between widgets while the form is untouched, so never write into it.
-        setErrors(viewModel.errors);
-        setIsTouched(viewModel.touched);
-        setTemplateData((current) =>
-          mergeViewModelIntoTemplateData(current, viewModel, formContext.dependencies, (vm) =>
-            // Keep the last rows while hidden, the view model empties them.
-            vm.widget !== undefined ? { rows: vm.rows } : {},
-          ),
-        );
-      });
-    return () => sub.unsubscribe();
-  }, [widget, formContext]);
+  // `errors` is shared between widgets while the form is untouched, so never write into it.
+  const { value, errors, touched: isTouched } = viewModel;
 
   // A repeater row widget arrives as a new object whenever the row set changes, so emit
   // `load` once per uid and store, not once per widget object identity.

--- a/libs/react/src/lib/hooks/useLayoutWidget.ts
+++ b/libs/react/src/lib/hooks/useLayoutWidget.ts
@@ -1,31 +1,35 @@
-import { type FormWidget, type LayoutWidget, widgetViewModel$ } from '@golemui/core';
-import { useCallback, useEffect, useState } from 'react';
+import { type FormWidget, type LayoutWidget } from '@golemui/core';
+import { useCallback } from 'react';
 import { useReactFormContext } from '../ReactFormContext';
 import { mergeViewModelIntoTemplateData, type WithFlattenedProps } from './internal/template-data';
+import { useViewModelAccumulator, useWidgetViewModel } from './internal/use-widget-view-model';
+
+type LayoutRenderData<ExtraProps extends Record<string, any>> = {
+  templateData: WithFlattenedProps<LayoutWidget<string>, ExtraProps>;
+  children: FormWidget<string>[];
+};
 
 export function useLayoutWidget<ExtraProps extends Record<string, any>>(
   widget: LayoutWidget<string>,
 ) {
   const { formContext } = useReactFormContext();
-  const [children, setChildren] = useState<FormWidget<string>[]>([]);
-  const [templateData, setTemplateData] = useState(
-    {} as WithFlattenedProps<LayoutWidget<string>, ExtraProps>,
-  );
 
-  useEffect(() => {
-    const sub = formContext.store.state$
-      .pipe(widgetViewModel$(widget.uid))
-      .subscribe((viewModel) => {
-        // Keep the last children while hidden, otherwise the layout renders empty
-        if (viewModel.widget !== undefined) {
-          setChildren(viewModel.children);
-        }
-        setTemplateData((current) =>
-          mergeViewModelIntoTemplateData(current, viewModel, formContext.dependencies),
-        );
-      });
-    return () => sub.unsubscribe();
-  }, [widget, formContext]);
+  const viewModel = useWidgetViewModel(formContext.store, widget.uid);
+  const { templateData, children } = useViewModelAccumulator<LayoutRenderData<ExtraProps>>(
+    viewModel,
+    (previous, currentViewModel) => ({
+      templateData: mergeViewModelIntoTemplateData(
+        previous?.templateData ?? ({} as WithFlattenedProps<LayoutWidget<string>, ExtraProps>),
+        currentViewModel,
+        formContext.dependencies,
+      ),
+      // Keep the last children while hidden, otherwise the layout renders empty
+      children:
+        currentViewModel.widget !== undefined
+          ? currentViewModel.children
+          : (previous?.children ?? []),
+    }),
+  );
 
   const onChange = useCallback(
     (detail: any) => {

--- a/libs/react/src/lib/hydration.spec.tsx
+++ b/libs/react/src/lib/hydration.spec.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { preloadFormWidgets } from '@golemui/core';
+import { act } from 'react';
+import { hydrateRoot, type Root } from 'react-dom/client';
+import { renderToString } from 'react-dom/server';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FormComponent } from './FormComponent';
+import { buildConfig, noopValidators, stubWidgetLoaders } from './ssr.fixture';
+
+const formElement = () => <FormComponent config={buildConfig()} validators={noopValidators} />;
+
+describe('hydrating server-rendered markup', () => {
+  let warnings: string[];
+  let consoleWarn: ReturnType<typeof vi.spyOn>;
+  let consoleError: ReturnType<typeof vi.spyOn>;
+  let root: Root | null;
+  let container: HTMLDivElement | null;
+
+  beforeAll(async () => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await preloadFormWidgets({ widgetLoaders: stubWidgetLoaders });
+  });
+
+  // React 18's server renderer warns about useLayoutEffect whenever a DOM exists in the
+  // process, which is exactly this spec's setup (renderToString inside jsdom). A real
+  // server has no document, so the adapter picks useEffect there and nothing warns.
+  // React 19 removed the warning. It is unrelated to hydration, so it is not captured.
+  const isReact18ServerLayoutEffectWarning = (message: string) =>
+    message.includes('useLayoutEffect does nothing on the server');
+
+  beforeEach(() => {
+    warnings = [];
+    // React reports hydration mismatches through console.error (and some through
+    // onRecoverableError below), so both are captured.
+    consoleWarn = vi.spyOn(console, 'warn').mockImplementation((...args) => {
+      warnings.push(args.join(' '));
+    });
+    consoleError = vi.spyOn(console, 'error').mockImplementation((...args) => {
+      const message = args.join(' ');
+      if (!isReact18ServerLayoutEffectWarning(message)) {
+        warnings.push(message);
+      }
+    });
+    root = null;
+    container = null;
+  });
+
+  afterEach(async () => {
+    if (root) {
+      const mountedRoot = root;
+      await act(async () => mountedRoot.unmount());
+    }
+    container?.remove();
+    consoleWarn.mockRestore();
+    consoleError.mockRestore();
+  });
+
+  const hydrate = async () => {
+    const serverHtml = renderToString(formElement());
+
+    container = document.createElement('div');
+    container.innerHTML = serverHtml;
+    document.body.appendChild(container);
+
+    // Read back through the DOM serializer, so the comparison below is not against a
+    // raw string that serializes boolean attributes differently.
+    const markupBeforeHydration = container.innerHTML;
+
+    const hydrationContainer = container;
+    await act(async () => {
+      root = hydrateRoot(hydrationContainer, formElement(), {
+        onRecoverableError: (error) => warnings.push(String(error)),
+      });
+    });
+
+    return { serverHtml, container: hydrationContainer, markupBeforeHydration };
+  };
+
+  it('reports no hydration mismatch', async () => {
+    await hydrate();
+
+    expect(warnings).toEqual([]);
+  });
+
+  it('keeps the markup the server produced', async () => {
+    const { container: hydrated, markupBeforeHydration } = await hydrate();
+
+    expect(hydrated.innerHTML).toBe(markupBeforeHydration);
+  });
+
+  it('reuses the server DOM nodes instead of replacing them', async () => {
+    const serverHtml = renderToString(formElement());
+    container = document.createElement('div');
+    container.innerHTML = serverHtml;
+    document.body.appendChild(container);
+    const firstInputBeforeHydration = container.querySelector('input');
+
+    const hydrationContainer = container;
+    await act(async () => {
+      root = hydrateRoot(hydrationContainer, formElement(), {
+        onRecoverableError: (error) => warnings.push(String(error)),
+      });
+    });
+
+    expect(warnings).toEqual([]);
+    expect(hydrationContainer.querySelector('input')).toBe(firstInputBeforeHydration);
+  });
+});

--- a/libs/react/src/lib/server-render.spec.tsx
+++ b/libs/react/src/lib/server-render.spec.tsx
@@ -1,0 +1,70 @@
+import { preloadFormWidgets } from '@golemui/core';
+import { renderToString } from 'react-dom/server';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { FormComponent } from './FormComponent';
+import { buildConfig, noopValidators, stubWidgetLoaders } from './ssr.fixture';
+
+const renderForm = () =>
+  renderToString(<FormComponent config={buildConfig()} validators={noopValidators} />);
+
+describe('server rendering a form in a plain node environment', () => {
+  beforeAll(async () => {
+    await preloadFormWidgets({ widgetLoaders: stubWidgetLoaders });
+  });
+
+  it('emits every widget of the definition', () => {
+    const html = renderForm();
+
+    expect(html).toContain('<form');
+    expect(html).toContain('class="stub-flex"');
+    expect(html.match(/<input/g)).toHaveLength(2);
+  });
+
+  it('emits the values the form was initialized with', () => {
+    const html = renderForm();
+
+    expect(html).toContain('value="Ada"');
+    expect(html).toContain('value="Lovelace"');
+  });
+
+  it('renders no loading placeholder, because the widgets were preloaded', () => {
+    const html = renderForm();
+
+    expect(html.toLowerCase()).not.toContain('loading');
+  });
+
+  it('renders no error text, because an untouched form has no errors', () => {
+    const html = renderForm();
+
+    expect(html.toLowerCase()).not.toContain('failed with');
+    expect(html.toLowerCase()).not.toContain('gui-form-health');
+  });
+});
+
+describe('server rendering determinism', () => {
+  beforeAll(async () => {
+    await preloadFormWidgets({ widgetLoaders: stubWidgetLoaders });
+  });
+
+  it('produces identical markup across two separately created trees', () => {
+    const [first, second] = [renderForm(), renderForm()];
+
+    expect(first).toBe(second);
+  });
+
+  it('gives every widget the same uid in both renders', () => {
+    const uids = (html: string) => [...html.matchAll(/ id="([^"]+)"/g)].map((m) => m[1]);
+
+    expect(uids(renderForm())).toEqual(uids(renderForm()));
+  });
+
+  it('gives the form the same id in both renders, without an explicit formName', () => {
+    const formId = (html: string) => html.match(/<form id="([^"]+)"/)?.[1];
+
+    const first = formId(renderForm());
+    const second = formId(renderForm());
+
+    expect(first).toBeDefined();
+    expect(first).toBe(second);
+  });
+});

--- a/libs/react/src/lib/ssr.fixture.tsx
+++ b/libs/react/src/lib/ssr.fixture.tsx
@@ -1,0 +1,89 @@
+import type {
+  FormInitConfig,
+  InputWidget,
+  LayoutWidget,
+  NonFunctionWidget,
+  StandardSchemaV1,
+  ValidatorFn,
+  WithWidget,
+} from '@golemui/core';
+import WidgetRenderer from './WidgetRenderer';
+import { useInputWidget } from './hooks/useInputWidget';
+import { useLayoutWidget } from './hooks/useLayoutWidget';
+
+/**
+ * Stub widgets and a form definition shared by the server render specs.
+ *
+ * The widgets use the real hooks and the real WidgetRenderer, so a value that reaches the
+ * markup was read from the store through the same path the shipped widgets use.
+ */
+
+function StubTextInput(widgetInstance: WithWidget) {
+  const widget = widgetInstance.widget as InputWidget<string, string>;
+  const { uid, value, templateData } = useInputWidget<string, Record<string, any>>(widget);
+
+  // readOnly only prevents React's controlled-input warning, the specs never type into it.
+  return (
+    <input
+      type="text"
+      id={uid}
+      name={widget.path}
+      data-label={templateData.label as string}
+      value={value ?? ''}
+      readOnly
+    />
+  );
+}
+
+function StubFlex(widgetInstance: WithWidget) {
+  const { uid, children } = useLayoutWidget<Record<string, any>>(
+    widgetInstance.widget as LayoutWidget<string>,
+  );
+
+  return (
+    <div className="stub-flex" id={uid}>
+      {(children as NonFunctionWidget<string>[]).map((child) => (
+        <WidgetRenderer key={child.uid} widget={child} />
+      ))}
+    </div>
+  );
+}
+
+type StubComponent = React.ComponentType<WithWidget>;
+
+export const stubWidgetLoaders = {
+  textinput: async (): Promise<StubComponent> => StubTextInput,
+  flex: async (): Promise<StubComponent> => StubFlex,
+};
+
+/** Accepts everything. The specs assert on markup, not on validation. */
+export const noopValidators: ValidatorFn<any> = () =>
+  ({
+    '~standard': {
+      version: 1,
+      vendor: 'golemui-ssr-fixture',
+      validate: (value: unknown) => ({ value }),
+    },
+  }) as StandardSchemaV1;
+
+export const formDef = {
+  form: {
+    uid: 'root',
+    kind: 'layout',
+    type: 'flex',
+    children: [
+      { kind: 'input', type: 'textinput', path: 'firstName', label: 'First name' },
+      { kind: 'input', type: 'textinput', path: 'lastName', label: 'Last name' },
+    ],
+  },
+};
+
+export const formData = { firstName: 'Ada', lastName: 'Lovelace' };
+
+export function buildConfig(): FormInitConfig<StubComponent> {
+  return {
+    formDef,
+    widgetLoaders: stubWidgetLoaders,
+    data: formData,
+  };
+}

--- a/libs/react/tsconfig.lib.json
+++ b/libs/react/tsconfig.lib.json
@@ -14,6 +14,8 @@
     ]
   },
   "exclude": [
+    "src/**/*.fixture.ts",
+    "src/**/*.fixture.tsx",
     "**/*.spec.ts",
     "**/*.test.ts",
     "**/*.spec.tsx",

--- a/libs/react/vite.config.ts
+++ b/libs/react/vite.config.ts
@@ -6,9 +6,29 @@ import { join } from 'path';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
+// React 18 version lock (REACT18=1): resolve the adapter against the lowest supported
+// React version, not React 19. This alias only reaches vite-transformed source. The
+// `require('react')` calls inside the react18 packages resolve natively, which the setup
+// file below redirects.
+const react18Alias = process.env.REACT18
+  ? {
+      resolve: {
+        alias: [
+          { find: /^react-dom\/client$/, replacement: 'react18-dom/client' },
+          { find: /^react-dom\/server$/, replacement: 'react18-dom/server.node' },
+          { find: /^react-dom$/, replacement: 'react18-dom' },
+          { find: /^react\/jsx-dev-runtime$/, replacement: 'react18/jsx-dev-runtime' },
+          { find: /^react\/jsx-runtime$/, replacement: 'react18/jsx-runtime' },
+          { find: /^react$/, replacement: 'react18' },
+        ],
+      },
+    }
+  : {};
+
 export default defineConfig(() => ({
   root: __dirname,
   cacheDir: '../../node_modules/.vite/libs/react',
+  ...react18Alias,
   plugins: [
     react(),
     nxViteTsPaths(),
@@ -30,6 +50,11 @@ export default defineConfig(() => ({
     },
     rollupOptions: {
       external: ['react', 'react-dom', 'react/jsx-runtime', '@golemui/core', '@golemui/dx'],
+      output: {
+        // Marks the published ES entry as a client module for React Server Component
+        // bundlers (Next.js App Router). Has no effect anywhere else
+        banner: '"use client";',
+      },
     },
   },
   test: {
@@ -37,6 +62,8 @@ export default defineConfig(() => ({
     watch: false,
     globals: true,
     environment: 'node',
+    // The runtime part of the React 18 version lock, see react18Alias above.
+    setupFiles: process.env.REACT18 ? ['./react18-test-setup.ts'] : [],
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     coverage: {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "start:angular": "nx run angular-playground:serve",
     "start:lit": "nx run lit-playground:serve",
     "start:react": "nx run react-playground:serve",
+    "start:react-ssr": "nx run react-ssr-harness:serve-ssr",
     "start:vue": "nx run vue-playground:serve",
     "start:vue-ssr": "nx run vue-ssr-harness:serve-ssr",
     "start:mcp": "npx nx run gui-mcp:build && npx @modelcontextprotocol/inspector node dist/libs/gui/mcp/cli.js",


### PR DESCRIPTION
## Server-side rendering for React forms

`@golemui/react` can now render a form to an HTML string in plain Node. The markup contains the full form structure: the `<form>` element, layout and wrapper elements with their classes and styles, and one `gui-*` element per widget. The widget interiors are not in the markup, Lit renders them on the client.

The client model is real hydration: `hydrateRoot` reuses the server DOM nodes with zero warnings. Every `gui-*` element in the server markup carries the `defer-hydration` attribute and stays empty until React has hydrated it, then `@lit/react` removes the attribute and Lit renders the widget content with the final properties.

## How it works

- Form init runs in a lazy `useState` initializer instead of an effect, and all store reads use `useSyncExternalStore`, so after `preloadFormWidgets` a single `renderToString` pass emits the full form from `(formDef, data, meta)`.
- The `formName` default comes from `useId`, so the server and the client produce the same form id.
- `safeDefine` now supports the `defer-hydration` attribute: an element with the attribute renders only after the attribute is removed. The React wrappers set it, `@lit/react` removes it after mount. Apps that never set the attribute are unaffected.
- The published ES entries of `@golemui/react` and `@golemui/gui-react` start with `"use client"`, so Server Components can import them directly.

Client-only behavior is unchanged: the async widget path stays as the fallback