### PR TITLE
ci: add a job timeout and make the analog playground build exit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   main:
     runs-on: ubuntu-latest
+    # A complete run takes about 10 minutes. Without this, a step that never exits is
+    # cancelled after the 6 hour default and the later steps are reported as skipped.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:

--- a/apps/analog-playground/vite.config.ts
+++ b/apps/analog-playground/vite.config.ts
@@ -1,7 +1,29 @@
 import analog from '@analogjs/platform';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { resolve } from 'node:path';
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
+
+// Vite disposes a sass compiler only when the css plugin of the same resolved config owns
+// it. By default Analog resolves one config per environment, so the Angular plugin compiles
+// component scss through a fallback compiler that vite never disposes. With sass-embedded
+// that compiler is a child process, and the build never exits once its work is done.
+// Sharing one config makes the css plugin own the compiler. Building the environments one
+// after the other keeps a second environment from replacing a compiler before it is closed.
+function disposeSassCompilerAfterBuild(): Plugin {
+  return {
+    name: 'dispose-sass-compiler-after-build',
+    config: () => ({ builder: { sharedConfigBuild: true } }),
+    async buildApp(builder) {
+      const build = builder.build.bind(builder);
+      let previous: Promise<unknown> = Promise.resolve();
+      builder.build = (environment) => {
+        const current = previous.then(() => build(environment));
+        previous = current.catch(() => undefined);
+        return current;
+      };
+    },
+  };
+}
 
 // The Analog platform plugin compiles the components and must come before the path plugin.
 // Playground ports: 3300 lit, 3500 vue, 3700 nuxt, 3800 nextjs, 3900 astro, 4200 angular.
@@ -25,5 +47,6 @@ export default defineConfig(() => ({
       prerender: { routes: ['/', '/dx/modular'], discover: false },
     }),
     nxViteTsPaths(),
+    disposeSassCompilerAfterBuild(),
   ],
 }));

--- a/templates/analog/vite.config.ts
+++ b/templates/analog/vite.config.ts
@@ -1,5 +1,27 @@
 import analog from '@analogjs/platform';
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
+
+// Vite disposes a sass compiler only when the css plugin of the same resolved config owns
+// it. By default Analog resolves one config per environment, so the Angular plugin compiles
+// component scss through a fallback compiler that vite never disposes. With sass-embedded
+// that compiler is a child process, and the build never exits once its work is done.
+// Sharing one config makes the css plugin own the compiler. Building the environments one
+// after the other keeps a second environment from replacing a compiler before it is closed.
+function disposeSassCompilerAfterBuild(): Plugin {
+  return {
+    name: 'dispose-sass-compiler-after-build',
+    config: () => ({ builder: { sharedConfigBuild: true } }),
+    async buildApp(builder) {
+      const build = builder.build.bind(builder);
+      let previous: Promise<unknown> = Promise.resolve();
+      builder.build = (environment) => {
+        const current = previous.then(() => build(environment));
+        previous = current.catch(() => undefined);
+        return current;
+      };
+    },
+  };
+}
 
 export default defineConfig({
   build: {
@@ -7,5 +29,5 @@ export default defineConfig({
   },
   // Server-side rendering is on by default: every page renders on request, and `/` is
   // prerendered at build time.
-  plugins: [analog()],
+  plugins: [analog(), disposeSassCompilerAfterBuild()],
 });


### PR DESCRIPTION
CI on `main` has not run the test and lint steps since PR #352. The `main` job had no timeout, `analog-playground:build` never exited, GitHub cancelled the job after 6 hours, and the later steps were skipped.

## Changes

- Added `timeout-minutes: 30` on the `main` job.
- The analog build finished its work and then waited for a `sass-embedded` child process, which vite never disposes. A small plugin in the playground and template configs sets `builder.sharedConfigBuild: true` and runs the environment builds one after the other, so the css plugin owns and closes the compiler