### PR TITLE
fix(gui-validators): report the required message when a required files value is absent

### DIFF
--- a/libs/gui/validators/src/lib/validators.spec.ts
+++ b/libs/gui/validators/src/lib/validators.spec.ts
@@ -202,6 +202,10 @@ describe('Golem validators', () => {
         expect(isValid(schema, [])).toBe(true);
       });
 
+      it('accepts null (a host may persist it in place of an empty array)', () => {
+        expect(isValid(schema, null)).toBe(true);
+      });
+
       it('accepts uploaded items', () => {
         expect(isValid(schema, [uploaded, { ...uploaded, id: 'f9' }])).toBe(true);
       });
@@ -218,6 +222,25 @@ describe('Golem validators', () => {
 
       it('rejects an empty array', () => {
         expect(getErrors(schema, [])).toEqual(['This field is required']);
+      });
+
+      it('rejects undefined and null with the required message', () => {
+        expect(getErrors(schema, undefined)).toEqual(['This field is required']);
+        expect(getErrors(schema, null)).toEqual(['This field is required']);
+      });
+
+      it('uses the custom required message for an absent value', () => {
+        const customSchema = validate({
+          type: 'files',
+          required: true,
+          messages: { required: 'Add at least one file' },
+        } satisfies FilesValidator);
+        expect(getErrors(customSchema, undefined)).toEqual(['Add at least one file']);
+      });
+
+      it('keeps the invalid and pending messages for a present value', () => {
+        expect(getErrors(schema, uploaded)).toEqual(['Invalid file']);
+        expect(getErrors(schema, [uploaded, uploading])).toEqual(['Wait for the upload to finish']);
       });
 
       it('accepts a non-empty array', () => {

--- a/libs/gui/validators/src/lib/validators.ts
+++ b/libs/gui/validators/src/lib/validators.ts
@@ -105,7 +105,8 @@ export interface FileValidator extends BaseValidator {
 
 /**
  * Validates the envelope array stored by the `multiFileUpload` widget
- * (`FileItem[]`). `required` means non-empty, like `array`.
+ * (`FileItem[]`). `required` means non-empty, like `array`. An absent value
+ * (`undefined` or `null`) counts as empty.
  */
 export interface FilesValidator extends BaseValidator {
   type: 'files';
@@ -443,56 +444,88 @@ function fromFileValidator(v: FileValidator, localization?: I18nTranslator) {
   );
 }
 
+// Not wrapped in `withOptional`: the absent value is checked here, before the array
+// type check, so a required empty field reports the required message and not "Invalid file".
 function fromFilesValidator(v: FilesValidator, localization?: I18nTranslator) {
-  return withOptional(v, (v) => {
-    const invalidMsg =
-      resolveMessage(v.messages?.['invalid'], localization) ?? DEFAULT_INVALID_FILE_MESSAGE;
-    let schema = array(any(), invalidMsg).check(
-      refine((val) => (val as unknown[]).every(isFileItem), { error: invalidMsg }),
+  const requiredMsg =
+    resolveMessage(v.messages?.['required'], localization) ?? DEFAULT_REQUIRED_MESSAGE;
+  const arraySchema = fromFilesArrayValidator(v, localization, requiredMsg);
+
+  return any().check(
+    superRefine((val, ctx) => {
+      if (val === null || val === undefined) {
+        if (v.required === true) {
+          ctx.addIssue({ code: 'custom', message: requiredMsg });
+        }
+        return;
+      }
+      // Typed as the standard interface so the result type is the generic result and not the array.
+      const result = standardValidate<StandardSchemaV1>(
+        arraySchema,
+        val,
+      ) as StandardSchemaV1.Result<unknown>;
+      if (isStandardValidateSuccess(result)) {
+        return;
+      }
+      for (const issue of result.issues) {
+        ctx.addIssue({ code: 'custom', message: issue.message });
+      }
+    }),
+  );
+}
+
+// The checks for a present value. The caller resolves `requiredMsg`, so the absent
+// value and the empty array report the same message.
+function fromFilesArrayValidator(
+  v: FilesValidator,
+  localization: I18nTranslator | undefined,
+  requiredMsg: string,
+) {
+  const invalidMsg =
+    resolveMessage(v.messages?.['invalid'], localization) ?? DEFAULT_INVALID_FILE_MESSAGE;
+  let schema = array(any(), invalidMsg).check(
+    refine((val) => (val as unknown[]).every(isFileItem), { error: invalidMsg }),
+  );
+
+  if (v.required === true) {
+    schema = schema.check(refine((val) => (val as unknown[]).length > 0, { error: requiredMsg }));
+  }
+
+  if (typeof v.minItems === 'number') {
+    const msg = resolveMessage(v.messages?.['minItems'], localization);
+    const threshold = v.minItems;
+    schema = schema.check(
+      msg
+        ? refine((val) => (val as unknown[]).length >= threshold, { error: msg })
+        : minLength(threshold),
     );
+  }
 
-    if (v.required === true) {
-      const msg =
-        resolveMessage(v.messages?.['required'], localization) ?? DEFAULT_REQUIRED_MESSAGE;
-      schema = schema.check(refine((val) => (val as unknown[]).length > 0, { error: msg }));
-    }
+  if (typeof v.maxItems === 'number') {
+    const msg = resolveMessage(v.messages?.['maxItems'], localization);
+    const threshold = v.maxItems;
+    schema = schema.check(
+      msg
+        ? refine((val) => (val as unknown[]).length <= threshold, { error: msg })
+        : maxLength(threshold),
+    );
+  }
 
-    if (typeof v.minItems === 'number') {
-      const msg = resolveMessage(v.messages?.['minItems'], localization);
-      const threshold = v.minItems;
-      schema = schema.check(
-        msg
-          ? refine((val) => (val as unknown[]).length >= threshold, { error: msg })
-          : minLength(threshold),
-      );
-    }
+  if (v.blockPendingUploads !== false) {
+    const msg =
+      resolveMessage(v.messages?.['pendingUploads'], localization) ??
+      DEFAULT_PENDING_UPLOADS_MESSAGE;
+    // Foreign items are already reported by the `invalid` refinement above.
+    schema = schema.check(
+      refine(
+        (val) =>
+          (val as unknown[]).every((item) => !isFileItem(item) || item.status === 'uploaded'),
+        { error: msg },
+      ),
+    );
+  }
 
-    if (typeof v.maxItems === 'number') {
-      const msg = resolveMessage(v.messages?.['maxItems'], localization);
-      const threshold = v.maxItems;
-      schema = schema.check(
-        msg
-          ? refine((val) => (val as unknown[]).length <= threshold, { error: msg })
-          : maxLength(threshold),
-      );
-    }
-
-    if (v.blockPendingUploads !== false) {
-      const msg =
-        resolveMessage(v.messages?.['pendingUploads'], localization) ??
-        DEFAULT_PENDING_UPLOADS_MESSAGE;
-      // Foreign items are already reported by the `invalid` refinement above.
-      schema = schema.check(
-        refine(
-          (val) =>
-            (val as unknown[]).every((item) => !isFileItem(item) || item.status === 'uploaded'),
-          { error: msg },
-        ),
-      );
-    }
-
-    return schema;
-  });
+  return schema;
 }
 
 function fromCustomValidator(v: CustomValidator, customValidators: CustomValidatorSchemas) {

--- a/libs/ui-testing/src/lib/gui-features/multifileupload.cy.ts
+++ b/libs/ui-testing/src/lib/gui-features/multifileupload.cy.ts
@@ -234,5 +234,24 @@ export const runMultiFileUploadComponentTests = (mountFn: MountComponentFn) => {
       cy.get(sel.submit).click();
       cy.get('@formSubmitHandler').should('have.been.calledOnce');
     });
+
+    it('reports the required message when a required field is submitted empty', () => {
+      const mock = createMockUploadService();
+      const formSubmitHandler = cy.stub().as('formSubmitHandler');
+      mountMultiFileUpload({
+        service: mock.service,
+        validator: { type: 'files', required: true },
+        formSubmit: formSubmitHandler,
+      });
+
+      cy.get(sel.submit).click();
+      cy.get('@formSubmitHandler').should('not.have.been.called');
+      cy.get(sel.validatorError).should('contain', 'This field is required');
+
+      pick([a]);
+      cy.get(sel.pill).should('have.length', 1);
+      cy.get(sel.submit).click();
+      cy.get('@formSubmitHandler').should('have.been.calledOnce');
+    });
   });
 };


### PR DESCRIPTION
## Problem

A `multiFileUpload` widget with no `defaultValue` holds `undefined` until the user picks a file.

For `{ type: "files", required: true }` the schema was not optional, so zod's array type check rejected `undefined` and the field showed "Invalid file" instead of "This field is required". `null` had the same problem, and `null` also failed when the field was not required, because zod's `optional()` accepts only `undefined`.

The `file` validator already handled this case: it checks `null` and `undefined` before any other check. This PR gives the `files` validator the same structure.

## Behavior

```ts
const validate = initValidators();

// required, no value picked yet
const required = validate({ type: 'files', required: true });
required['~standard'].validate(undefined); // issues: ["This field is required"]
required['~standard'].validate(null);      // issues: ["This field is required"]
required['~standard'].validate([]);        // issues: ["This field is required"] (unchanged)

// required with a custom message
const custom = validate({
  type: 'files',
  required: true,
  messages: { required: 'Add at least one file' },
});
custom['~standard'].validate(undefined);   // issues: ["Add at least one file"]

// not required: an absent value passes, like an empty array
const optional = validate({ type: 'files' });
optional['~standard'].validate(undefined); // no issues
optional['~standard'].validate(null);      // no issues (was "Invalid file")

// a present value keeps the existing checks
required['~standard'].validate('cv.pdf');  // issues: ["Invalid file"]
```
