### PR TITLE
fix(lit): define the server query methods on the registered elements only

### DIFF
--- a/libs/lit/src/lib/ssr/server.spec.ts
+++ b/libs/lit/src/lib/ssr/server.spec.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest';
-import { stripFalseBooleanAttributes } from './server';
+import { LitElement } from 'lit';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { safeDefine } from '../utils/define';
+import { installLitSsrSupport, stripFalseBooleanAttributes } from './server';
 
 describe('stripFalseBooleanAttributes', () => {
   it('removes a false-valued selected attribute and a false-valued checked attribute', () => {
@@ -53,5 +55,38 @@ describe('stripFalseBooleanAttributes', () => {
     const markup =
       '<gui-core-form class="gui-form" defer-hydration><form id="f"><input value="Ada"></form></gui-core-form>';
     expect(stripFalseBooleanAttributes(markup)).toBe(markup);
+  });
+});
+
+class RegisteredBeforeInstall extends LitElement {}
+class RegisteredAfterInstall extends LitElement {}
+class NeverRegistered extends LitElement {}
+
+describe('installLitSsrSupport element shim scope', () => {
+  beforeAll(() => {
+    safeDefine('x-shim-before-install', RegisteredBeforeInstall);
+    installLitSsrSupport();
+    safeDefine('x-shim-after-install', RegisteredAfterInstall);
+  });
+
+  it('defines the query methods on a class registered before the install', () => {
+    const element = new RegisteredBeforeInstall() as unknown as Element;
+    expect(element.querySelector('input')).toBeNull();
+    expect(element.querySelectorAll('input')).toHaveLength(0);
+  });
+
+  it('defines the query methods on a class registered after the install', () => {
+    const element = new RegisteredAfterInstall() as unknown as Element;
+    expect(element.querySelector('input')).toBeNull();
+    expect(element.querySelectorAll('input')).toHaveLength(0);
+  });
+
+  it('leaves a Lit element that safeDefine never registered without the query methods', () => {
+    expect('querySelector' in NeverRegistered.prototype).toBe(false);
+    expect('querySelectorAll' in NeverRegistered.prototype).toBe(false);
+  });
+
+  it('installs classList on the prototype shared with every Lit element', () => {
+    expect('classList' in NeverRegistered.prototype).toBe(true);
   });
 });

--- a/libs/lit/src/lib/ssr/server.spec.ts
+++ b/libs/lit/src/lib/ssr/server.spec.ts
@@ -81,12 +81,12 @@ describe('installLitSsrSupport element shim scope', () => {
     expect(element.querySelectorAll('input')).toHaveLength(0);
   });
 
-  it('leaves a Lit element that safeDefine never registered without the query methods', () => {
+  it('does not define the query methods on a Lit element that safeDefine never registered', () => {
     expect('querySelector' in NeverRegistered.prototype).toBe(false);
     expect('querySelectorAll' in NeverRegistered.prototype).toBe(false);
   });
 
-  it('installs classList on the prototype shared with every Lit element', () => {
+  it('installs classList on the prototype shared with every Lit element in the process', () => {
     expect('classList' in NeverRegistered.prototype).toBe(true);
   });
 });

--- a/libs/lit/src/lib/ssr/server.ts
+++ b/libs/lit/src/lib/ssr/server.ts
@@ -8,7 +8,7 @@ import { html } from 'lit';
 import { LitElementRenderer, render } from '@lit-labs/ssr';
 import { collectResult } from '@lit-labs/ssr/lib/render-result.js';
 import { FormElement } from '../components/form/form.element';
-import { tagNameOf } from '../utils/define';
+import { onElementRegistered, tagNameOf } from '../utils/define';
 import type { Type } from '../utils/type';
 
 /**
@@ -52,21 +52,30 @@ let supportInstalled = false;
  * only needed when calling @lit-labs/ssr's `render` yourself.
  *
  * It extends the DOM shim element (the shim only implements attributes) with a
- * `classList` accessor, because the elements set host classes in connectedCallback, and
- * with `querySelector`/`querySelectorAll` that find nothing, because the elements read
- * their own children through `@query` accessors in willUpdate and render, and the shim
- * has no children to query. Finding nothing is what the first client render sees too, so
- * the widgets already take that branch. It also registers a render option so every
- * safeDefine-registered element runs connectedCallback on the server. That call is what
- * attaches the form context and creates the store subscriptions, and without it the
- * widgets render empty.
+ * `classList` accessor, because the elements set host classes in connectedCallback. That
+ * prototype is shared with every other Lit element rendered in the same Node process, so
+ * the accessor is process-wide. It adds a missing member, so it changes no existing
+ * behavior.
+ *
+ * It also defines `querySelector` and `querySelectorAll` that find nothing, because the
+ * elements read their own children through `@query` accessors in willUpdate and render,
+ * and the shim has no children to query. Finding nothing is what the first client render
+ * sees too, so the widgets already take that branch. These two are defined on the
+ * safeDefine-registered classes only, including the ones registered later. Any other Lit
+ * element in the process keeps the shim behavior, which is a TypeError, so a missing
+ * query never turns into markup that is silently incomplete.
+ *
+ * It also registers a render option so every safeDefine-registered element runs
+ * connectedCallback on the server. That call is what attaches the form context and
+ * creates the store subscriptions, and without it the widgets render empty.
  */
 export function installLitSsrSupport(): void {
   if (supportInstalled) {
     return;
   }
   supportInstalled = true;
-  installElementShim();
+  installClassListShim();
+  onElementRegistered(installQueryMethods);
   LitElementRenderer.renderOptions.push((element) =>
     tagNameOf(element.constructor as CustomElementConstructor)
       ? { connectedCallback: true }
@@ -74,7 +83,27 @@ export function installLitSsrSupport(): void {
   );
 }
 
-function installElementShim(): void {
+// Defines the two query methods on one registered element class. A real DOM and a class
+// that inherits them from an already-extended base class are both left untouched.
+function installQueryMethods(ctor: CustomElementConstructor): void {
+  const prototype = ctor.prototype as object;
+  if (!('querySelector' in prototype)) {
+    Object.defineProperty(prototype, 'querySelector', {
+      configurable: true,
+      writable: true,
+      value: () => null,
+    });
+  }
+  if (!('querySelectorAll' in prototype)) {
+    Object.defineProperty(prototype, 'querySelectorAll', {
+      configurable: true,
+      writable: true,
+      value: () => [],
+    });
+  }
+}
+
+function installClassListShim(): void {
   // Find the prototype that owns setAttribute: in Node with lit loaded that is the
   // @lit-labs/ssr-dom-shim element prototype. Reached through a registered element so
   // this module never imports the shim package itself.
@@ -88,22 +117,8 @@ function installElementShim(): void {
   if (!proto || proto === Object.prototype) {
     return;
   }
-  // Each member is checked on its own: a real DOM (Element.prototype owns setAttribute)
-  // has all of them, and a second evaluation of this module finds the ones it installed.
-  if (!('querySelector' in proto)) {
-    Object.defineProperty(proto, 'querySelector', {
-      configurable: true,
-      writable: true,
-      value: () => null,
-    });
-  }
-  if (!('querySelectorAll' in proto)) {
-    Object.defineProperty(proto, 'querySelectorAll', {
-      configurable: true,
-      writable: true,
-      value: () => [],
-    });
-  }
+  // A real DOM (Element.prototype owns setAttribute) already has classList, and a second
+  // evaluation of this module finds the accessor it installed.
   if ('classList' in proto) {
     return;
   }

--- a/libs/lit/src/lib/ssr/server.ts
+++ b/libs/lit/src/lib/ssr/server.ts
@@ -60,10 +60,10 @@ let supportInstalled = false;
  * It also defines `querySelector` and `querySelectorAll` that find nothing, because the
  * elements read their own children through `@query` accessors in willUpdate and render,
  * and the shim has no children to query. Finding nothing is what the first client render
- * sees too, so the widgets already take that branch. These two are defined on the
- * safeDefine-registered classes only, including the ones registered later. Any other Lit
- * element in the process keeps the shim behavior, which is a TypeError, so a missing
- * query never turns into markup that is silently incomplete.
+ * sees too, so the widgets already take that branch. Both methods are defined on the
+ * safeDefine-registered classes only, including the classes registered after this call.
+ * Any other Lit element in the process keeps the shim behavior, which is a TypeError.
+ * That reports the failed query instead of rendering incomplete markup with no error.
  *
  * It also registers a render option so every safeDefine-registered element runs
  * connectedCallback on the server. That call is what attaches the form context and
@@ -83,8 +83,8 @@ export function installLitSsrSupport(): void {
   );
 }
 
-// Defines the two query methods on one registered element class. A real DOM and a class
-// that inherits them from an already-extended base class are both left untouched.
+// Defines the two query methods on one registered element class. The `in` check skips a
+// real DOM, and skips a class that inherits the methods from a registered base class.
 function installQueryMethods(ctor: CustomElementConstructor): void {
   const prototype = ctor.prototype as object;
   if (!('querySelector' in prototype)) {

--- a/libs/lit/src/lib/utils/define.ts
+++ b/libs/lit/src/lib/utils/define.ts
@@ -35,9 +35,9 @@ const registrationListeners = new Set<(ctor: CustomElementConstructor) => void>(
  * Registers a listener for {@link safeDefine} registrations. It runs once for every
  * constructor already registered, then once per later registration.
  *
- * Not exported from the package entry point. The server entry point uses it to extend
- * the GolemUI element classes only, instead of the element prototype the DOM shim
- * shares with every other Lit element in the process.
+ * Not exported from the package entry point. The server entry point uses it to add the
+ * server-only query methods to the GolemUI element classes only, instead of to the
+ * element prototype that the DOM shim shares with every other Lit element.
  */
 export function onElementRegistered(listener: (ctor: CustomElementConstructor) => void): void {
   for (const ctor of tagByConstructor.keys()) {

--- a/libs/lit/src/lib/utils/define.ts
+++ b/libs/lit/src/lib/utils/define.ts
@@ -22,9 +22,29 @@ export function safeDefine(tag: string, ctor: CustomElementConstructor): void {
   supportDeferHydrationAttribute(ctor);
   customElements.define(tag, ctor);
   tagByConstructor.set(ctor, tag);
+  for (const listener of registrationListeners) {
+    listener(ctor);
+  }
 }
 
 const tagByConstructor = new Map<CustomElementConstructor, string>();
+
+const registrationListeners = new Set<(ctor: CustomElementConstructor) => void>();
+
+/**
+ * Registers a listener for {@link safeDefine} registrations. It runs once for every
+ * constructor already registered, then once per later registration.
+ *
+ * Not exported from the package entry point. The server entry point uses it to extend
+ * the GolemUI element classes only, instead of the element prototype the DOM shim
+ * shares with every other Lit element in the process.
+ */
+export function onElementRegistered(listener: (ctor: CustomElementConstructor) => void): void {
+  for (const ctor of tagByConstructor.keys()) {
+    listener(ctor);
+  }
+  registrationListeners.add(listener);
+}
 
 /**
  * Returns the tag a constructor was registered with through {@link safeDefine}, or


### PR DESCRIPTION
On the server, `installLitSsrSupport` defined `querySelector` and `querySelectorAll` on the `@lit-labs/ssr-dom-shim` element prototype, which is the base of every Lit element in the process. Both methods answer every query with nothing, so a third-party element that reads its own children on the server rendered incomplete markup and reported no error.

Both methods are now defined on the classes registered through `safeDefine` only, through a new internal `onElementRegistered` listener. Any other Lit element keeps the shim behavior, which is a TypeError. `classList` stays on the shared prototype, because it adds a member the shim does not have. Behaviour for the GolemUI widgets is unchanged.