### PR TITLE
feat(lit,gui-lit,gui-components): support server-side rendering of forms

### DIFF
--- a/apps/apps-shared/src/lib/mocks/mocks.schema-validation.spec.ts
+++ b/apps/apps-shared/src/lib/mocks/mocks.schema-validation.spec.ts
@@ -179,8 +179,10 @@ describe('mocks validate against the schema they declare', () => {
     expect(entries.some(([key]) => key.startsWith('./tabs/'))).toBe(true);
   });
 
+  // The first mock reaching a schema pays its ajv compile, which can take several
+  // seconds on a loaded CI runner - hence the raised timeout.
   for (const [mockKey, mock] of entries) {
-    it(`${mockKey} validates`, () => {
+    it(`${mockKey} validates`, { timeout: 30_000 }, () => {
       const resolved = resolveSchemaId(mockKey, (mock as Record<string, unknown>)['$schema']);
       if ('error' in resolved) {
         expect.fail(resolved.error);

--- a/apps/lit-ssr-harness/eslint.config.mjs
+++ b/apps/lit-ssr-harness/eslint.config.mjs
@@ -1,0 +1,3 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default [...baseConfig];

--- a/apps/lit-ssr-harness/index.html
+++ b/apps/lit-ssr-harness/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en" data-theme="auto">
+  <head>
+    <meta charset="utf-8" />
+    <title>GolemUI Lit server rendering harness</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/src/styles.scss" />
+  </head>
+  <body>
+    <div id="root"><!--app-html--></div>
+    <script type="module" src="/src/entry-client.ts"></script>
+  </body>
+</html>

--- a/apps/lit-ssr-harness/package.json
+++ b/apps/lit-ssr-harness/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@golemui/lit-ssr-harness",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module"
+}

--- a/apps/lit-ssr-harness/project.json
+++ b/apps/lit-ssr-harness/project.json
@@ -1,0 +1,39 @@
+{
+  "name": "lit-ssr-harness",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "apps/lit-ssr-harness/src",
+  "tags": ["scope:app", "type:app"],
+  "// targets": "to see all targets run: nx show project lit-ssr-harness --web",
+  "targets": {
+    "build": {
+      "dependsOn": ["build-server"]
+    },
+    "build-server": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "outputs": ["{workspaceRoot}/dist/apps/lit-ssr-harness/server"],
+      "dependsOn": ["^build"],
+      "options": {
+        "cwd": "apps/lit-ssr-harness",
+        "command": "npx vite build --ssr src/entry-server.ts"
+      }
+    },
+    "serve-ssr": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "node apps/lit-ssr-harness/server.mjs"
+      }
+    },
+    "serve-ssr-prod": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["build"],
+      "options": {
+        "command": "node apps/lit-ssr-harness/server.mjs --production"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
+}

--- a/apps/lit-ssr-harness/server.mjs
+++ b/apps/lit-ssr-harness/server.mjs
@@ -1,0 +1,87 @@
+import { createServer as createHttpServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { dirname, extname, join, normalize } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Minimal server for the harness. Development uses vite in middleware mode.
+// Production reads the two build outputs.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const clientDir = join(here, '../../dist/apps/lit-ssr-harness/client');
+const serverEntry = join(here, '../../dist/apps/lit-ssr-harness/server/entry-server.js');
+const isProduction = process.argv.includes('--production');
+const port = Number(process.env.PORT ?? 3602);
+
+const contentTypes = {
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.css': 'text/css',
+  '.svg': 'image/svg+xml',
+  '.woff2': 'font/woff2',
+  '.json': 'application/json',
+};
+
+const send = (res, status, body, contentType = 'text/html') => {
+  res.writeHead(status, { 'Content-Type': contentType });
+  res.end(body);
+};
+
+const sendError = (res, error) => {
+  console.error(error);
+  send(res, 500, String(error?.stack ?? error), 'text/plain');
+};
+
+async function startDevelopment() {
+  const { createServer } = await import('vite');
+  const vite = await createServer({
+    configFile: join(here, 'vite.config.mts'),
+    server: { middlewareMode: true },
+    appType: 'custom',
+  });
+
+  return createHttpServer((req, res) => {
+    vite.middlewares(req, res, async () => {
+      try {
+        const template = await vite.transformIndexHtml(
+          req.url,
+          await readFile(join(here, 'index.html'), 'utf-8'),
+        );
+        const { render } = await vite.ssrLoadModule('/src/entry-server.ts');
+        send(res, 200, template.replace('<!--app-html-->', await render()));
+      } catch (error) {
+        vite.ssrFixStacktrace(error);
+        sendError(res, error);
+      }
+    });
+  });
+}
+
+async function startProduction() {
+  const template = await readFile(join(clientDir, 'index.html'), 'utf-8');
+  const { render } = await import(serverEntry);
+
+  return createHttpServer(async (req, res) => {
+    try {
+      const path = normalize(decodeURIComponent(new URL(req.url, 'http://localhost').pathname));
+      const asset = join(clientDir, path);
+
+      if (path !== '/' && asset.startsWith(clientDir)) {
+        const file = await readFile(asset).catch(() => null);
+        if (file) {
+          send(res, 200, file, contentTypes[extname(asset)] ?? 'application/octet-stream');
+          return;
+        }
+      }
+
+      send(res, 200, template.replace('<!--app-html-->', await render()));
+    } catch (error) {
+      sendError(res, error);
+    }
+  });
+}
+
+const server = isProduction ? await startProduction() : await startDevelopment();
+server.listen(port, () => {
+  const mode = isProduction ? 'production' : 'development';
+  console.log(`lit-ssr-harness (${mode}) on http://localhost:${port}`);
+});

--- a/apps/lit-ssr-harness/src/entry-client.ts
+++ b/apps/lit-ssr-harness/src/entry-client.ts
@@ -1,0 +1,37 @@
+import { preloadFormWidgets, type FormInitConfig, type WithWidget } from '@golemui/core';
+import { widgetLoaders } from '@golemui/gui-lit';
+import type { GuiFormInitConfig } from '@golemui/gui-shared';
+import { initValidators } from '@golemui/gui-validators';
+import {
+  resumeServerRenderedForm,
+  type FormElement,
+  type Type,
+  type WidgetSetFormElement,
+} from '@golemui/lit';
+import { config } from './form-config';
+
+// The preload has to finish before the resume, or the first client render would resolve
+// no widgets. styles.scss is linked from index.html, so the page is styled with
+// JavaScript disabled.
+preloadFormWidgets({ widgetLoaders }).then(() => {
+  const form = document.querySelector<HTMLElement>(
+    'gui-form',
+  ) as WidgetSetFormElement<GuiFormInitConfig> | null;
+  if (!form) {
+    throw new Error('The gui-form element is missing from the server markup');
+  }
+
+  // resumeServerRenderedForm is typed for the core gui-core-form element. The widget set
+  // element follows the same contract but takes the widget set config, so the call needs
+  // casts. It also builds its own validators, so the ones passed here are ignored.
+  resumeServerRenderedForm(form as unknown as FormElement, {
+    config: config as unknown as FormInitConfig<Type<WithWidget>>,
+    validators: initValidators(),
+  });
+
+  const status = document.querySelector<HTMLElement>('.harness__status');
+  if (status) {
+    status.dataset['resumed'] = 'true';
+    status.textContent = 'Resumed on the client';
+  }
+});

--- a/apps/lit-ssr-harness/src/entry-server.ts
+++ b/apps/lit-ssr-harness/src/entry-server.ts
@@ -1,0 +1,29 @@
+import { preloadFormWidgets } from '@golemui/core';
+import { widgetLoaders } from '@golemui/gui-lit';
+import { renderGuiHtml } from '@golemui/lit/ssr';
+import { html } from 'lit';
+import { config } from './form-config';
+
+/**
+ * Renders the harness page to a string. Called once per request by server.mjs.
+ *
+ * The widgets have to be preloaded before the render, because the server cannot await a
+ * dynamic import while producing a string. The heading and the status text are part of
+ * the same lit template, so the whole page comes from one server render, as in the Vue
+ * and React harnesses.
+ */
+export async function render(): Promise<string> {
+  await preloadFormWidgets({ widgetLoaders });
+  return renderGuiHtml(html`
+    <div class="harness">
+      <h1 class="harness__title">Lit server rendering harness</h1>
+      <p class="harness__status" data-resumed="false">Server HTML, not yet resumed</p>
+      <p class="harness__note">
+        The whole form is server rendered, widget internals included: inputs, labels and values are
+        in the HTML. The client does not hydrate that markup, it replaces it with one live render.
+        View source to see the server output.
+      </p>
+      <gui-form .config=${config}></gui-form>
+    </div>
+  `);
+}

--- a/apps/lit-ssr-harness/src/form-config.ts
+++ b/apps/lit-ssr-harness/src/form-config.ts
@@ -1,0 +1,57 @@
+import { gui, type DxDefinitionItem, type GuiFormInitConfig } from '@golemui/gui-shared';
+
+// The same form as the Vue and React harnesses, so the three SSR harnesses stay directly
+// comparable. No tabs, no markdown, and no calendar, so the render does not depend on the
+// server clock.
+const formDef: DxDefinitionItem[] = [
+  gui.layouts.flex(
+    [
+      gui.inputs.textInput('firstName', {
+        label: 'First name',
+        placeholder: 'Ada',
+        validator: { required: true, minLength: 2 },
+      }),
+      gui.inputs.textInput('lastName', {
+        label: 'Last name',
+        placeholder: 'Lovelace',
+        validator: { required: true, minLength: 2 },
+      }),
+    ],
+    { direction: 'row', gap: 16 },
+  ),
+  gui.inputs.numberInput('seats', {
+    label: 'Seats',
+    validator: { required: true, minimum: 1 },
+  }),
+  gui.inputs.select('plan', {
+    label: 'Plan',
+    options: [
+      { value: 'free', label: 'Free' },
+      { value: 'pro', label: 'Pro' },
+      { value: 'enterprise', label: 'Enterprise' },
+    ],
+    validator: { type: 'string', required: true },
+  }),
+  gui.inputs.checkbox('acceptTerms', {
+    label: 'I accept the terms',
+    validator: { required: true },
+  }),
+  gui.actions.button({
+    label: 'Create account',
+    actionType: 'submit',
+  }),
+];
+
+// Server rendering requires an explicit formName: it is what makes the server and the
+// client produce the same form id.
+export const config: GuiFormInitConfig = {
+  formName: 'harness-form',
+  formDef,
+  data: {
+    firstName: 'Ada',
+    lastName: 'Lovelace',
+    seats: 3,
+    plan: 'pro',
+    acceptTerms: false,
+  },
+};

--- a/apps/lit-ssr-harness/src/styles.scss
+++ b/apps/lit-ssr-harness/src/styles.scss
@@ -1,0 +1,41 @@
+@use '../../../libs/gui/components/src/styles/index';
+
+html,
+body {
+  background-color: var(--gui-bg-default);
+  font-family: system-ui, sans-serif;
+  margin: 0;
+}
+
+.harness {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.harness__title {
+  font-size: 1.25rem;
+  margin: 0 0 1rem 0;
+}
+
+.harness__status {
+  font-family: ui-monospace, monospace;
+  font-size: var(--gui-font-sm);
+  margin: 0 0 0.5rem 0;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--gui-border-default);
+  border-radius: var(--gui-radius-md);
+  background-color: var(--gui-bg-surface);
+  color: var(--gui-text-default);
+}
+
+.harness__status[data-resumed='true'] {
+  border-color: var(--gui-intent-primary);
+  color: var(--gui-intent-primary);
+}
+
+.harness__note {
+  font-size: var(--gui-font-sm);
+  color: var(--gui-text-muted);
+  margin: 0 0 1.5rem 0;
+}

--- a/apps/lit-ssr-harness/tsconfig.app.json
+++ b/apps/lit-ssr-harness/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["node", "vite/client"]
+  },
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/apps/lit-ssr-harness/tsconfig.json
+++ b/apps/lit-ssr-harness/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ESNext", "DOM"],
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
+}

--- a/apps/lit-ssr-harness/vite.config.mts
+++ b/apps/lit-ssr-harness/vite.config.mts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vite';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+
+// One config for both builds of the harness.
+// `vite build` emits the client bundle plus an index.html that already links the hashed
+// script and style, which is what the production server uses as its template.
+// `vite build --ssr src/entry-server.ts` emits the server bundle. Vite sets isSsrBuild for it.
+// No framework plugin: the widgets are custom elements, so the harness compiles plain TypeScript.
+export default defineConfig(({ isSsrBuild }) => ({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/apps/lit-ssr-harness',
+  plugins: [nxViteTsPaths()],
+  build: {
+    outDir: isSsrBuild
+      ? '../../dist/apps/lit-ssr-harness/server'
+      : '../../dist/apps/lit-ssr-harness/client',
+    emptyOutDir: true,
+    reportCompressedSize: !isSsrBuild,
+    commonjsOptions: { transformMixedEsModules: true },
+  },
+}));

--- a/libs/gui/components/src/lib/components/number.ts
+++ b/libs/gui/components/src/lib/components/number.ts
@@ -53,7 +53,12 @@ export class GuiNumber extends LitElement {
   override render() {
     super.render();
 
-    const inputElement = this.querySelector(`input[id="${this.uid}"]`) as HTMLInputElement;
+    // A server render has no querySelector on the element shim. The first client render
+    // finds no input either, so both fall back to the same default width.
+    const inputElement =
+      typeof document === 'undefined'
+        ? null
+        : (this.querySelector(`input[id="${this.uid}"]`) as HTMLInputElement | null);
 
     // TODO: Try to calculate this better, too many magic numbers
     const inputStyles: any = {

--- a/libs/gui/components/src/lib/controllers/focus-leave.controller.ts
+++ b/libs/gui/components/src/lib/controllers/focus-leave.controller.ts
@@ -35,6 +35,10 @@ export class GUIFocusLeaveController implements ReactiveController {
   }
 
   hostConnected() {
+    // A server render runs connectedCallback without a document.
+    if (typeof document === 'undefined') {
+      return;
+    }
     this.host.addEventListener('mousedown', this.onHostMouseDown);
     document.addEventListener('mousedown', this.onDocumentMouseDown, true);
   }

--- a/libs/gui/components/src/lib/controllers/popup.controller.ts
+++ b/libs/gui/components/src/lib/controllers/popup.controller.ts
@@ -239,6 +239,10 @@ export class GUIPopupController implements ReactiveController {
   }
 
   hostConnected() {
+    // A server render runs connectedCallback without a document.
+    if (typeof document === 'undefined') {
+      return;
+    }
     document.addEventListener('click', this.onDocumentClick);
     document.addEventListener('pointerdown', this.onDocumentPointerDown, true);
     document.addEventListener('keydown', this.onDocumentKeyDown, true);

--- a/libs/gui/lit/src/lib/components/dropdown.element.ts
+++ b/libs/gui/lit/src/lib/components/dropdown.element.ts
@@ -69,7 +69,10 @@ export class DropdownElement extends LitElement implements WithWidget {
 
   override connectedCallback() {
     super.connectedCallback();
-    document.addEventListener('click', this.onDocumentClick);
+    // A server render runs connectedCallback without a document.
+    if (typeof document !== 'undefined') {
+      document.addEventListener('click', this.onDocumentClick);
+    }
     this.classList.add('gui-dropdown', 'gui-field');
     this.adapter.context = this.formContext;
     this.adapter.init(this.widget);

--- a/libs/gui/lit/src/lib/components/multi-dropdown.element.ts
+++ b/libs/gui/lit/src/lib/components/multi-dropdown.element.ts
@@ -80,7 +80,10 @@ export class MultiDropdownElement extends LitElement implements WithWidget {
 
   override connectedCallback() {
     super.connectedCallback();
-    document.addEventListener('click', this.onDocumentClick);
+    // A server render runs connectedCallback without a document.
+    if (typeof document !== 'undefined') {
+      document.addEventListener('click', this.onDocumentClick);
+    }
     this.classList.add('gui-multi-dropdown', 'gui-field');
     this.adapter.context = this.formContext;
     this.adapter.init(this.widget);

--- a/libs/gui/lit/src/lib/server-render.spec.ts
+++ b/libs/gui/lit/src/lib/server-render.spec.ts
@@ -35,12 +35,13 @@ const config: FormInitConfig<Type<WithWidget>> = {
       children: [
         { kind: 'input', type: 'textinput', path: 'firstName', label: 'First name' },
         { kind: 'input', type: 'textinput', path: 'lastName', label: 'Last name' },
+        { kind: 'input', type: 'number', path: 'seats', label: 'Seats' },
         { kind: 'action', type: 'button', label: 'Create account', action: 'submit' },
       ],
     },
   },
   widgetLoaders,
-  data: { firstName: 'Ada', lastName: 'Lovelace' },
+  data: { firstName: 'Ada', lastName: 'Lovelace', seats: 3 },
 };
 
 describe('server rendering the gui widget set in plain node', () => {
@@ -69,6 +70,14 @@ describe('server rendering the gui widget set in plain node', () => {
     expect(markup).toMatch(/<input[^>]*id="lastName-textinput"[^>]*value="Lovelace"/);
     expect(markup).toContain('Create account');
     expect(markup).toContain('gui-flex__widget');
+  });
+
+  it('renders the number widget, which reads the DOM in render()', () => {
+    // It looks the input up with querySelector to measure it, which the element shim on
+    // the server does not implement.
+    expect(markup).toMatch(/<gui-number-input[^>]*class="[^"]*gui-number[^"]*gui-field/);
+    expect(markup).toContain('Seats');
+    expect(markup).toMatch(/<input[^>]*type="number"[^>]*id="seats-number"/);
   });
 
   it('emits inert light DOM: defer-hydration everywhere, no shadow root wrappers', () => {

--- a/libs/gui/lit/src/lib/server-render.spec.ts
+++ b/libs/gui/lit/src/lib/server-render.spec.ts
@@ -1,0 +1,85 @@
+import {
+  preloadFormWidgets,
+  type FormInitConfig,
+  type StandardSchemaV1,
+  type ValidatorFn,
+  type WithWidget,
+} from '@golemui/core';
+import { renderGuiFormHtml } from '@golemui/lit/ssr';
+import type { Type } from '@golemui/lit';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { widgetLoaders } from './widget.loaders';
+
+/**
+ * Server-markup spec against the real widget set: the stub spec in the adapter
+ * package proves the mechanism, this one proves the shipped elements render on the
+ * server (host classes from connectedCallback, labels, values, no browser globals).
+ */
+
+const noopValidators: ValidatorFn<any> = () =>
+  ({
+    '~standard': {
+      version: 1,
+      vendor: 'golemui-ssr-spec',
+      validate: (value: unknown) => ({ value }),
+    },
+  }) as StandardSchemaV1;
+
+const config: FormInitConfig<Type<WithWidget>> = {
+  formName: 'gui-lit-ssr-form',
+  formDef: {
+    form: {
+      uid: 'root',
+      kind: 'layout',
+      type: 'flex',
+      children: [
+        { kind: 'input', type: 'textinput', path: 'firstName', label: 'First name' },
+        { kind: 'input', type: 'textinput', path: 'lastName', label: 'Last name' },
+        { kind: 'action', type: 'button', label: 'Create account', action: 'submit' },
+      ],
+    },
+  },
+  widgetLoaders,
+  data: { firstName: 'Ada', lastName: 'Lovelace' },
+};
+
+describe('server rendering the gui widget set in plain node', () => {
+  let markup = '';
+
+  beforeAll(async () => {
+    await preloadFormWidgets({ widgetLoaders });
+    markup = await renderGuiFormHtml({ config, validators: noopValidators });
+  });
+
+  it('renders the form with its host class and name', () => {
+    expect(markup).toMatch(/<gui-core-form[^>]*class="[^"]*gui-form/);
+    expect(markup).toMatch(/<form[^>]*id="gui-lit-ssr-form"/);
+    expect(markup).not.toContain('Loading form...');
+  });
+
+  it('renders the widget elements with their host classes', () => {
+    expect(markup).toMatch(/<gui-flex-layout[^>]*class="[^"]*gui-flex[^"]*gui-field/);
+    expect(markup).toMatch(/<gui-textinput-input[^>]*class="[^"]*gui-textinput[^"]*gui-field/);
+    expect(markup).toMatch(/<gui-button-interactive[^>]*class="[^"]*gui-button[^"]*gui-field/);
+  });
+
+  it('renders labels, values and the layout structure', () => {
+    expect(markup).toContain('First name');
+    expect(markup).toMatch(/<input[^>]*id="firstName-textinput"[^>]*value="Ada"/);
+    expect(markup).toMatch(/<input[^>]*id="lastName-textinput"[^>]*value="Lovelace"/);
+    expect(markup).toContain('Create account');
+    expect(markup).toContain('gui-flex__widget');
+  });
+
+  it('emits inert light DOM: defer-hydration everywhere, no shadow root wrappers', () => {
+    expect(markup).toMatch(/<gui-core-form[^>]*defer-hydration/);
+    expect(markup).toMatch(/<gui-textinput-input[^>]*defer-hydration/);
+    expect(markup).not.toContain('<template');
+    expect(markup).not.toContain('lit-part');
+  });
+
+  it('is deterministic across renders', async () => {
+    const second = await renderGuiFormHtml({ config, validators: noopValidators });
+    expect(second).toBe(markup);
+  });
+});

--- a/libs/gui/lit/src/lib/widget.loaders.spec.ts
+++ b/libs/gui/lit/src/lib/widget.loaders.spec.ts
@@ -1,0 +1,17 @@
+import { preloadFormWidgets } from '@golemui/core';
+import { describe, expect, it } from 'vitest';
+import { widgetLoaders } from './widget.loaders';
+
+describe('preloading the gui widget set outside a browser', () => {
+  it('resolves every widget module in a plain node environment', async () => {
+    await expect(preloadFormWidgets({ widgetLoaders })).resolves.toBeUndefined();
+  });
+
+  it('defines a loader function for every widget type', () => {
+    const missing = Object.entries(widgetLoaders)
+      .filter(([, loader]) => typeof loader !== 'function')
+      .map(([type]) => type);
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/libs/gui/lit/src/lib/widget.loaders.spec.ts
+++ b/libs/gui/lit/src/lib/widget.loaders.spec.ts
@@ -2,10 +2,16 @@ import { preloadFormWidgets } from '@golemui/core';
 import { describe, expect, it } from 'vitest';
 import { widgetLoaders } from './widget.loaders';
 
+// The awaited imports cold-transform every widget module, which can take several
+// seconds on a loaded CI runner - hence the raised timeout.
 describe('preloading the gui widget set outside a browser', () => {
-  it('resolves every widget module in a plain node environment', async () => {
-    await expect(preloadFormWidgets({ widgetLoaders })).resolves.toBeUndefined();
-  });
+  it(
+    'resolves every widget module in a plain node environment',
+    { timeout: 30_000 },
+    async () => {
+      await expect(preloadFormWidgets({ widgetLoaders })).resolves.toBeUndefined();
+    },
+  );
 
   it('defines a loader function for every widget type', () => {
     const missing = Object.entries(widgetLoaders)

--- a/libs/gui/react/src/lib/components/Dropdown.tsx
+++ b/libs/gui/react/src/lib/components/Dropdown.tsx
@@ -5,6 +5,7 @@ import type { DropdownProps, ListItem, OptionValue } from '@golemui/gui-shared/i
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DefaultListItemRenderer } from './item-renderers/DefaultListItemRenderer';
 import { type ListItemRendererProps } from './item-renderers/props';
+import { useBrowserLayoutEffect } from './shared/use-browser-layout-effect';
 import type { GuiList } from '@golemui/gui-components/list';
 import type { GuiLabel } from '@golemui/gui-components/label';
 
@@ -82,7 +83,9 @@ export function Dropdown(widgetInstance: WithWidget) {
     [handleValueChange, onFilter, templateData.readonly],
   );
 
-  useEffect(() => {
+  // A layout effect so these listeners exist before first paint. A passive effect
+  // attaches them after paint, and an early click then fires 'change' with no listener.
+  useBrowserLayoutEffect(() => {
     const element = listRef.current;
     if (!element) return;
 

--- a/libs/gui/react/src/lib/components/List.tsx
+++ b/libs/gui/react/src/lib/components/List.tsx
@@ -1,10 +1,11 @@
 import { GuiErrorsReact, GuiLabelReact, GuiListReact } from '../web-components';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useInputWidget, useItemRenderer } from '@golemui/react';
 import type { ListItem, ListProps, OptionValue } from '@golemui/gui-shared/internals';
 import { DefaultListItemRenderer } from './item-renderers/DefaultListItemRenderer';
 import { type ListItemRendererProps } from './item-renderers/props';
+import { useBrowserLayoutEffect } from './shared/use-browser-layout-effect';
 import type { GuiList } from '@golemui/gui-components/list';
 
 export function List(widgetInstance: WithWidget) {
@@ -38,7 +39,9 @@ export function List(widgetInstance: WithWidget) {
     return items.slice(range.start, range.end);
   }, [listItems, templateData.items, range]);
 
-  useEffect(() => {
+  // A layout effect so these listeners exist before first paint. A passive effect
+  // attaches them after paint, and an early click then fires 'change' with no listener.
+  useBrowserLayoutEffect(() => {
     const element = listRef.current;
     if (!element) return;
 

--- a/libs/gui/react/src/lib/components/MultiDropdown.tsx
+++ b/libs/gui/react/src/lib/components/MultiDropdown.tsx
@@ -16,6 +16,7 @@ import { updateListItems } from '@golemui/gui-components/internals';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DefaultMultiListItemRenderer } from './item-renderers/DefaultMultiListItemRenderer';
 import { type ListItemRendererProps } from './item-renderers/props';
+import { useBrowserLayoutEffect } from './shared/use-browser-layout-effect';
 import type { GuiMultiList } from '@golemui/gui-components/multi-list';
 import type { GuiMultiSelectTrigger } from '@golemui/gui-components/multi-select-trigger';
 import type { GuiPillItem } from '@golemui/gui-components/pills';
@@ -108,7 +109,9 @@ export function MultiDropdown(widgetInstance: WithWidget) {
     [templateData.readonly, toggleValue],
   );
 
-  useEffect(() => {
+  // A layout effect so these listeners exist before first paint. A passive effect
+  // attaches them after paint, and an early click then fires 'change' with no listener.
+  useBrowserLayoutEffect(() => {
     const element = listRef.current;
     if (!element) return;
 

--- a/libs/gui/react/src/lib/components/MultiList.tsx
+++ b/libs/gui/react/src/lib/components/MultiList.tsx
@@ -1,10 +1,11 @@
 import { GuiErrorsReact, GuiLabelReact, GuiMultiListReact } from '../web-components';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import type { InputWidget, Validator, WithWidget } from '@golemui/core';
 import { useInputWidget, useItemRenderer } from '@golemui/react';
 import type { ListItem, MultiListProps, OptionValue } from '@golemui/gui-shared/internals';
 import { DefaultMultiListItemRenderer } from './item-renderers/DefaultMultiListItemRenderer';
 import { type ListItemRendererProps } from './item-renderers/props';
+import { useBrowserLayoutEffect } from './shared/use-browser-layout-effect';
 import type { GuiMultiList } from '@golemui/gui-components/multi-list';
 
 export function MultiList(widgetInstance: WithWidget) {
@@ -52,7 +53,9 @@ export function MultiList(widgetInstance: WithWidget) {
     [currentValues, onValueChanged, templateData.disabled, templateData.readonly],
   );
 
-  useEffect(() => {
+  // A layout effect so these listeners exist before first paint. A passive effect
+  // attaches them after paint, and an early click then fires 'change' with no listener.
+  useBrowserLayoutEffect(() => {
     const element = listRef.current;
     if (!element) return;
 

--- a/libs/gui/react/src/lib/components/shared/use-browser-layout-effect.ts
+++ b/libs/gui/react/src/lib/components/shared/use-browser-layout-effect.ts
@@ -1,0 +1,7 @@
+import { useEffect, useLayoutEffect } from 'react';
+
+/**
+ * `useLayoutEffect` in the browser, `useEffect` in a server render, where layout
+ * effects never run and `renderToString` warns on them.
+ */
+export const useBrowserLayoutEffect = typeof document === 'undefined' ? useEffect : useLayoutEffect;

--- a/libs/gui/react/src/lib/widget.loaders.spec.ts
+++ b/libs/gui/react/src/lib/widget.loaders.spec.ts
@@ -2,10 +2,16 @@ import { preloadFormWidgets } from '@golemui/core';
 import { describe, expect, it } from 'vitest';
 import { widgetLoaders } from './widget.loaders';
 
+// The awaited imports cold-transform every widget module, which can take several
+// seconds on a loaded CI runner - hence the raised timeout.
 describe('preloading the gui widget set outside a browser', () => {
-  it('resolves every widget module in a plain node environment', async () => {
-    await expect(preloadFormWidgets({ widgetLoaders })).resolves.toBeUndefined();
-  });
+  it(
+    'resolves every widget module in a plain node environment',
+    { timeout: 30_000 },
+    async () => {
+      await expect(preloadFormWidgets({ widgetLoaders })).resolves.toBeUndefined();
+    },
+  );
 
   it('defines a loader function for every widget type', () => {
     const missing = Object.entries(widgetLoaders)

--- a/libs/gui/vue/src/lib/widget.loaders.spec.ts
+++ b/libs/gui/vue/src/lib/widget.loaders.spec.ts
@@ -2,10 +2,16 @@ import { preloadFormWidgets } from '@golemui/core';
 import { describe, expect, it } from 'vitest';
 import { widgetLoaders } from './widget.loaders';
 
+// The awaited imports cold-transform every widget module, which can take several
+// seconds on a loaded CI runner - hence the raised timeout.
 describe('preloading the gui widget set outside a browser', () => {
-  it('resolves every widget module in a plain node environment', async () => {
-    await expect(preloadFormWidgets({ widgetLoaders })).resolves.toBeUndefined();
-  });
+  it(
+    'resolves every widget module in a plain node environment',
+    { timeout: 30_000 },
+    async () => {
+      await expect(preloadFormWidgets({ widgetLoaders })).resolves.toBeUndefined();
+    },
+  );
 
   it('defines a loader function for every widget type', () => {
     const missing = Object.entries(widgetLoaders)

--- a/libs/lit/package.json
+++ b/libs/lit/package.json
@@ -19,6 +19,11 @@
       "types": "./internals.d.ts",
       "import": "./internals.js",
       "require": "./internals.cjs"
+    },
+    "./ssr": {
+      "types": "./ssr.d.ts",
+      "import": "./ssr.js",
+      "require": "./ssr.cjs"
     }
   },
   "files": [
@@ -29,6 +34,9 @@
     "internals.d.ts",
     "internals.js",
     "internals.cjs",
+    "ssr.d.ts",
+    "ssr.js",
+    "ssr.cjs",
     "*.js",
     "*.cjs",
     "*.md"
@@ -39,8 +47,14 @@
   "peerDependencies": {
     "@golemui/core": "*",
     "@lit/context": "^1.1.6",
+    "@lit-labs/ssr": "^4.1.0",
     "lit": "^3.3.1",
     "rxjs": "^7.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@lit-labs/ssr": {
+      "optional": true
+    }
   },
   "repository": {
     "type": "git",

--- a/libs/lit/src/index.ts
+++ b/libs/lit/src/index.ts
@@ -18,5 +18,6 @@ export {
 export type { LitItemRenderer } from './lib/components/item-renderers/item-renderer';
 export { WidgetElement } from './lib/components/widget/widget-element';
 export { formContext, LitFormContext } from './lib/context/form.context';
+export { resumeServerRenderedForm } from './lib/ssr/resume';
 
 export type { Type } from './lib/utils/type';

--- a/libs/lit/src/internals.ts
+++ b/libs/lit/src/internals.ts
@@ -1,2 +1,2 @@
-export { safeDefine } from './lib/utils/define';
+export { safeDefine, tagNameOf } from './lib/utils/define';
 export { unsubscribeAll } from './lib/utils/subscriptions';

--- a/libs/lit/src/lib/components/form/form.element.ts
+++ b/libs/lit/src/lib/components/form/form.element.ts
@@ -88,8 +88,11 @@ export class FormElement extends LitElement {
     );
   }
 
-  override updated(changed: Map<string, unknown>) {
-    super.updated(changed);
+  // Runs before render (not in updated()) so a server render, which never reaches
+  // updated(), computes the form in the same pass. On the client the first render
+  // then shows the form instead of the loading fallback.
+  override willUpdate(changed: Map<string, unknown>) {
+    super.willUpdate(changed);
     if ((changed.has('config') || changed.has('validators')) && this.config) {
       this._reinitialize(this.config);
     }

--- a/libs/lit/src/lib/hydration.spec.ts
+++ b/libs/lit/src/lib/hydration.spec.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { preloadFormWidgets } from '@golemui/core';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FormElement } from './components/form/form.element';
+import { resumeServerRenderedForm } from './ssr/resume';
+import {
+  buildConfig,
+  canonicalServerMarkup,
+  noopValidators,
+  stubWidgetLoaders,
+} from './ssr.fixture';
+
+/**
+ * Resume spec: loads the canonical server markup into the DOM (the server render
+ * spec asserts that markup byte for byte), verifies the defer-hydration hold, and
+ * verifies that the resume entry point replaces the markup with an equivalent live
+ * render.
+ */
+
+// Lit renders on the microtask schedule, so waiting one macrotask completes every
+// nested first render.
+const afterLitRenderSchedule = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('resuming a server rendered form', () => {
+  beforeAll(async () => {
+    await preloadFormWidgets({ widgetLoaders: stubWidgetLoaders as any });
+  });
+
+  beforeEach(() => {
+    document.body.innerHTML = canonicalServerMarkup;
+  });
+
+  it('holds the server markup unchanged while defer-hydration is present', async () => {
+    const before = document.body.innerHTML;
+    await afterLitRenderSchedule();
+    await afterLitRenderSchedule();
+    expect(document.body.innerHTML).toBe(before);
+  });
+
+  it('replaces the server markup with one equivalent live render', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const form = document.querySelector('gui-core-form') as FormElement;
+
+    resumeServerRenderedForm(form, { config: buildConfig(), validators: noopValidators });
+    await afterLitRenderSchedule();
+    await afterLitRenderSchedule();
+
+    // The same features the server markup contained, read from the live DOM.
+    expect(document.querySelectorAll('form')).toHaveLength(1);
+    expect(document.querySelector('form')?.id).toBe('fixture-form');
+
+    const serverDocument = new DOMParser().parseFromString(canonicalServerMarkup, 'text/html');
+    const serverInputs = [...serverDocument.querySelectorAll('input')].map((input) => [
+      input.id,
+      input.getAttribute('value'),
+    ]);
+    const liveInputs = [...document.querySelectorAll('input')].map((input) => [
+      input.id,
+      input.value,
+    ]);
+    expect(liveInputs).toEqual(serverInputs);
+    expect(liveInputs).toHaveLength(2);
+
+    expect(document.querySelector('gui-core-form')?.hasAttribute('defer-hydration')).toBe(false);
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it('accepts user input after the resume', async () => {
+    const form = document.querySelector('gui-core-form') as FormElement;
+    resumeServerRenderedForm(form, { config: buildConfig(), validators: noopValidators });
+    await afterLitRenderSchedule();
+    await afterLitRenderSchedule();
+
+    const input = document.getElementById('firstName-textinput') as HTMLInputElement;
+    input.value = 'Grace';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(input.value).toBe('Grace');
+  });
+});

--- a/libs/lit/src/lib/mixins/widget-mixin.ts
+++ b/libs/lit/src/lib/mixins/widget-mixin.ts
@@ -2,7 +2,21 @@ import { type FormHealth, type FormWidget, errorCodes, formEventNames } from '@g
 import { consume } from '@lit/context';
 import { type LitElement } from 'lit';
 import { property } from 'lit/decorators.js';
+import { html as staticHtml, unsafeStatic } from 'lit/static-html.js';
 import { formContext, type LitFormContext } from '../context/form.context';
+import { tagNameOf } from '../utils/define';
+
+// Static template identity is derived from the strings, so one value per tag is enough.
+const staticTagCache = new Map<string, ReturnType<typeof unsafeStatic>>();
+
+const staticTagFor = (tag: string) => {
+  let staticTag = staticTagCache.get(tag);
+  if (!staticTag) {
+    staticTag = unsafeStatic(tag);
+    staticTagCache.set(tag, staticTag);
+  }
+  return staticTag;
+};
 
 export const WidgetMixin = <T extends new (...args: any[]) => LitElement>(superClass: T) => {
   class WidgetElement extends superClass {
@@ -12,9 +26,39 @@ export const WidgetMixin = <T extends new (...args: any[]) => LitElement>(superC
 
     @property({ type: Object }) widget!: FormWidget<string> | undefined;
 
+    override createRenderRoot() {
+      return this;
+    }
+
     override connectedCallback() {
       super.connectedCallback?.();
-      this.loadWidgetComponent();
+      if (this.resolvePreloadedTag()) {
+        // On the preloaded path this element stays in the DOM as the widget's parent,
+        // so it must not become a flex or grid item of the surrounding layout.
+        this.setAttribute('style', 'display:contents');
+      } else {
+        this.loadWidgetComponent();
+      }
+    }
+
+    /**
+     * Returns the tag of the widget's component when it was preloaded, undefined
+     * otherwise (no widget, no form context, or the component was never preloaded).
+     */
+    private resolvePreloadedTag(): string | undefined {
+      const type = this.widget?.type;
+      if (!type) {
+        return undefined;
+      }
+      const component = this.formContext?.widgetRegistry.getIfLoaded(type);
+      if (!component) {
+        return undefined;
+      }
+      const ctor = component as unknown as CustomElementConstructor;
+      const registry = customElements as CustomElementRegistry & {
+        getName?(ctor: CustomElementConstructor): string | null;
+      };
+      return tagNameOf(ctor) ?? registry.getName?.(ctor) ?? undefined;
     }
 
     private async loadWidgetComponent() {
@@ -47,7 +91,12 @@ export const WidgetMixin = <T extends new (...args: any[]) => LitElement>(superC
     }
 
     override render() {
-      return null;
+      const tag = this.resolvePreloadedTag();
+      if (!tag || !this.widget) {
+        return null;
+      }
+      const staticTag = staticTagFor(tag);
+      return staticHtml`<${staticTag} id=${`host-${this.widget.uid}`} .widget=${this.widget}></${staticTag}>`;
     }
   }
 

--- a/libs/lit/src/lib/server-render.spec.ts
+++ b/libs/lit/src/lib/server-render.spec.ts
@@ -1,0 +1,90 @@
+import { preloadFormWidgets } from '@golemui/core';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { renderGuiFormHtml } from '../ssr';
+import {
+  buildConfig,
+  canonicalServerMarkup,
+  formData,
+  noopValidators,
+  stubWidgetLoaders,
+} from './ssr.fixture';
+
+/**
+ * Server-markup spec: renders a form to a string in a plain node environment (no DOM
+ * globals beyond the lit shim) and asserts on the markup.
+ */
+
+async function renderFixtureForm(options?: { keepMarkers?: boolean }): Promise<string> {
+  return renderGuiFormHtml({
+    config: buildConfig(),
+    validators: noopValidators,
+    keepMarkers: options?.keepMarkers,
+  });
+}
+
+describe('server rendering a form in plain node', () => {
+  let markup = '';
+
+  beforeAll(async () => {
+    await preloadFormWidgets({ widgetLoaders: stubWidgetLoaders as any });
+    markup = await renderFixtureForm();
+  });
+
+  it('matches the canonical markup the resume spec hydrates from', () => {
+    expect(markup).toBe(canonicalServerMarkup);
+  });
+
+  it('renders the form tag with the explicit form name', () => {
+    expect(markup).toContain('<gui-core-form');
+    expect(markup).toMatch(/<form[^>]*id="fixture-form"/);
+    expect(markup).not.toContain('Loading form...');
+  });
+
+  it('renders every widget of the definition', () => {
+    expect(markup.match(/<gui-stub-input/g)).toHaveLength(2);
+    expect(markup).toMatch(/<div[^>]*class="stub-flex"[^>]*id="root"/);
+  });
+
+  it('renders the data values into the inputs', () => {
+    expect(markup).toMatch(/<input[^>]*id="firstName-textinput"[^>]*value="Ada"/);
+    expect(markup).toMatch(/<input[^>]*id="lastName-textinput"[^>]*value="Lovelace"/);
+    expect(markup).toMatch(/data-label="First name"/);
+  });
+
+  it('holds every element inert through defer-hydration', () => {
+    expect(markup).toMatch(/<gui-core-form[^>]*defer-hydration/);
+    expect(markup).toMatch(/<gui-widget[^>]*defer-hydration/);
+    expect(markup).toMatch(/<gui-stub-input[^>]*defer-hydration/);
+  });
+
+  it('emits light DOM only: no shadow root wrappers and no marker comments', () => {
+    expect(markup).not.toContain('<template');
+    expect(markup).not.toContain('lit-part');
+    expect(markup).not.toContain('lit-node');
+    expect(markup).not.toContain('<?>');
+  });
+
+  it('keeps the hydration markers when keepMarkers is set', async () => {
+    const withMarkers = await renderFixtureForm({ keepMarkers: true });
+    expect(withMarkers).toContain('lit-part');
+    expect(withMarkers).not.toContain('<template');
+  });
+
+  it('is deterministic: two renders produce identical markup', async () => {
+    const second = await renderFixtureForm();
+    expect(second).toBe(markup);
+  });
+
+  it('throws without an explicit formName', async () => {
+    const config = buildConfig();
+    delete config.formName;
+    await expect(renderGuiFormHtml({ config, validators: noopValidators })).rejects.toThrow(
+      /formName/,
+    );
+  });
+
+  it('renders an untouched form without validation errors', () => {
+    expect(formData.firstName).toBe('Ada'); // the data is set, yet no error markup exists
+    expect(markup).not.toMatch(/error/i);
+  });
+});

--- a/libs/lit/src/lib/ssr.fixture.ts
+++ b/libs/lit/src/lib/ssr.fixture.ts
@@ -1,0 +1,185 @@
+import type {
+  FormInitConfig,
+  InputWidget,
+  LayoutWidget,
+  NonFunctionWidget,
+  StandardSchemaV1,
+  ValidatorFn,
+  WithWidget,
+} from '@golemui/core';
+import { consume } from '@lit/context';
+import { html, LitElement } from 'lit';
+import { property } from 'lit/decorators.js';
+import { type Subscription } from 'rxjs';
+import { InputWidgetAdapter } from './adapters/input-widget.adapter';
+import { LayoutWidgetAdapter } from './adapters/layout-widget.adapter';
+import { formContext, type LitFormContext } from './context/form.context';
+import { safeDefine } from './utils/define';
+import type { Type } from './utils/type';
+import './components/form/form.element';
+
+/**
+ * Stub widget elements and a form definition shared by the server render and the
+ * resume specs. The stubs use the real adapters and the real form context, so a value
+ * that appears in the markup was read from the store through the same code path the
+ * gui widget set uses.
+ */
+
+class StubTextInputElement extends LitElement implements WithWidget {
+  widget!: InputWidget<string>;
+
+  @consume({ context: formContext })
+  @property({ attribute: false })
+  formContext!: LitFormContext<any>;
+
+  adapter = new InputWidgetAdapter<string, { placeholder?: string }>();
+
+  subscriptions: Subscription[] = [];
+
+  override createRenderRoot() {
+    return this;
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.adapter.context = this.formContext;
+    this.adapter.init(this.widget);
+    this.subscriptions.push(
+      this.adapter.templateDataChanged$.subscribe(() => this.requestUpdate()),
+    );
+  }
+
+  override render() {
+    return html`<input
+      type="text"
+      id=${this.widget.uid}
+      data-label=${this.adapter.templateData.label ?? ''}
+      .value=${this.adapter.templateData.value ?? ''}
+    />`;
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    this.adapter.destroy();
+    for (const subscription of this.subscriptions) {
+      subscription.unsubscribe();
+    }
+  }
+}
+
+class StubFlexElement extends LitElement implements WithWidget {
+  widget!: LayoutWidget;
+
+  @consume({ context: formContext })
+  @property({ attribute: false })
+  formContext!: LitFormContext<any>;
+
+  adapter = new LayoutWidgetAdapter();
+
+  subscriptions: Subscription[] = [];
+
+  override createRenderRoot() {
+    return this;
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.adapter.context = this.formContext;
+    this.adapter.init(this.widget);
+    this.subscriptions.push(
+      this.adapter.templateDataChanged$.subscribe(() => this.requestUpdate()),
+    );
+  }
+
+  override render() {
+    const children = (this.adapter.templateData.children ?? []) as NonFunctionWidget<string>[];
+    return html`<div class="stub-flex" id=${this.widget.uid}>
+      ${children.map((child) => html`<gui-widget .widget=${child}></gui-widget>`)}
+    </div>`;
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    this.adapter.destroy();
+    for (const subscription of this.subscriptions) {
+      subscription.unsubscribe();
+    }
+  }
+}
+
+safeDefine('gui-stub-input', StubTextInputElement);
+safeDefine('gui-stub-flex', StubFlexElement);
+
+export const stubWidgetLoaders = {
+  textinput: async (): Promise<Type<WithWidget>> => StubTextInputElement as Type<WithWidget>,
+  flex: async (): Promise<Type<WithWidget>> => StubFlexElement as Type<WithWidget>,
+};
+
+/** Accepts everything. The specs assert on markup, not on validation. */
+export const noopValidators: ValidatorFn<any> = () =>
+  ({
+    '~standard': {
+      version: 1,
+      vendor: 'golemui-ssr-fixture',
+      validate: (value: unknown) => ({ value }),
+    },
+  }) as StandardSchemaV1;
+
+export const formDef = {
+  form: {
+    uid: 'root',
+    kind: 'layout',
+    type: 'flex',
+    children: [
+      { kind: 'input', type: 'textinput', path: 'firstName', label: 'First name' },
+      { kind: 'input', type: 'textinput', path: 'lastName', label: 'Last name' },
+    ],
+  },
+};
+
+export const formData = { firstName: 'Ada', lastName: 'Lovelace' };
+
+export function buildConfig(): FormInitConfig<Type<WithWidget>> {
+  return {
+    formName: 'fixture-form',
+    formDef,
+    widgetLoaders: stubWidgetLoaders as any,
+    data: formData,
+  };
+}
+
+/**
+ * The exact output of renderGuiFormHtml for buildConfig() plus noopValidators.
+ * The server render spec asserts equality with this string byte for byte, and the
+ * resume spec loads it into the DOM, so the two specs always test the same markup.
+ */
+export const canonicalServerMarkup = `<gui-core-form
+      
+      
+      
+     class="gui-form" defer-hydration>
+  
+  
+      <form
+        id="fixture-form"
+        novalidate
+        dir="ltr"
+        
+        
+      >
+         <gui-widget  style="display:contents" defer-hydration><gui-stub-flex   id="host-root" defer-hydration><div class="stub-flex" id="root">
+      <gui-widget  style="display:contents" defer-hydration><gui-stub-input   id="host-firstName-textinput" defer-hydration><input
+      type="text"
+      id="firstName-textinput"
+      data-label="First name"
+      value="Ada"
+    /></gui-stub-input></gui-widget><gui-widget  style="display:contents" defer-hydration><gui-stub-input   id="host-lastName-textinput" defer-hydration><input
+      type="text"
+      id="lastName-textinput"
+      data-label="Last name"
+      value="Lovelace"
+    /></gui-stub-input></gui-widget>
+    </div></gui-stub-flex></gui-widget>
+      </form>
+    
+</gui-core-form>`;

--- a/libs/lit/src/lib/ssr/resume.ts
+++ b/libs/lit/src/lib/ssr/resume.ts
@@ -1,0 +1,40 @@
+import type { FormInitConfig, ValidatorFn, WithWidget } from '@golemui/core';
+import type { FormElement } from '../components/form/form.element';
+import type { Type } from '../utils/type';
+
+/**
+ * Client entry point for a server-rendered GolemUI form.
+ *
+ * The server markup holds the form inert through the `defer-hydration` attribute.
+ * This call replaces the server-rendered children with a live client render: it
+ * clears them, assigns `config` and `validators`, and removes the attribute, which
+ * runs the held connectedCallback. Lit renders before the browser paints again, so
+ * the server markup is not visible in a cleared state.
+ *
+ * Call it only after the widgets are preloaded (`preloadFormWidgets`) and the form
+ * element definitions are imported, so the first client render resolves every
+ * widget synchronously. `config.formName` must match the server value, which the
+ * server render enforces by requiring an explicit `formName`.
+ *
+ * @param element - The server-rendered form element (`gui-core-form` or a widget-set
+ * form element that extends it).
+ * @param options - The same `config` and `validators` the server render used.
+ * @example
+ * await preloadFormWidgets({ widgetLoaders });
+ * const form = document.querySelector('gui-core-form')!;
+ * resumeServerRenderedForm(form, { config, validators });
+ */
+export function resumeServerRenderedForm(
+  element: FormElement,
+  options: {
+    config: FormInitConfig<Type<WithWidget>>;
+    validators: ValidatorFn<any>;
+  },
+): void {
+  element.replaceChildren();
+  // The element property is typed on widget instances while configs are built with
+  // component classes. createFormComponent applies the same cast.
+  element.config = options.config as unknown as FormInitConfig<WithWidget>;
+  element.validators = options.validators;
+  element.removeAttribute('defer-hydration');
+}

--- a/libs/lit/src/lib/ssr/server.ts
+++ b/libs/lit/src/lib/ssr/server.ts
@@ -1,0 +1,232 @@
+/**
+ * Server-only entry point (@golemui/lit/ssr). It calls @lit-labs/ssr, which is an
+ * optional peer dependency: install it in the project that server-renders. Importing
+ * this module in a browser bundle is unsupported.
+ */
+import type { FormInitConfig, ValidatorFn, WithWidget } from '@golemui/core';
+import { html } from 'lit';
+import { LitElementRenderer, render } from '@lit-labs/ssr';
+import { collectResult } from '@lit-labs/ssr/lib/render-result.js';
+import { FormElement } from '../components/form/form.element';
+import { tagNameOf } from '../utils/define';
+import type { Type } from '../utils/type';
+
+/**
+ * ElementRenderer for the GolemUI elements (everything registered through safeDefine).
+ *
+ * It exists to repair the server event path for light DOM: the renderer links a nested
+ * element to its host through the host's shadow root, and a light-DOM host has none,
+ * so the link falls back to the document shim and skips the host. A bubbling
+ * `context-request` then never reaches the form's context provider. The repair points
+ * the link at the host itself, before connectedCallback dispatches anything.
+ *
+ * Pass it before the default renderer:
+ * `render(template, { elementRenderers: [GuiSsrElementRenderer, LitElementRenderer] })`.
+ */
+export class GuiSsrElementRenderer extends LitElementRenderer {
+  static override matchesClass(ceClass: typeof HTMLElement): boolean {
+    return (
+      tagNameOf(ceClass as CustomElementConstructor) !== undefined && super.matchesClass(ceClass)
+    );
+  }
+
+  override connectedCallback(): void {
+    const element = this.element as unknown as {
+      __host?: { __shadowRoot?: unknown };
+      __eventTargetParent?: unknown;
+      __eventPathCache?: unknown;
+    };
+    if (element.__host && !element.__host.__shadowRoot) {
+      element.__eventTargetParent = element.__host;
+      element.__eventPathCache = undefined;
+    }
+    super.connectedCallback();
+  }
+}
+
+let supportInstalled = false;
+
+/**
+ * Prepares the Node environment for rendering GolemUI elements. Idempotent, and called
+ * by {@link renderGuiHtml} and {@link renderGuiFormHtml}, so calling it directly is
+ * only needed when calling @lit-labs/ssr's `render` yourself.
+ *
+ * It installs a `classList` accessor on the DOM shim (the elements set host classes in
+ * connectedCallback, and the shim only implements attributes), and it registers a
+ * render option so every safeDefine-registered element runs connectedCallback on the
+ * server. That call is what attaches the form context and creates the store
+ * subscriptions, and without it the widgets render empty.
+ */
+export function installLitSsrSupport(): void {
+  if (supportInstalled) {
+    return;
+  }
+  supportInstalled = true;
+  installClassListShim();
+  LitElementRenderer.renderOptions.push((element) =>
+    tagNameOf(element.constructor as CustomElementConstructor)
+      ? { connectedCallback: true }
+      : undefined,
+  );
+}
+
+function installClassListShim(): void {
+  // Find the prototype that owns setAttribute: in Node with lit loaded that is the
+  // @lit-labs/ssr-dom-shim element prototype. Reached through a registered element so
+  // this module never imports the shim package itself.
+  let proto: object | null = FormElement.prototype;
+  while (proto && proto !== Object.prototype) {
+    if ('classList' in proto) {
+      return; // A real DOM is present, nothing to install.
+    }
+    if (Object.getOwnPropertyDescriptor(proto, 'setAttribute')) {
+      break;
+    }
+    proto = Object.getPrototypeOf(proto);
+  }
+  if (!proto || proto === Object.prototype) {
+    return;
+  }
+  Object.defineProperty(proto, 'classList', {
+    configurable: true,
+    get(this: Element) {
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      const element = this;
+      const read = () =>
+        new Set<string>(
+          String(element.getAttribute('class') ?? '')
+            .split(/\s+/)
+            .filter(Boolean),
+        );
+      const write = (names: Set<string>) => {
+        element.setAttribute('class', [...names].join(' '));
+      };
+      return {
+        add: (...names: string[]) => {
+          const current = read();
+          for (const name of names) {
+            current.add(name);
+          }
+          write(current);
+        },
+        remove: (...names: string[]) => {
+          const current = read();
+          for (const name of names) {
+            current.delete(name);
+          }
+          write(current);
+        },
+        toggle: (name: string, force?: boolean) => {
+          const current = read();
+          const shouldAdd = force ?? !current.has(name);
+          if (shouldAdd) {
+            current.add(name);
+          } else {
+            current.delete(name);
+          }
+          write(current);
+          return shouldAdd;
+        },
+        contains: (name: string) => read().has(name),
+      };
+    },
+  });
+}
+
+/**
+ * Removes the declarative shadow root wrappers from server output. Every GolemUI
+ * element renders into light DOM, but @lit-labs/ssr wraps each element's output in a
+ * `<template shadowroot>` anyway, where global stylesheets do not apply and where
+ * jsdom does not parse it into children. Removing the wrappers restores the light-DOM
+ * tree the client renders. Non-shadow-root `<template>` elements are kept.
+ */
+export function stripShadowRootTemplates(markup: string): string {
+  const token = /<template[^>]*>|<\/template>/g;
+  const isShadowRootOpen = (tag: string) =>
+    tag.startsWith('<template') && tag.includes('shadowroot');
+  let output = '';
+  let last = 0;
+  // true = shadow root wrapper (removed), false = real template (kept)
+  const stack: boolean[] = [];
+  for (let match = token.exec(markup); match; match = token.exec(markup)) {
+    output += markup.slice(last, match.index);
+    last = match.index + match[0].length;
+    if (match[0] === '</template>') {
+      if (stack.pop() === false) {
+        output += match[0];
+      }
+    } else if (isShadowRootOpen(match[0])) {
+      stack.push(true);
+    } else {
+      stack.push(false);
+      output += match[0];
+    }
+  }
+  output += markup.slice(last);
+  return output;
+}
+
+/** Removes the lit hydration marker comments. The resume entry point does not read them. */
+function stripHydrationMarkers(markup: string): string {
+  return markup
+    .replace(/<!--\/?lit-part[^>]*-->/g, '')
+    .replace(/<!--lit-node \d+-->/g, '')
+    .replace(/<\?>/g, '');
+}
+
+/**
+ * Renders a lit template containing GolemUI elements to an HTML string in plain Node.
+ *
+ * The output is complete light-DOM markup: shadow root wrappers are removed and every
+ * GolemUI element has the `defer-hydration` attribute, so on the client the
+ * elements stay inert until a resume entry point removes the attribute.
+ *
+ * @param template - A lit `html` template. Widgets must be preloaded first.
+ * @param options - `keepMarkers` keeps the lit hydration marker comments (default false).
+ * @returns The rendered markup.
+ */
+export async function renderGuiHtml(
+  template: unknown,
+  options?: { keepMarkers?: boolean },
+): Promise<string> {
+  installLitSsrSupport();
+  const result = render(template, {
+    deferHydration: true,
+    elementRenderers: [GuiSsrElementRenderer, LitElementRenderer],
+  });
+  const markup = stripShadowRootTemplates(await collectResult(result));
+  return options?.keepMarkers ? markup : stripHydrationMarkers(markup);
+}
+
+/**
+ * Renders one GolemUI form to an HTML string in plain Node.
+ *
+ * @param options - The form inputs. `config` must contain an explicit `formName`, and
+ * the widgets in `config.widgetLoaders` must already be preloaded with
+ * `preloadFormWidgets` so the render can read them synchronously.
+ * @returns The rendered markup: a `<gui-core-form>` element holding the complete form.
+ * @example
+ * await preloadFormWidgets({ widgetLoaders });
+ * const markup = await renderGuiFormHtml({ config, validators });
+ */
+export async function renderGuiFormHtml(options: {
+  config: FormInitConfig<Type<WithWidget>>;
+  validators: ValidatorFn<any>;
+  autocomplete?: string;
+  keepMarkers?: boolean;
+}): Promise<string> {
+  if (!options.config.formName) {
+    throw new Error(
+      'Server rendering needs an explicit formName in the form config, ' +
+        'so the server and the client produce the same markup.',
+    );
+  }
+  return renderGuiHtml(
+    html`<gui-core-form
+      .config=${options.config}
+      .validators=${options.validators}
+      .autocomplete=${options.autocomplete}
+    ></gui-core-form>`,
+    { keepMarkers: options.keepMarkers },
+  );
+}

--- a/libs/lit/src/lib/utils/define.spec.ts
+++ b/libs/lit/src/lib/utils/define.spec.ts
@@ -79,4 +79,39 @@ describe('safeDefine defer-hydration support', () => {
 
     expect(element?.childElementCount).toBe(0);
   });
+
+  it('finalizes a subclass of a registered element, so its own properties work', async () => {
+    class DeferSpecRegisteredBase extends DeferSpecBase {}
+    safeDefine('x-defer-base', DeferSpecRegisteredBase);
+
+    // `static properties` is only read by Lit during finalization, which the
+    // `observedAttributes` override has to keep reachable for a subclass.
+    class DeferSpecSubclass extends DeferSpecRegisteredBase {
+      static override properties = { badge: {} };
+      declare badge: string;
+
+      override render() {
+        return html`<span>${this.label}</span><b>${this.badge}</b>`;
+      }
+    }
+    safeDefine('x-defer-sub', DeferSpecSubclass);
+
+    expect(DeferSpecSubclass.observedAttributes).toContain('badge');
+    expect(DeferSpecSubclass.observedAttributes.filter((a) => a === 'defer-hydration')).toHaveLength(
+      1,
+    );
+
+    const element = document.createElement('x-defer-sub') as DeferSpecSubclass;
+    element.setAttribute('defer-hydration', '');
+    document.body.appendChild(element);
+    element.setAttribute('badge', 'set before the removal');
+
+    await afterLitRenderSchedule();
+    expect(element.childElementCount).toBe(0);
+
+    element.removeAttribute('defer-hydration');
+    await afterLitRenderSchedule();
+
+    expect(element.querySelector('b')?.textContent).toBe('set before the removal');
+  });
 });

--- a/libs/lit/src/lib/utils/define.ts
+++ b/libs/lit/src/lib/utils/define.ts
@@ -12,6 +12,18 @@ export function safeDefine(tag: string, ctor: CustomElementConstructor): void {
   }
   supportDeferHydrationAttribute(ctor);
   customElements.define(tag, ctor);
+  tagByConstructor.set(ctor, tag);
+}
+
+const tagByConstructor = new Map<CustomElementConstructor, string>();
+
+/**
+ * Returns the tag a constructor was registered with through {@link safeDefine}, or
+ * undefined for a constructor that was never registered with it. Works in every
+ * runtime, including registries without `customElements.getName`.
+ */
+export function tagNameOf(ctor: CustomElementConstructor): string | undefined {
+  return tagByConstructor.get(ctor);
 }
 
 const deferHydrationPatched = new WeakSet<CustomElementConstructor>();

--- a/libs/lit/src/lib/utils/define.ts
+++ b/libs/lit/src/lib/utils/define.ts
@@ -33,6 +33,39 @@ type PatchablePrototype = HTMLElement & {
   attributeChangedCallback?(name: string, oldValue: string | null, value: string | null): void;
 };
 
+type ObservedAttributesGetter = (this: CustomElementConstructor) => string[] | undefined;
+
+const installedObservedAttributesGetters = new WeakSet<ObservedAttributesGetter>();
+
+/**
+ * Returns the `observedAttributes` implementation of the class or the first ancestor
+ * that this file did not install itself.
+ *
+ * A subclass inherits the getter installed on its base class. Reading that inherited
+ * getter returns the base class attributes and skips `ReactiveElement.finalize()`,
+ * which Lit only runs from its own getter.
+ */
+function originalObservedAttributesOf(
+  ctor: CustomElementConstructor,
+): ObservedAttributesGetter | undefined {
+  for (let current: object | null = ctor; current; current = Object.getPrototypeOf(current)) {
+    const descriptor = Object.getOwnPropertyDescriptor(current, 'observedAttributes');
+    if (!descriptor) {
+      continue;
+    }
+    if (descriptor.get) {
+      const getter = descriptor.get as ObservedAttributesGetter;
+      if (!installedObservedAttributesGetters.has(getter)) {
+        return getter;
+      }
+      continue;
+    }
+    const value = descriptor.value as string[] | undefined;
+    return () => value;
+  }
+  return undefined;
+}
+
 /**
  * Implements the `defer-hydration` community protocol: an element that connects with a
  * `defer-hydration` attribute does not render until the attribute is removed.
@@ -53,12 +86,16 @@ function supportDeferHydrationAttribute(ctor: CustomElementConstructor): void {
   }
   deferHydrationPatched.add(ctor);
 
-  // `observedAttributes` is read once by `customElements.define`, right after this runs.
-  const staticSide = ctor as CustomElementConstructor & { observedAttributes?: string[] };
-  const observedAttributes = [...(staticSide.observedAttributes ?? [])];
+  // Calls through with the receiving class, so Lit finalizes that class and reports its
+  // own attributes. A snapshot taken here would freeze a subclass to its base class list.
+  const originalObservedAttributes = originalObservedAttributesOf(ctor);
+  const observedAttributes: ObservedAttributesGetter = function (this: CustomElementConstructor) {
+    return [...(originalObservedAttributes?.call(this) ?? []), 'defer-hydration'];
+  };
+  installedObservedAttributesGetters.add(observedAttributes);
   Object.defineProperty(ctor, 'observedAttributes', {
     configurable: true,
-    get: () => [...observedAttributes, 'defer-hydration'],
+    get: observedAttributes,
   });
 
   const prototype = ctor.prototype as PatchablePrototype;

--- a/libs/lit/src/ssr.ts
+++ b/libs/lit/src/ssr.ts
@@ -1,0 +1,7 @@
+export {
+  GuiSsrElementRenderer,
+  installLitSsrSupport,
+  renderGuiFormHtml,
+  renderGuiHtml,
+  stripShadowRootTemplates,
+} from './lib/ssr/server';

--- a/libs/lit/tsconfig.lib.json
+++ b/libs/lit/tsconfig.lib.json
@@ -9,5 +9,6 @@
     "declaration": true,
     "types": ["node"]
   },
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts", "src/**/*.fixture.ts"],
   "include": ["src/**/*.ts"]
 }

--- a/libs/lit/vite.config.ts
+++ b/libs/lit/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig(() => ({
       entry: {
         index: 'src/index.ts',
         internals: 'src/internals.ts',
+        ssr: 'src/ssr.ts',
       },
       name: 'lit',
       formats: ['es', 'cjs'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,8 @@
         "@angular/compiler-cli": "21.2.19",
         "@angular/language-service": "21.2.19",
         "@angular/platform-browser-dynamic": "21.2.19",
+        "@lit-labs/ssr": "^4.1.0",
+        "@lit-labs/ssr-client": "^1.1.8",
         "@nx/angular": "22.7.8",
         "@nx/cypress": "22.7.8",
         "@nx/eslint": "22.7.8",
@@ -5944,11 +5946,98 @@
         "listr2": "9.0.5"
       }
     },
+    "node_modules/@lit-labs/ssr": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr/-/ssr-4.1.0.tgz",
+      "integrity": "sha512-m0zymVVlHB1ddJQ1lastsV8ROW3whFOiHJhVPQWd04MnGTkTlUUVLQctux1QlyD9BtLXNN6iASxv388vhgKMFg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-client": "^1.1.7",
+        "@lit-labs/ssr-dom-shim": "^1.6.0",
+        "@lit/reactive-element": "^2.0.4",
+        "@parse5/tools": "^0.3.0",
+        "enhanced-resolve": "^5.10.0",
+        "lit": "^3.1.2",
+        "lit-element": "^4.0.4",
+        "lit-html": "^3.1.2",
+        "node-fetch": "^3.2.8",
+        "parse5": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=13.9.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=20.0.0 <25.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lit-labs/ssr-client": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-client/-/ssr-client-1.1.8.tgz",
+      "integrity": "sha512-PjGh81oKsoI64m3IDjTqqjhC7dr2uC/o0jrllUb5gRAyp/RlAHxapgJrjq9kWz97faCHLQ8jUlTi6tGm+8fgyA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit": "^3.1.2",
+        "lit-html": "^3.1.2"
+      }
+    },
     "node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
-      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit-labs/ssr/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@lit-labs/ssr/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@lit-labs/ssr/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/@lit/context": {
       "version": "1.1.6",
@@ -10064,6 +10153,42 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@parse5/tools": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@parse5/tools/-/tools-0.3.0.tgz",
+      "integrity": "sha512-zxRyTHkqb7WQMV8kTNBKWb1BeOFUKXBXTBWuxg9H9hfvQB3IwP6Iw2U75Ia5eyRxPNltmY7E8YAlz6zWwUnjKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      }
+    },
+    "node_modules/@parse5/tools/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@parse5/tools/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/@peculiar/asn1-cms": {
       "version": "2.8.0",
@@ -17945,6 +18070,16 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
@@ -20074,6 +20209,30 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
@@ -20580,6 +20739,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -24825,6 +24997,27 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
     },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
@@ -34174,6 +34367,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "@angular/compiler-cli": "21.2.19",
     "@angular/language-service": "21.2.19",
     "@angular/platform-browser-dynamic": "21.2.19",
+    "@lit-labs/ssr": "^4.1.0",
+    "@lit-labs/ssr-client": "^1.1.8",
     "@nx/angular": "22.7.8",
     "@nx/cypress": "22.7.8",
     "@nx/eslint": "22.7.8",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "reset:dev": "pkill -f 'astro dev' 2>/dev/null; pkill -f 'nx run-many' 2>/dev/null; lsof -ti:4220,4221,4222,4223,4321,4322,4323 2>/dev/null | xargs kill -9 2>/dev/null; rm -rf docs/.astro docs/node_modules/.astro node_modules/.astro; npx nx reset",
     "start:angular": "nx run angular-playground:serve",
     "start:lit": "nx run lit-playground:serve",
+    "start:lit-ssr": "nx run lit-ssr-harness:serve-ssr",
     "start:react": "nx run react-playground:serve",
     "start:react-ssr": "nx run react-ssr-harness:serve-ssr",
     "start:vue": "nx run vue-playground:serve",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -112,6 +112,7 @@
       "@golemui/gui-components/toggle": ["libs/gui/components/src/lib/components/toggle.ts"],
       "@golemui/lit": ["libs/lit/src/index.ts"],
       "@golemui/lit/internals": ["libs/lit/src/internals.ts"],
+      "@golemui/lit/ssr": ["libs/lit/src/ssr.ts"],
       "@golemui/react": ["libs/react/src/index.ts"],
       "@golemui/vue": ["libs/vue/src/index.ts"],
       "@golemui/gui-validators": ["libs/gui/validators/src/index.ts"],


### PR DESCRIPTION
## Server-side rendering for Lit forms (experimental)

`@golemui/lit` can now render a form to an HTML string in plain Node. The markup is complete light DOM: structure, host classes, labels, and input values. The form is visible before JavaScript loads.

The client model is hold-and-resume, not hydration (`@lit-labs/ssr-client` cannot hydrate light-DOM elements): every element in the server markup stays inert through the `defer-hydration` attribute, and `resumeServerRenderedForm` replaces it with one live client render before the next paint.

## How it works

- New subpath `@golemui/lit/ssr` (`@lit-labs/ssr` as optional peer): `renderGuiFormHtml` renders a core form to a string, and `renderGuiHtml` renders any lit template containing golemui elements, which is the path a widget set consumer takes for `<gui-form>`. Both correct the server event path for light-DOM hosts, remove the shadow root wrappers, and require an explicit `formName` so server and client produce the same markup.
- `resumeServerRenderedForm`, on the main entry, takes the same `config` and `validators` the server used.
- Form init runs in `willUpdate()`, preloaded widgets render synchronously, and document listeners are skipped when `document` is undefined, so the full render works without a DOM.

Client-only behavior is unchanged: the async widget path stays as is.

## Fixes included

- `safeDefine` now finalizes subclasses of registered elements. The defer-hydration support replaced the static `observedAttributes` getter with a list captured at registration time, so a subclass like `GuiMultiList` never ran Lit's `finalize()` and lost its own attributes.
- Dropdown, List, MultiList and MultiDropdown in `@golemui/gui-react` attach their element listeners in a layout effect instead of a passive one. An early click could fire `change` with no listener attached, which made their component tests flake on loaded CI runners and could lose a fast first click from a real user.
- The number widget calls `querySelector` in `render()` to measure its input for autoGrow. The element shim in Node has no `querySelector`, so a server render of any form with a number input threw. It now returns null when `document` is undefined, which is the branch the first client render already takes.

## Known limitations

- `@lit-labs/ssr` writes a reflected boolean property as `selected="false"` or `checked="false"`, and HTML reads any such attribute as true. Before the resume, or with JavaScript off, a select shows its last option and an unchecked box shows as ticked. The resume corrects both.
- A widget that assigns its input value outside the template does not carry that value in the server markup. The number widget is the one in the current set.


