### PR TITLE
fix(lit): remove false-valued boolean attributes from the server markup

### DIFF
--- a/libs/gui/lit/src/lib/server-render.spec.ts
+++ b/libs/gui/lit/src/lib/server-render.spec.ts
@@ -36,12 +36,50 @@ const config: FormInitConfig<Type<WithWidget>> = {
         { kind: 'input', type: 'textinput', path: 'firstName', label: 'First name' },
         { kind: 'input', type: 'textinput', path: 'lastName', label: 'Last name' },
         { kind: 'input', type: 'number', path: 'seats', label: 'Seats' },
+        // The data values sit in the middle of each option list, so a render that marks the
+        // last option or the last radio as selected is distinguishable from a correct one.
+        {
+          kind: 'input',
+          type: 'select',
+          path: 'plan',
+          label: 'Plan',
+          props: {
+            options: [
+              { value: 'free', label: 'Free' },
+              { value: 'pro', label: 'Pro' },
+              { value: 'enterprise', label: 'Enterprise' },
+            ],
+          },
+        },
+        {
+          kind: 'input',
+          type: 'radiogroup',
+          path: 'size',
+          label: 'Size',
+          props: {
+            options: [
+              { value: 's', label: 'S' },
+              { value: 'm', label: 'M' },
+              { value: 'l', label: 'L' },
+            ],
+          },
+        },
+        { kind: 'input', type: 'checkbox', path: 'acceptTerms', label: 'I accept the terms' },
+        { kind: 'input', type: 'toggle', path: 'newsletter', label: 'Newsletter' },
         { kind: 'action', type: 'button', label: 'Create account', action: 'submit' },
       ],
     },
   },
   widgetLoaders,
-  data: { firstName: 'Ada', lastName: 'Lovelace', seats: 3 },
+  data: {
+    firstName: 'Ada',
+    lastName: 'Lovelace',
+    seats: 3,
+    plan: 'pro',
+    size: 'm',
+    acceptTerms: false,
+    newsletter: false,
+  },
 };
 
 describe('server rendering the gui widget set in plain node', () => {
@@ -78,6 +116,25 @@ describe('server rendering the gui widget set in plain node', () => {
     expect(markup).toMatch(/<gui-number-input[^>]*class="[^"]*gui-number[^"]*gui-field/);
     expect(markup).toContain('Seats');
     expect(markup).toMatch(/<input[^>]*type="number"[^>]*id="seats-number"/);
+  });
+
+  // @lit-labs/ssr serializes a false `.selected` or `.checked` property as `name="false"`,
+  // and HTML reads any present boolean attribute as true. renderGuiHtml removes those.
+  it('renders exactly one selected option and no false-valued selected attribute', () => {
+    expect(markup).not.toMatch(/\sselected="false"/);
+    const selectedOptions = markup.match(/<option[^>]*\sselected=[^>]*>/g) ?? [];
+    expect(selectedOptions).toHaveLength(1);
+    expect(selectedOptions[0]).toMatch(/value="pro"/);
+  });
+
+  it('renders the unchecked checkbox, toggle and radios without a checked attribute', () => {
+    expect(markup).not.toMatch(/\schecked="false"/);
+    expect(markup).toMatch(/<input[^>]*type="checkbox"[^>]*id="acceptTerms-checkbox"/);
+    expect(markup).not.toMatch(/<input[^>]*id="acceptTerms-checkbox"[^>]*\schecked=/);
+    expect(markup).not.toMatch(/<input[^>]*id="newsletter-toggle"[^>]*\schecked=/);
+    const checkedRadios = markup.match(/<input[^>]*type="radio"[^>]*\schecked=[^>]*>/g) ?? [];
+    expect(checkedRadios).toHaveLength(1);
+    expect(checkedRadios[0]).toMatch(/value="m"/);
   });
 
   it('emits inert light DOM: defer-hydration everywhere, no shadow root wrappers', () => {

--- a/libs/lit/src/lib/ssr/server.spec.ts
+++ b/libs/lit/src/lib/ssr/server.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { stripFalseBooleanAttributes } from './server';
+
+describe('stripFalseBooleanAttributes', () => {
+  it('removes a false-valued selected attribute and a false-valued checked attribute', () => {
+    expect(stripFalseBooleanAttributes('<option value="free" selected="false">Free</option>')).toBe(
+      '<option value="free">Free</option>',
+    );
+    expect(stripFalseBooleanAttributes('<input type="checkbox" checked="false">')).toBe(
+      '<input type="checkbox">',
+    );
+  });
+
+  it('removes every false-valued boolean attribute in one tag', () => {
+    expect(
+      stripFalseBooleanAttributes(
+        '<input disabled="false" hidden="false" required="false" value="x">',
+      ),
+    ).toBe('<input value="x">');
+  });
+
+  it('handles a self-closing tag and attributes split across lines', () => {
+    expect(stripFalseBooleanAttributes('<input checked="false"/>')).toBe('<input/>');
+    expect(stripFalseBooleanAttributes('<input\n  type="radio"\n  checked="false"\n/>')).toBe(
+      '<input\n  type="radio"\n/>',
+    );
+  });
+
+  it('keeps aria and data attributes whose value is the string false', () => {
+    const markup = '<li aria-selected="false" aria-disabled="false" data-resumed="false"></li>';
+    expect(stripFalseBooleanAttributes(markup)).toBe(markup);
+  });
+
+  it('keeps enumerated attributes where false is a real value', () => {
+    const markup = '<div draggable="false" spellcheck="false" contenteditable="false"></div>';
+    expect(stripFalseBooleanAttributes(markup)).toBe(markup);
+  });
+
+  it('keeps true-valued, empty and bare boolean attributes', () => {
+    const markup =
+      '<input checked="true"><input checked=""><input checked><option selected>A</option>';
+    expect(stripFalseBooleanAttributes(markup)).toBe(markup);
+  });
+
+  it('keeps text content that contains the same characters', () => {
+    const escaped = '<p>checked=&quot;false&quot;</p>';
+    expect(stripFalseBooleanAttributes(escaped)).toBe(escaped);
+    const literal = '<p>an attribute checked="false" in text</p>';
+    expect(stripFalseBooleanAttributes(literal)).toBe(literal);
+  });
+
+  it('returns markup without boolean attributes unchanged', () => {
+    const markup =
+      '<gui-core-form class="gui-form" defer-hydration><form id="f"><input value="Ada"></form></gui-core-form>';
+    expect(stripFalseBooleanAttributes(markup)).toBe(markup);
+  });
+});

--- a/libs/lit/src/lib/ssr/server.ts
+++ b/libs/lit/src/lib/ssr/server.ts
@@ -186,6 +186,50 @@ export function stripShadowRootTemplates(markup: string): string {
   return output;
 }
 
+// The HTML boolean attributes in the @lit-labs/ssr reflected-attributes table. The enumerated
+// attributes of that table (`draggable`, `spellcheck`, `contenteditable`, `translate`) are not
+// listed, because "false" is a real value for them.
+const BOOLEAN_ATTRIBUTES = [
+  'async',
+  'autofocus',
+  'autoplay',
+  'checked',
+  'controls',
+  'default',
+  'defer',
+  'disabled',
+  'formnovalidate',
+  'hidden',
+  'ismap',
+  'loop',
+  'multiple',
+  'muted',
+  'novalidate',
+  'open',
+  'readonly',
+  'required',
+  'reversed',
+  'selected',
+];
+
+// The name must follow whitespace, so `aria-selected="false"` and `data-x="false"` never match.
+const falseBooleanAttribute = new RegExp(
+  `\\s+(?:${BOOLEAN_ATTRIBUTES.join('|')})="false"(?=[\\s/>])`,
+  'gi',
+);
+
+/**
+ * Removes the false-valued boolean attributes that @lit-labs/ssr writes for a property
+ * binding, such as `selected="false"` and `checked="false"`. It serializes a reflected
+ * property as `name="String(value)"`, and HTML reads any present boolean attribute as
+ * true, so until the client resumes an unchecked checkbox renders ticked and a browser
+ * selects the last option. Only start tags are scanned. Bound text and attribute values
+ * are escaped by @lit-labs/ssr, so they cannot contain a `"` or a `>` and are never touched.
+ */
+export function stripFalseBooleanAttributes(markup: string): string {
+  return markup.replace(/<[a-zA-Z][^>]*>/g, (tag) => tag.replace(falseBooleanAttribute, ''));
+}
+
 /** Removes the lit hydration marker comments. The resume entry point does not read them. */
 function stripHydrationMarkers(markup: string): string {
   return markup
@@ -199,7 +243,9 @@ function stripHydrationMarkers(markup: string): string {
  *
  * The output is complete light-DOM markup: shadow root wrappers are removed and every
  * GolemUI element has the `defer-hydration` attribute, so on the client the
- * elements stay inert until a resume entry point removes the attribute.
+ * elements stay inert until a resume entry point removes the attribute. False-valued
+ * boolean attributes such as `selected="false"` are removed too, because HTML reads them
+ * as true.
  *
  * @param template - A lit `html` template. Widgets must be preloaded first.
  * @param options - `keepMarkers` keeps the lit hydration marker comments (default false).
@@ -214,7 +260,8 @@ export async function renderGuiHtml(
     deferHydration: true,
     elementRenderers: [GuiSsrElementRenderer, LitElementRenderer],
   });
-  const markup = stripShadowRootTemplates(await collectResult(result));
+  const lightDom = stripShadowRootTemplates(await collectResult(result));
+  const markup = stripFalseBooleanAttributes(lightDom);
   return options?.keepMarkers ? markup : stripHydrationMarkers(markup);
 }
 

--- a/libs/lit/src/ssr.ts
+++ b/libs/lit/src/ssr.ts
@@ -3,5 +3,6 @@ export {
   installLitSsrSupport,
   renderGuiFormHtml,
   renderGuiHtml,
+  stripFalseBooleanAttributes,
   stripShadowRootTemplates,
 } from './lib/ssr/server';

--- a/skills/golemui/references/framework-setup.md
+++ b/skills/golemui/references/framework-setup.md
@@ -216,11 +216,9 @@ Rules that follow from it:
   module-scope object, spread into both preload calls and passed as `customWidgetLoaders`.
 - `@golemui/lit/ssr` has no browser build; import it only in server code.
 - `onLoad`, `onChange` and every other handler run in the browser only.
-- Known limitations: a false boolean property serializes as `selected="false"`, which HTML reads
-  as true until the resume corrects it (visible only with JavaScript off, or before the client
-  entry runs). A widget that assigns its input value imperatively (the number widget) renders
-  without its value. Calendar widgets read the server clock, so their markup depends on when the
-  server rendered.
+- Known limitations: a widget that assigns its input value imperatively (the number widget)
+  renders without its value. Calendar widgets read the server clock, so their markup depends on
+  when the server rendered.
 
 Starter: `templates/astro` in the GolemUI repo (`output: 'server'` + `@astrojs/node`; the same
 code prerenders at build time under Astro's default static output).


### PR DESCRIPTION
`@lit-labs/ssr` serializes a property binding on a native element as `name="String(value)"`.

A widget template that binds `.selected=${live(false)}` or `.checked=${live(false)}` therefore renders `selected="false"` and `checked="false"` on the server. **HTML reads any present boolean attribute as true**. Until the client resumes the form, or with JavaScript disabled, a browser shows the last option as selected, an unchecked checkbox as ticked, and the last radio of a group as checked.

The widget templates are correct on the client. Only the serialization is wrong, so the fix is a third string pass in `renderGuiHtml`, next to the two that already exist.