### PR TITLE
fix(gui-react, gui-lit): stop bundling the validators package into the builds

### DIFF
--- a/libs/gui/lit/vite.config.ts
+++ b/libs/gui/lit/vite.config.ts
@@ -32,6 +32,7 @@ export default defineConfig(() => ({
         '@golemui/core',
         '@golemui/gui-components',
         '@golemui/gui-shared',
+        '@golemui/gui-validators',
         'rxjs',
         /^@?lit(-\w+)?($|\/.+)/,
         /^@golemui\/lit\/.+/,

--- a/libs/gui/react/vite.config.ts
+++ b/libs/gui/react/vite.config.ts
@@ -63,6 +63,7 @@ export default defineConfig(() => ({
         '@golemui/react',
         '@golemui/gui-components',
         '@golemui/gui-shared',
+        '@golemui/gui-validators',
         /^@golemui\/gui-components\/.+/,
         /^@golemui\/gui-shared\/.+/,
       ],


### PR DESCRIPTION
Both packages declare `@golemui/gui-validators` as a peer dependency, so the consumer installs it and it must not also be copied into the published bundle. Their build configs listed every other `@golemui/*` package as external but not this one, so rollup inlined the validators package and its own peer dependency `zod`.

That shipped a duplicate `zod` to every consumer, and the inlined copy was a different module instance than the one the consumer imports. Marking the package as external repairs both. No public API, type or runtime behavior changes.

`@golemui/gui-vue` already had it in its external list, and `@golemui/gui-angular` is built by ng-packagr, so neither was affected.